### PR TITLE
feat: CsaError・共通型定義と EngineLock 排他制御を追加

### DIFF
--- a/apps/desktop/src-tauri/src/csa_types.rs
+++ b/apps/desktop/src-tauri/src/csa_types.rs
@@ -1,11 +1,19 @@
 //! CSA対局の共通型定義
-#![allow(dead_code)] // 後続タスクで使用予定
+//!
+//! ## エラー処理方針
+//!
+//! `CsaError` は Serialize を実装しない。フロントエンドへのエラー通知は
+//! `CsaSessionEvent::Error { message: String }` 経由で行い、
+//! `Display` trait で文字列化する。
 
 use serde::{Deserialize, Serialize};
 
 // ─── CsaError ───
 
 /// CSA対局で発生するエラー
+///
+/// フロントエンドへの送信は `CsaSessionEvent::Error` 経由。
+/// `Display::to_string()` でメッセージを取得する。
 #[derive(Debug)]
 pub enum CsaError {
     ConnectionFailed(String),

--- a/apps/desktop/src-tauri/src/csa_types.rs
+++ b/apps/desktop/src-tauri/src/csa_types.rs
@@ -1,0 +1,292 @@
+//! CSA対局の共通型定義
+#![allow(dead_code)] // 後続タスクで使用予定
+
+use serde::{Deserialize, Serialize};
+
+// ─── CsaError ───
+
+/// CSA対局で発生するエラー
+#[derive(Debug)]
+pub enum CsaError {
+    ConnectionFailed(String),
+    LoginFailed(String),
+    ProtocolError(String),
+    EngineTimeout,
+    EngineCrashed,
+    EngineError(String),
+    ServerDisconnected,
+    SessionAborted,
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for CsaError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionFailed(s) => write!(f, "TCP接続失敗: {s}"),
+            Self::LoginFailed(s) => write!(f, "ログイン失敗: {s}"),
+            Self::ProtocolError(s) => write!(f, "プロトコルエラー: {s}"),
+            Self::EngineTimeout => write!(f, "エンジン初期化タイムアウト"),
+            Self::EngineCrashed => write!(f, "エンジンプロセス異常終了"),
+            Self::EngineError(s) => write!(f, "エンジンエラー: {s}"),
+            Self::ServerDisconnected => write!(f, "サーバー切断"),
+            Self::SessionAborted => write!(f, "セッション中断"),
+            Self::Io(e) => write!(f, "I/Oエラー: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for CsaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for CsaError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+// ─── Time Configuration ───
+
+/// CSA対局の時間設定
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TimeConfig {
+    /// 持ち時間（ミリ秒）
+    pub total_ms: i64,
+    /// 秒読み（ミリ秒）
+    pub byoyomi_ms: i64,
+    /// フィッシャー加算（ミリ秒）
+    pub increment_ms: i64,
+}
+
+/// 対局中のクロック状態
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Clock {
+    pub black_time_ms: i64,
+    pub white_time_ms: i64,
+    pub byoyomi_ms: i64,
+    pub increment_ms: i64,
+}
+
+/// フロントエンド向けクロック情報
+#[derive(Clone, Debug, Serialize)]
+pub struct ClockInfo {
+    pub black_time_ms: i64,
+    pub white_time_ms: i64,
+    pub byoyomi_ms: i64,
+    pub increment_ms: i64,
+}
+
+/// フロントエンド向けクロック更新
+#[derive(Clone, Debug, Serialize)]
+pub struct ClockUpdate {
+    pub sente_ms: i64,
+    pub gote_ms: i64,
+}
+
+// ─── Engine Parameters ───
+
+/// CsaEngine に渡す go コマンドのパラメータ
+#[derive(Clone, Debug)]
+pub struct CsaGoParams {
+    pub btime_ms: i64,
+    pub wtime_ms: i64,
+    pub byoyomi_ms: Option<i64>,
+    pub binc_ms: Option<i64>,
+    pub winc_ms: Option<i64>,
+}
+
+/// エンジンからの bestmove 結果
+#[derive(Clone, Debug)]
+pub enum BestMoveResult {
+    Move { usi: String, ponder: Option<String> },
+    Resign,
+    Win,
+}
+
+/// エンジンからの探索情報
+#[derive(Clone, Debug)]
+pub struct CsaSearchInfo {
+    pub depth: u32,
+    pub score_cp: Option<i32>,
+    pub score_mate: Option<i32>,
+    pub pv: Vec<String>,
+    pub nps: u64,
+}
+
+// ─── Game Summary ───
+
+/// サーバーから受信する対局概要
+#[derive(Clone, Debug)]
+pub struct GameSummary {
+    pub game_id: String,
+    pub my_color: CsaColor,
+    pub sente_name: String,
+    pub gote_name: String,
+    pub sfen: String,
+    pub black_time: TimeConfig,
+    pub white_time: TimeConfig,
+}
+
+/// CSA対局における手番
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CsaColor {
+    Sente,
+    Gote,
+}
+
+impl CsaColor {
+    pub fn is_sente(&self) -> bool {
+        matches!(self, Self::Sente)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Sente => "sente",
+            Self::Gote => "gote",
+        }
+    }
+}
+
+// ─── Game Result ───
+
+/// 対局結果
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GameResult {
+    Win,
+    Lose,
+    Draw,
+    Censored,
+    Interrupted,
+}
+
+// ─── Server Line ───
+
+/// サーバーから受信した行のパース結果
+#[derive(Clone, Debug)]
+pub enum ServerLine {
+    Move {
+        csa: String,
+        time_sec: u32,
+    },
+    GameEnd {
+        result: GameResult,
+        reason: Option<String>,
+    },
+    Start,
+    Reject,
+    Other(String),
+}
+
+// ─── Session Event (sent to frontend) ───
+
+/// フロントエンドに送信する CSA セッションイベント
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum CsaSessionEvent {
+    Connected {
+        host: String,
+    },
+    GameSummary {
+        game_id: String,
+        my_color: String,
+        sente_name: String,
+        gote_name: String,
+        sfen: String,
+        clocks: ClockInfo,
+    },
+    GameStarted,
+    Move {
+        side: String,
+        usi: String,
+        sfen: String,
+        clock: ClockUpdate,
+    },
+    SearchInfo {
+        depth: u32,
+        score_cp: Option<i32>,
+        score_mate: Option<i32>,
+        pv: Vec<String>,
+        nps: u64,
+    },
+    GameEnded {
+        result: String,
+        reason: Option<String>,
+        games_played: u32,
+        record_path: Option<String>,
+    },
+    Disconnected,
+    Error {
+        message: String,
+    },
+}
+
+// ─── Config (received from frontend) ───
+
+/// フロントエンドから受信する CSA 接続設定
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaConfig {
+    pub server: CsaServerConfig,
+    pub engine: CsaEngineConfig,
+    pub time: CsaTimeConfig,
+    pub game: CsaGameConfig,
+    pub record: CsaRecordConfig,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub user_id: String,
+    pub password: String,
+    pub floodgate: bool,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaEngineConfig {
+    #[serde(rename = "type")]
+    pub engine_type: CsaEngineType,
+    pub registration_id: Option<String>,
+    pub options: std::collections::HashMap<String, serde_json::Value>,
+    pub ponder: bool,
+    #[serde(default = "default_startup_timeout_sec")]
+    pub startup_timeout_sec: u64,
+}
+
+fn default_startup_timeout_sec() -> u64 {
+    30
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CsaEngineType {
+    Builtin,
+    External,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaTimeConfig {
+    #[serde(default)]
+    pub margin_ms: i64,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaGameConfig {
+    #[serde(default = "default_max_games")]
+    pub max_games: u32,
+}
+
+fn default_max_games() -> u32 {
+    1
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct CsaRecordConfig {
+    pub save_dir: String,
+}

--- a/apps/desktop/src-tauri/src/engine_lock.rs
+++ b/apps/desktop/src-tauri/src/engine_lock.rs
@@ -2,11 +2,20 @@
 //!
 //! CSA対局中は使用エンジンを専有し、通常のエンジン操作を排他する。
 //! EngineLockGuard の RAII Drop により、パニック時もロックが自動解放される。
-#![allow(dead_code)] // acquire/EngineLockGuard は後続タスクで使用予定
+//!
+//! ## TOCTOU に関する設計判断
+//!
+//! `check_engine_available()` によるロックチェックと後続のエンジン操作は
+//! 原子的ではない（TOCTOU gap がある）。ただし以下の理由から実害はない:
+//! - CSA ロック取得はユーザーの手動操作（「接続」ボタン）でのみ発生する
+//! - エンジンコマンドも同様にユーザー操作起点であり、同時発生は想定外
+//! - 仮に競合しても最悪ケースは「エンジン操作が失敗する」のみで、
+//!   データ破損やクラッシュには至らない（EngineState 自体が Mutex で保護）
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 /// ロック対象のエンジン種別
+#[allow(dead_code)] // CSA対局実装タスクで使用予定
 #[derive(Clone, Debug)]
 pub enum EngineTarget {
     Builtin,
@@ -18,6 +27,12 @@ pub struct EngineLock {
     locked: Mutex<Option<EngineTarget>>,
 }
 
+/// Mutex の poison を回復してガードを返す。
+/// パニックしたスレッドが残した状態でも継続可能にする。
+fn recover_lock(mutex: &Mutex<Option<EngineTarget>>) -> MutexGuard<'_, Option<EngineTarget>> {
+    mutex.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 impl EngineLock {
     pub fn new() -> Self {
         Self {
@@ -26,11 +41,9 @@ impl EngineLock {
     }
 
     /// ロックを取得し、RAII ガードを返す。既にロック中ならエラー。
+    #[allow(dead_code)] // CSA対局実装タスクで使用予定
     pub fn acquire(self: &Arc<Self>, target: EngineTarget) -> Result<EngineLockGuard, String> {
-        let mut guard = self
-            .locked
-            .lock()
-            .map_err(|e| format!("EngineLock mutex poisoned: {e}"))?;
+        let mut guard = recover_lock(&self.locked);
         if guard.is_some() {
             return Err("CSA対局中のためエンジンは使用できません".to_string());
         }
@@ -42,12 +55,13 @@ impl EngineLock {
 
     /// 現在ロックされているかどうか
     pub fn is_locked(&self) -> bool {
-        self.locked.lock().map(|g| g.is_some()).unwrap_or(false)
+        recover_lock(&self.locked).is_some()
     }
 
     /// 現在のロック対象を返す（UIステータス表示用）
+    #[allow(dead_code)] // CSA対局実装タスクで使用予定
     pub fn locked_target(&self) -> Option<EngineTarget> {
-        self.locked.lock().ok().and_then(|g| g.clone())
+        recover_lock(&self.locked).clone()
     }
 }
 
@@ -58,14 +72,13 @@ impl Default for EngineLock {
 }
 
 /// RAII ガード — Drop 時に自動でロック解放
+#[allow(dead_code)] // CSA対局実装タスクで使用予定
 pub struct EngineLockGuard {
     lock: Arc<EngineLock>,
 }
 
 impl Drop for EngineLockGuard {
     fn drop(&mut self) {
-        if let Ok(mut guard) = self.lock.locked.lock() {
-            *guard = None;
-        }
+        *recover_lock(&self.lock.locked) = None;
     }
 }

--- a/apps/desktop/src-tauri/src/engine_lock.rs
+++ b/apps/desktop/src-tauri/src/engine_lock.rs
@@ -1,0 +1,71 @@
+//! CSA対局中のエンジン排他制御
+//!
+//! CSA対局中は使用エンジンを専有し、通常のエンジン操作を排他する。
+//! EngineLockGuard の RAII Drop により、パニック時もロックが自動解放される。
+#![allow(dead_code)] // acquire/EngineLockGuard は後続タスクで使用予定
+
+use std::sync::{Arc, Mutex};
+
+/// ロック対象のエンジン種別
+#[derive(Clone, Debug)]
+pub enum EngineTarget {
+    Builtin,
+    External { registration_id: String },
+}
+
+/// エンジン排他制御
+pub struct EngineLock {
+    locked: Mutex<Option<EngineTarget>>,
+}
+
+impl EngineLock {
+    pub fn new() -> Self {
+        Self {
+            locked: Mutex::new(None),
+        }
+    }
+
+    /// ロックを取得し、RAII ガードを返す。既にロック中ならエラー。
+    pub fn acquire(self: &Arc<Self>, target: EngineTarget) -> Result<EngineLockGuard, String> {
+        let mut guard = self
+            .locked
+            .lock()
+            .map_err(|e| format!("EngineLock mutex poisoned: {e}"))?;
+        if guard.is_some() {
+            return Err("CSA対局中のためエンジンは使用できません".to_string());
+        }
+        *guard = Some(target);
+        Ok(EngineLockGuard {
+            lock: Arc::clone(self),
+        })
+    }
+
+    /// 現在ロックされているかどうか
+    pub fn is_locked(&self) -> bool {
+        self.locked.lock().map(|g| g.is_some()).unwrap_or(false)
+    }
+
+    /// 現在のロック対象を返す（UIステータス表示用）
+    pub fn locked_target(&self) -> Option<EngineTarget> {
+        self.locked.lock().ok().and_then(|g| g.clone())
+    }
+}
+
+impl Default for EngineLock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RAII ガード — Drop 時に自動でロック解放
+pub struct EngineLockGuard {
+    lock: Arc<EngineLock>,
+}
+
+impl Drop for EngineLockGuard {
+    fn drop(&mut self) {
+        if let Ok(mut guard) = self.lock.locked.lock() {
+            *guard = None;
+        }
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+#[allow(dead_code)] // CSA対局実装タスクで使用予定
 mod csa_types;
 mod engine_lock;
 mod usi_engine;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,3 +1,5 @@
+mod csa_types;
+mod engine_lock;
 mod usi_engine;
 
 use std::path::{Path, PathBuf};
@@ -582,11 +584,26 @@ fn stop_active_search(state: &State<'_, Arc<EngineState>>) -> Result<(), String>
     Ok(())
 }
 
+/// CSA対局中でないことを確認するヘルパー
+fn check_engine_available(lock: &State<'_, Arc<engine_lock::EngineLock>>) -> Result<(), String> {
+    if lock.is_locked() {
+        return Err("CSA対局中のためエンジンは使用できません".to_string());
+    }
+    Ok(())
+}
+
+#[tauri::command]
+fn csa_engine_lock_status(lock: State<'_, Arc<engine_lock::EngineLock>>) -> Result<bool, String> {
+    Ok(lock.is_locked())
+}
+
 #[tauri::command]
 fn engine_init(
+    lock: State<'_, Arc<engine_lock::EngineLock>>,
     state: State<'_, Arc<EngineState>>,
     opts: Option<serde_json::Value>,
 ) -> Result<(), String> {
+    check_engine_available(&lock)?;
     stop_active_search(&state)?;
 
     let parsed_opts: Option<InitOptions> = if let Some(opts) = opts {
@@ -628,11 +645,13 @@ fn engine_init(
 
 #[tauri::command]
 fn engine_position(
+    lock: State<'_, Arc<engine_lock::EngineLock>>,
     state: State<'_, Arc<EngineState>>,
     sfen: String,
     moves: Option<Vec<String>>,
     pass_rights: Option<PassRightsInput>,
 ) -> Result<(), String> {
+    check_engine_available(&lock)?;
     eprintln!(
         "engine_position: sfen={}, moves={:?}, passRights={:?}",
         sfen, moves, pass_rights
@@ -653,10 +672,12 @@ fn engine_position(
 
 #[tauri::command]
 fn engine_option(
+    lock: State<'_, Arc<engine_lock::EngineLock>>,
     state: State<'_, Arc<EngineState>>,
     name: String,
     value: serde_json::Value,
 ) -> Result<(), String> {
+    check_engine_available(&lock)?;
     stop_active_search(&state)?;
 
     let mut inner = state
@@ -669,10 +690,12 @@ fn engine_option(
 
 #[tauri::command]
 fn engine_search(
+    lock: State<'_, Arc<engine_lock::EngineLock>>,
     window: Window,
     state: State<'_, Arc<EngineState>>,
     params: serde_json::Value,
 ) -> Result<(), String> {
+    check_engine_available(&lock)?;
     stop_active_search(&state)?;
 
     eprintln!("engine_search: received params = {}", params);
@@ -753,7 +776,11 @@ fn engine_search(
 }
 
 #[tauri::command]
-fn engine_stop(state: State<'_, Arc<EngineState>>) -> Result<(), String> {
+fn engine_stop(
+    lock: State<'_, Arc<engine_lock::EngineLock>>,
+    state: State<'_, Arc<EngineState>>,
+) -> Result<(), String> {
+    check_engine_available(&lock)?;
     eprintln!("engine_stop: requested");
     stop_active_search(&state)
 }
@@ -1583,6 +1610,7 @@ pub fn run() {
         .plugin(tauri_plugin_store::Builder::default().build())
         // Arc 化: CSA 対局の tokio タスクから EngineState を共有するため
         .manage(Arc::new(EngineState::default()))
+        .manage(Arc::new(engine_lock::EngineLock::default()))
         .manage(usi_engine::UsiEngineManager::default())
         .invoke_handler(tauri::generate_handler![
             engine_init,
@@ -1608,6 +1636,8 @@ pub fn run() {
             abort_nnue_save,
             detect_nnue_format_cmd,
             is_nnue_compatible_cmd,
+            // CSA 対局
+            csa_engine_lock_status,
             // USI エンジン管理
             usi_engine_probe,
             usi_engine_start,


### PR DESCRIPTION
## Summary
- Task 2.1: `csa_types.rs` — CsaError enum、時間設定型、エンジンパラメータ型、対局型、セッションイベント、設定構造体を定義
- Task 3.1: `engine_lock.rs` — EngineLock/EngineLockGuard RAII パターンでエンジン排他制御
- `lib.rs` — engine_init/position/option/search/stop に CSA ロックチェック追加、csa_engine_lock_status コマンド新設

## Design Decisions
- **CsaError**: Serialize は実装せず、`CsaSessionEvent::Error { message }` 経由で `Display::to_string()` を使用
- **Mutex poison**: `unwrap_or_else(|e| e.into_inner())` で全メソッド統一（recover_lock パターン）
- **TOCTOU**: check_engine_available() と実操作間の gap は、ユーザー操作起点で同時発生しないため許容（ドキュメント化済み）

## Test plan
- [x] `cargo fmt -- --check` パス
- [x] `cargo clippy -- -D warnings` パス
- [ ] デスクトップアプリ起動確認（既存の engine_* コマンドが正常動作すること）
- [ ] CSA ロックチェックがエラーを返すことの確認（後続タスクで統合テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)