### PR TITLE
feat(viewer): rshogi CSA 棋譜 viewer MVP (scaffold + モック API)

### DIFF
--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -3,3 +3,5 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # Optional
 # VITE_DEFAULT_NNUE_PRESET=ramu
 # VITE_BASE_PATH=/
+# rshogi 棋譜配信 API (未設定なら viewer は組み込みモック fixture を返す)
+# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActiveEngineSettingsPanel } from "./components/ActiveEngineSettingsPanel";
 import { CsaGameView } from "./components/csa/CsaGameView";
 import { EngineManagerPanel } from "./components/EngineManagerPanel";
+import { RshogiViewerView } from "./components/rshogi-viewer/RshogiViewerView";
 
 const createEngineClient = () =>
     createTauriEngineClient({
@@ -81,7 +82,7 @@ interface EngineSettingsTarget {
     label: string;
 }
 
-type AppMode = "local" | "csa";
+type AppMode = "local" | "csa" | "rshogi-viewer";
 
 function App() {
     const [appMode, setAppMode] = useState<AppMode>("local");
@@ -97,6 +98,10 @@ function App() {
             // ロック状態確認失敗時はそのまま切り替えを許可
         }
         setAppMode("csa");
+    };
+
+    const handleSwitchToRshogiViewer = () => {
+        setAppMode("rshogi-viewer");
     };
 
     const [panelPosition, setPanelPosition] = useState<{
@@ -184,10 +189,23 @@ function App() {
         );
     }
 
+    if (appMode === "rshogi-viewer") {
+        return (
+            <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
+                <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
+                    <RshogiViewerView onBackToLocal={() => setAppMode("local")} />
+                </main>
+            </NnueProvider>
+        );
+    }
+
     return (
         <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
             <main className="mx-auto flex max-w-[1100px] flex-col gap-3 md:px-5">
-                <div className="flex justify-end pt-2 px-1">
+                <div className="flex justify-end gap-2 pt-2 px-1">
+                    <Button variant="outline" size="sm" onClick={handleSwitchToRshogiViewer}>
+                        rshogi viewer
+                    </Button>
                     <Button variant="outline" size="sm" onClick={handleSwitchToCsa}>
                         CSA対局
                     </Button>

--- a/apps/desktop/src/components/rshogi-viewer/RshogiViewerView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiViewerView.tsx
@@ -1,0 +1,81 @@
+import { createTauriEngineClient, getLegalMoves } from "@shogi/engine-tauri";
+import type { EngineOption } from "@shogi/ui";
+import { listMockRshogiGameIds, RshogiCsaViewer } from "@shogi/ui";
+import { Button } from "@shogi/ui/components/button";
+import { type ReactElement, useState } from "react";
+
+const ENGINE_OPTIONS: EngineOption[] = [
+    {
+        id: "native",
+        label: "内蔵エンジン",
+        createClient: () =>
+            createTauriEngineClient({
+                stopMode: "terminate",
+                useMockOnError: false,
+                debug: true,
+            }),
+        kind: "internal",
+    },
+];
+
+const nnueManifestUrl = import.meta.env.VITE_NNUE_MANIFEST_URL as string;
+
+interface Props {
+    onBackToLocal: () => void;
+}
+
+export function RshogiViewerView({ onBackToLocal }: Props): ReactElement {
+    const mockIds = listMockRshogiGameIds();
+    const [gameId, setGameId] = useState<string>(mockIds[0] ?? "sample-1");
+    const [draftGameId, setDraftGameId] = useState<string>(gameId);
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    const handleApply = () => {
+        const next = draftGameId.trim();
+        if (next.length > 0) setGameId(next);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Button variant="outline" size="sm" onClick={onBackToLocal}>
+                    ← ローカル対局へ戻る
+                </Button>
+                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer</span>
+                <span className="text-xs text-muted-foreground">
+                    対局 ID を指定して CSA 棋譜を再生します。
+                </span>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-2">
+                <label className="text-xs text-muted-foreground" htmlFor="rshogi-game-id">
+                    対局 ID
+                </label>
+                <input
+                    id="rshogi-game-id"
+                    className="rounded border border-wafuu-border bg-background px-2 py-1 text-sm"
+                    value={draftGameId}
+                    onChange={(e) => setDraftGameId(e.target.value)}
+                />
+                <Button size="sm" onClick={handleApply}>
+                    再生
+                </Button>
+                {mockIds.length > 0 && (
+                    <span className="text-xs text-muted-foreground">
+                        モック ID 例: {mockIds.join(", ")}
+                    </span>
+                )}
+            </div>
+            <RshogiCsaViewer
+                gameId={gameId}
+                engineOptions={ENGINE_OPTIONS}
+                manifestUrl={nnueManifestUrl}
+                apiBaseUrl={apiBaseUrl}
+                fetchLegalMoves={(sfen, moves, options) =>
+                    getLegalMoves({ sfen, moves, passRights: options?.passRights })
+                }
+                isDevMode={true}
+            />
+        </div>
+    );
+}

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -13,7 +13,9 @@
             "@shogi/engine-client": ["packages/engine-client/src"],
             "@shogi/engine-client/*": ["packages/engine-client/src/*"],
             "@shogi/engine-tauri": ["packages/engine-tauri/src"],
-            "@shogi/engine-tauri/*": ["packages/engine-tauri/src/*"]
+            "@shogi/engine-tauri/*": ["packages/engine-tauri/src/*"],
+            "@shogi/match-client": ["packages/match-client/src"],
+            "@shogi/match-client/*": ["packages/match-client/src/*"]
         }
     },
     "include": ["src"],

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -36,6 +36,10 @@ export default defineConfig(async () => ({
                 find: "@shogi/engine-tauri",
                 replacement: path.resolve(rootDir, "../../packages/engine-tauri/src"),
             },
+            {
+                find: "@shogi/match-client",
+                replacement: path.resolve(rootDir, "../../packages/match-client/src"),
+            },
         ],
         // React の重複インスタンスを防ぐ保険として dedupe を設定
         // バージョンが統一されていれば影響はないが、将来の安全性のため明示的に指定

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,3 +4,5 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # VITE_DEFAULT_NNUE_PRESET=ramu
 # VITE_BASE_PATH=/
 # VITE_ALLOWED_HOSTS=your-host.example.com,another-host.example.com
+# rshogi 棋譜配信 API (未設定なら viewer は組み込みモック fixture を返す)
+# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
@@ -1,0 +1,59 @@
+import { createWasmEngineClient } from "@shogi/engine-wasm";
+import type { EngineOption } from "@shogi/ui";
+import { RshogiCsaViewer } from "@shogi/ui";
+import { getRouteApi } from "@tanstack/react-router";
+import type { ReactElement } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageHeader } from "../../components/PageHeader";
+
+const resolveWasmThreads = (): number => {
+    const fallback = import.meta.env.DEV ? 4 : 1;
+    const raw = import.meta.env.VITE_WASM_THREADS;
+    if (typeof raw !== "string" || raw.trim() === "") return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+    return Math.trunc(parsed);
+};
+
+const wasmThreads = resolveWasmThreads();
+
+const engineOptions: EngineOption[] = [
+    {
+        id: "wasm",
+        label: "内蔵エンジン",
+        createClient: () =>
+            createWasmEngineClient({
+                stopMode: "terminate",
+                defaultInitOptions: { threads: wasmThreads },
+                logWarningsToConsole: true,
+            }),
+        kind: "internal",
+    },
+];
+
+const routeApi = getRouteApi("/rshogi-viewer/$gameId");
+
+export default function RshogiViewerPage(): ReactElement {
+    const { gameId } = routeApi.useParams();
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    return (
+        <>
+            <PageHeader
+                items={[
+                    { label: "ラム将棋", to: "/" },
+                    { label: "rshogi viewer" },
+                    { label: gameId },
+                ]}
+                right={<HeaderNav />}
+            />
+            <RshogiCsaViewer
+                gameId={gameId}
+                engineOptions={engineOptions}
+                manifestUrl={import.meta.env.VITE_NNUE_MANIFEST_URL as string}
+                apiBaseUrl={apiBaseUrl}
+            />
+        </>
+    );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -22,6 +22,7 @@ import CreateRoomPage from "./pages/online/CreateRoomPage";
 import OnlinePage from "./pages/online/OnlinePage";
 import RoomPage from "./pages/online/RoomPage";
 import PrivacyPage from "./pages/privacy/PrivacyPage";
+import RshogiViewerPage from "./pages/rshogi-viewer/RshogiViewerPage";
 import { handleLoaderResponse } from "./router-loader-utils";
 
 const rootRoute = createRootRoute({
@@ -208,6 +209,12 @@ const privacyRoute = createRoute({
     component: PrivacyPage,
 });
 
+const rshogiViewerRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer/$gameId",
+    component: RshogiViewerPage,
+});
+
 const createRoomRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/online/create",
@@ -272,6 +279,7 @@ const routeTree = rootRoute.addChildren([
     nnueFilesRoute,
     createRoomRoute,
     roomRoute,
+    rshogiViewerRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -46,6 +46,20 @@ export {
     storeSeat,
 } from "./reconnect";
 export type {
+    FetchRshogiGameOptions,
+    RshogiGame,
+    RshogiGameMeta,
+    RshogiGameResult,
+    RshogiGameResultKind,
+    RshogiTimeControl,
+} from "./rshogi-csa/client";
+export {
+    fetchRshogiGame,
+    listMockRshogiGameIds,
+    RshogiGameFetchError,
+    RshogiGameNotFoundError,
+} from "./rshogi-csa/client";
+export type {
     RoomClient,
     RoomClientOpenEvent,
     RoomClientOptions,

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    fetchRshogiGame,
+    listMockRshogiGameIds,
+    RshogiGameFetchError,
+    RshogiGameNotFoundError,
+} from "./client";
+
+describe("fetchRshogiGame (mock fallback)", () => {
+    it("returns the embedded fixture when no baseUrl is provided", async () => {
+        const game = await fetchRshogiGame("sample-1");
+        expect(game.meta.gameId).toBe("sample-1");
+        expect(game.meta.senteName).toBe("RAMU_TP");
+        expect(game.csa).toContain("V2.2");
+        expect(game.csa).toContain("+7776FU");
+    });
+
+    it("throws RshogiGameNotFoundError for unknown ids in mock mode", async () => {
+        await expect(fetchRshogiGame("does-not-exist")).rejects.toBeInstanceOf(
+            RshogiGameNotFoundError,
+        );
+    });
+
+    it("rejects when gameId is empty", async () => {
+        await expect(fetchRshogiGame("")).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+
+    it("lists mock game ids", () => {
+        const ids = listMockRshogiGameIds();
+        expect(ids).toContain("sample-1");
+    });
+});
+
+describe("fetchRshogiGame (real baseUrl)", () => {
+    it("calls baseUrl/games/<id> and returns the parsed payload", async () => {
+        const payload = {
+            meta: { gameId: "abc", senteName: "S", goteName: "G" },
+            csa: "V2.2\nN+S\nN-G\nPI\n+\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(payload), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+        ) as unknown as typeof fetch;
+
+        const game = await fetchRshogiGame("abc", {
+            baseUrl: "https://rshogi.example.com/api/",
+            fetchImpl,
+        });
+
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        const calledUrl = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+            .calls[0][0];
+        expect(calledUrl).toBe("https://rshogi.example.com/api/games/abc");
+        expect(game.meta.gameId).toBe("abc");
+        expect(game.csa).toContain("V2.2");
+    });
+
+    it("maps 404 to RshogiGameNotFoundError", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response("not found", { status: 404 }),
+        ) as unknown as typeof fetch;
+
+        await expect(
+            fetchRshogiGame("missing", {
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameNotFoundError);
+    });
+
+    it("maps non-2xx (other than 404) to RshogiGameFetchError", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response("boom", { status: 500, statusText: "Server Error" }),
+        ) as unknown as typeof fetch;
+
+        await expect(
+            fetchRshogiGame("boom", {
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+});

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -1,0 +1,132 @@
+/**
+ * rshogi CSA viewer 用 API クライアント (MVP モック)。
+ *
+ * 配信 API 本体は別タスク (rshogi#542) で設計中のため、ここでは
+ * モックの fixture を返すだけの薄い stub を 1 箇所に集約する。
+ * 本実装に差し替える際は本ファイルの `fetchRshogiGame` 内の分岐を
+ * 実 fetch に置き換えるだけで viewer Page 側を弄らずに済む構造を維持する。
+ */
+
+import { MOCK_RSHOGI_GAMES } from "./fixtures";
+
+export type RshogiGameResultKind = "resignation" | "checkmate" | "time_expired" | "draw" | "abort";
+
+export interface RshogiGameResult {
+    kind: RshogiGameResultKind;
+    /** 勝者 (draw / abort 時は undefined) */
+    winner?: "sente" | "gote";
+}
+
+export interface RshogiTimeControl {
+    mainSeconds: number;
+    byoyomiSeconds: number;
+    incrementSeconds?: number;
+}
+
+export interface RshogiGameMeta {
+    gameId: string;
+    senteName: string;
+    goteName: string;
+    /** ISO 8601 UTC timestamp */
+    startedAt?: string;
+    /** ISO 8601 UTC timestamp */
+    endedAt?: string;
+    event?: string;
+    timeControl?: RshogiTimeControl;
+    result?: RshogiGameResult;
+}
+
+export interface RshogiGame {
+    meta: RshogiGameMeta;
+    /** CSA V2.2 形式の棋譜全文 */
+    csa: string;
+}
+
+export interface FetchRshogiGameOptions {
+    /**
+     * rshogi 配信 API のベース URL。
+     * 空文字 / undefined のときはモック fixture を返す (MVP 動作)。
+     */
+    baseUrl?: string;
+    /** 主にテスト・SSR で fetch を差し替えるためのフック */
+    fetchImpl?: typeof fetch;
+    /** AbortController などからの中断に対応 */
+    signal?: AbortSignal;
+}
+
+export class RshogiGameNotFoundError extends Error {
+    readonly gameId: string;
+    constructor(gameId: string) {
+        super(`rshogi game not found: ${gameId}`);
+        this.name = "RshogiGameNotFoundError";
+        this.gameId = gameId;
+    }
+}
+
+export class RshogiGameFetchError extends Error {
+    readonly status?: number;
+    readonly gameId: string;
+    constructor(gameId: string, message: string, status?: number) {
+        super(message);
+        this.name = "RshogiGameFetchError";
+        this.gameId = gameId;
+        this.status = status;
+    }
+}
+
+const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "");
+
+/**
+ * rshogi の対局 ID から CSA 棋譜とメタを取得する。
+ *
+ * @param gameId rshogi 上の対局 ID
+ * @param options baseUrl 等の上書き。未指定時はモック fixture を返す。
+ */
+export async function fetchRshogiGame(
+    gameId: string,
+    options: FetchRshogiGameOptions = {},
+): Promise<RshogiGame> {
+    if (!gameId) {
+        throw new RshogiGameFetchError(gameId, "gameId is required");
+    }
+
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) {
+        const mock = MOCK_RSHOGI_GAMES[gameId];
+        if (!mock) {
+            throw new RshogiGameNotFoundError(gameId);
+        }
+        return mock;
+    }
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError(gameId, "fetch is not available in this environment");
+    }
+
+    const url = `${trimTrailingSlash(baseUrl)}/games/${encodeURIComponent(gameId)}`;
+    const response = await fetchImpl(url, { signal: options.signal });
+    if (response.status === 404) {
+        throw new RshogiGameNotFoundError(gameId);
+    }
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            gameId,
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+
+    const payload = (await response.json()) as Partial<RshogiGame> | null;
+    if (!payload || typeof payload.csa !== "string" || !payload.meta) {
+        throw new RshogiGameFetchError(gameId, "rshogi API response missing csa/meta");
+    }
+    return { csa: payload.csa, meta: payload.meta };
+}
+
+/**
+ * モック対局 ID 一覧。一覧/選択 UI などからの参照用。
+ */
+export function listMockRshogiGameIds(): string[] {
+    return Object.keys(MOCK_RSHOGI_GAMES);
+}

--- a/packages/match-client/src/rshogi-csa/fixtures.ts
+++ b/packages/match-client/src/rshogi-csa/fixtures.ts
@@ -1,0 +1,82 @@
+/**
+ * rshogi CSA viewer 用の組み込みモック棋譜。
+ *
+ * NOTE: 本実装に差し替える際はこのファイルではなく `client.ts` の
+ * `fetchRshogiGame` を fetch ベースに置き換える。
+ * fixture 自体は MVP 動作確認・テスト用としてそのまま残す想定。
+ */
+
+import type { RshogiGame } from "./client";
+
+const SAMPLE_1_CSA = [
+    "V2.2",
+    "N+RAMU_TP",
+    "N-FFF-70k",
+    "$EVENT:rshogi viewer mock sample",
+    "$START_TIME:2026/04/29 19:00:00",
+    "$TIME_LIMIT:00:10+30",
+    "PI",
+    "+",
+    "+7776FU",
+    "T8",
+    "-3334FU",
+    "T7",
+    "+7968GI",
+    "T9",
+    "-8384FU",
+    "T6",
+    "+6878GI",
+    "T5",
+    "-8485FU",
+    "T7",
+    "%TORYO",
+].join("\n");
+
+const SAMPLE_2_CSA = [
+    "V2.2",
+    "N+PC1_save012",
+    "N-RAMU_TP",
+    "$EVENT:rshogi viewer mock sample 2",
+    "$START_TIME:2026/04/30 21:00:00",
+    "$TIME_LIMIT:00:05+15",
+    "PI",
+    "+",
+    "+2726FU",
+    "T6",
+    "-8384FU",
+    "T5",
+    "+2625FU",
+    "T7",
+    "-8485FU",
+    "T6",
+    "%TORYO",
+].join("\n");
+
+export const MOCK_RSHOGI_GAMES: Record<string, RshogiGame> = {
+    "sample-1": {
+        meta: {
+            gameId: "sample-1",
+            senteName: "RAMU_TP",
+            goteName: "FFF-70k",
+            startedAt: "2026-04-29T10:00:00.000Z",
+            endedAt: "2026-04-29T10:18:42.000Z",
+            event: "rshogi viewer mock sample",
+            timeControl: { mainSeconds: 600, byoyomiSeconds: 30 },
+            result: { kind: "resignation", winner: "sente" },
+        },
+        csa: SAMPLE_1_CSA,
+    },
+    "sample-2": {
+        meta: {
+            gameId: "sample-2",
+            senteName: "PC1_save012",
+            goteName: "RAMU_TP",
+            startedAt: "2026-04-30T12:00:00.000Z",
+            endedAt: "2026-04-30T12:09:11.000Z",
+            event: "rshogi viewer mock sample 2",
+            timeControl: { mainSeconds: 300, byoyomiSeconds: 15 },
+            result: { kind: "resignation", winner: "sente" },
+        },
+        csa: SAMPLE_2_CSA,
+    },
+};

--- a/packages/ui/src/components/rshogi-csa-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.tsx
@@ -1,0 +1,224 @@
+/**
+ * rshogi CSA viewer 共通コンポーネント。
+ *
+ * Web/Desktop の各 Page から `engineOptions` と NNUE manifest を渡して使う。
+ * フェッチ・パース・読み込み中表示までをここで集約し、本体の盤面/棋譜は
+ * 既存の `<ShogiMatch>` の `initialReview + reviewMode` に委譲する。
+ *
+ * 配信 API は別タスク (rshogi#542) で設計中のため、`fetchRshogiGame` は
+ * モックを返す stub。本実装に差し替える際はこのコンポーネントは触らずに済む。
+ */
+
+import { parseCsaMoves } from "@shogi/app-core";
+import type { FetchRshogiGameOptions, RshogiGame } from "@shogi/match-client";
+import { fetchRshogiGame, RshogiGameNotFoundError } from "@shogi/match-client";
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+import { ShogiMatch } from "./shogi-match";
+import type { EngineOption } from "./shogi-match/types";
+
+export interface RshogiCsaViewerProps {
+    gameId: string;
+    engineOptions: EngineOption[];
+    manifestUrl: string;
+    /** rshogi 配信 API のベース URL。空のときはモック fixture を返す。 */
+    apiBaseUrl?: string;
+    /** 主にテスト・SSR で fetch を差し替えるためのフック */
+    fetchOverride?: FetchRshogiGameOptions["fetchImpl"];
+    /** ヘッダ等の追加レイアウト要素 */
+    header?: ReactNode;
+    aiIconUrl?: string;
+    fetchLegalMoves?: React.ComponentProps<typeof ShogiMatch>["fetchLegalMoves"];
+    onRequestNnueFilePath?: React.ComponentProps<typeof ShogiMatch>["onRequestNnueFilePath"];
+    isDevMode?: boolean;
+}
+
+interface LoadState {
+    status: "loading" | "ready" | "not-found" | "error";
+    game?: RshogiGame;
+    moves?: string[];
+    errorMessage?: string;
+}
+
+const formatTimestamp = (value: string | undefined): string => {
+    if (!value) return "不明";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return value;
+    return date.toLocaleString("ja-JP");
+};
+
+const formatTimeControl = (value: RshogiGame["meta"]["timeControl"]): string => {
+    if (!value) return "持ち時間: 不明";
+    const main = `${Math.round(value.mainSeconds / 60)}分`;
+    const byoyomi = value.byoyomiSeconds > 0 ? ` + 秒読み${value.byoyomiSeconds}秒` : "";
+    const inc =
+        value.incrementSeconds && value.incrementSeconds > 0
+            ? ` + 加算${value.incrementSeconds}秒`
+            : "";
+    return `持ち時間: ${main}${byoyomi}${inc}`;
+};
+
+const formatResult = (meta: RshogiGame["meta"]): string => {
+    const result = meta.result;
+    if (!result) return "結果: 不明";
+    const winnerLabel =
+        result.winner === "sente"
+            ? `先手 (${meta.senteName}) 勝ち`
+            : result.winner === "gote"
+              ? `後手 (${meta.goteName}) 勝ち`
+              : "引き分け";
+    const reason: Record<typeof result.kind, string> = {
+        resignation: "投了",
+        checkmate: "詰み",
+        time_expired: "時間切れ",
+        draw: "引き分け",
+        abort: "中断",
+    };
+    return `結果: ${winnerLabel} (${reason[result.kind]})`;
+};
+
+function RshogiGameMetaPanel({ game }: { game: RshogiGame }): ReactElement {
+    const { meta } = game;
+    return (
+        <section
+            aria-label="対局情報"
+            className="flex flex-col gap-2 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-sm text-wafuu-sumi"
+        >
+            <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">対局 ID</span>
+                <span className="font-mono text-xs text-wafuu-sumi">{meta.gameId}</span>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">対局者</span>
+                <span className="text-sm font-semibold">
+                    ☗ {meta.senteName} vs ☖ {meta.goteName}
+                </span>
+            </div>
+            {meta.event && (
+                <div className="flex flex-col gap-1">
+                    <span className="text-xs text-muted-foreground">大会</span>
+                    <span>{meta.event}</span>
+                </div>
+            )}
+            <div className="flex flex-col gap-0.5 text-xs text-muted-foreground">
+                <span>開始: {formatTimestamp(meta.startedAt)}</span>
+                <span>終了: {formatTimestamp(meta.endedAt)}</span>
+            </div>
+            <div className="text-xs text-muted-foreground">
+                {formatTimeControl(meta.timeControl)}
+            </div>
+            <div className="text-sm">{formatResult(meta)}</div>
+        </section>
+    );
+}
+
+export function RshogiCsaViewer({
+    gameId,
+    engineOptions,
+    manifestUrl,
+    apiBaseUrl,
+    fetchOverride,
+    header,
+    aiIconUrl,
+    fetchLegalMoves,
+    onRequestNnueFilePath,
+    isDevMode,
+}: RshogiCsaViewerProps): ReactElement {
+    const [state, setState] = useState<LoadState>({ status: "loading" });
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setState({ status: "loading" });
+        void (async () => {
+            try {
+                const game = await fetchRshogiGame(gameId, {
+                    baseUrl: apiBaseUrl,
+                    fetchImpl: fetchOverride,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                let moves: string[];
+                try {
+                    moves = parseCsaMoves(game.csa);
+                } catch (parseError) {
+                    setState({
+                        status: "error",
+                        errorMessage: `CSA の解析に失敗しました: ${String(parseError)}`,
+                    });
+                    return;
+                }
+                setState({ status: "ready", game, moves });
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                if (error instanceof RshogiGameNotFoundError) {
+                    setState({ status: "not-found" });
+                    return;
+                }
+                setState({
+                    status: "error",
+                    errorMessage:
+                        error instanceof Error
+                            ? error.message
+                            : `読み込みに失敗しました: ${String(error)}`,
+                });
+            }
+        })();
+        return () => {
+            controller.abort();
+        };
+    }, [gameId, apiBaseUrl, fetchOverride]);
+
+    if (state.status === "loading") {
+        return (
+            <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm text-muted-foreground">
+                {header}
+                <p>棋譜を読み込み中...</p>
+            </div>
+        );
+    }
+
+    if (state.status === "not-found") {
+        return (
+            <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm">
+                {header}
+                <p className="text-destructive">
+                    対局 ID「{gameId}」の棋譜が見つかりませんでした。
+                </p>
+            </div>
+        );
+    }
+
+    if (state.status === "error") {
+        return (
+            <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm">
+                {header}
+                <p className="text-destructive">{state.errorMessage}</p>
+            </div>
+        );
+    }
+
+    const { game, moves } = state;
+    if (!game || !moves) {
+        return <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm" />;
+    }
+
+    return (
+        <div>
+            {header}
+            <ShogiMatch
+                engineOptions={engineOptions}
+                manifestUrl={manifestUrl}
+                aiIconUrl={aiIconUrl}
+                fetchLegalMoves={fetchLegalMoves}
+                onRequestNnueFilePath={onRequestNnueFilePath}
+                isDevMode={isDevMode}
+                defaultSides={{
+                    sente: { role: "human" },
+                    gote: { role: "human" },
+                }}
+                initialReview={{ sfen: "startpos", moves }}
+                reviewMode={true}
+                reviewLeftContent={<RshogiGameMetaPanel game={game} />}
+            />
+        </div>
+    );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -46,10 +46,14 @@ export { boardToGrid } from "./components/shogi-match/utils/positionUtils";
 // progress
 // shogi-board
 
+export { listMockRshogiGameIds } from "@shogi/match-client";
 export type { RemoteNnueFile, RemoteNnueManager } from "./components/nnue/types";
 export type { AnalysisMoveResult, OnlineAnalysis } from "./components/online-game-view";
 // online-game-view
 export { OnlineGameView } from "./components/online-game-view";
+export type { RshogiCsaViewerProps } from "./components/rshogi-csa-viewer";
+// rshogi-csa-viewer
+export { RshogiCsaViewer } from "./components/rshogi-csa-viewer";
 // shogi-match
 export { ShogiMatch } from "./components/shogi-match";
 


### PR DESCRIPTION
親 Issue: SH11235/ramu-shogi#24
親 Epic: SH11235/rshogi#541

## Summary

rshogi csa-server に保存された CSA 棋譜を 1 局単位で再生する viewer MVP の scaffold を Web / Desktop 両方に追加。配信 API は SH11235/rshogi#542 で並行設計中のため、本 PR ではモック関数 (`fetchRshogiGame`) を 1 箇所に集約し、後で実 fetch に差し替える前提で進める。

## 変更点

- `packages/match-client/src/rshogi-csa/` 新設: `client.ts` (モック付き fetch 抽象) + `fixtures.ts` (サンプル CSA)
- `packages/ui/src/components/rshogi-csa-viewer.tsx` 新設: 既存 ShogiMatch (reviewMode) と KifuPanel を流用した再生 UI
- `apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx` 新設 + `apps/web/src/router.tsx` に `/rshogi-viewer/$gameId` ルートを追加
- `apps/desktop/src/components/rshogi-viewer/RshogiViewerView.tsx` 新設 + `apps/desktop/src/App.tsx` の appMode 切替で接続
- `apps/{web,desktop}/.env.example` に `VITE_RSHOGI_API_BASE` (空 = モック) を追加

## 動作確認

- `pnpm --filter web dev` → `/rshogi-viewer/sample-1` を Playwright で開き、メタパネル / 棋譜パネル / 盤面再生 / パンくずすべて動作確認済み
- Desktop は appMode 切替で同 viewer を表示

## Non-goals (別 Issue)

- 棋譜一覧 (SH11235/ramu-shogi#25)
- live 観戦 (SH11235/ramu-shogi#26)
- 評価値グラフ
- 認証

## 関連事項 (本 PR スコープ外)

- `packages/app-core/src/game/board.ts:122` の `STARTPOS_BOARD_SFEN` に 8 筋歩欠落の既存タイポを発見。本 PR では viewer 側で `parseCsaMoves` 経路を回避することで影響を受けない構造になっているが、別 PR で fix する。
- API contract: server (CSA 語彙 / snake_case / epoch_ms) と client (camelCase / sente-gote / Date) の差は `decodeServerResponse` 層を `fetchRshogiGame` 内に追加する形 (A 案) で SH11235/rshogi#542 と整合させる。実装は #542 確定後の追従 PR で行う。

Closes SH11235/ramu-shogi#24

🤖 Generated with [Claude Code](https://claude.com/claude-code)