### PR TITLE
fix(app-core): STARTPOS_BOARD_SFEN の 8 筋歩欠落タイポを修正する

### DIFF
--- a/packages/app-core/src/game/board.ts
+++ b/packages/app-core/src/game/board.ts
@@ -119,7 +119,7 @@ export function cloneBoard(board: BoardState): BoardState {
     return clone;
 }
 
-const STARTPOS_BOARD_SFEN = "lnsgkgsnl/1r5b1/p1ppppppp/9/9/9/P1PPPPPPP/1B5R1/LNSGKGSNL";
+const STARTPOS_BOARD_SFEN = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL";
 
 function getFallbackInitialPosition(): PositionState {
     if (fallbackInitialPosition) return fallbackInitialPosition;


### PR DESCRIPTION
## Summary

- `packages/app-core/src/game/board.ts` の `STARTPOS_BOARD_SFEN` で 8 筋の歩 (8c / 8g) が両軍欠落していたタイポを修正
- `p1ppppppp` / `P1PPPPPPP` → `ppppppppp` / `PPPPPPPPP` への 1 文字置換 ×2 のみ

## 経緯

- 2025-12-15 commit `0564ae22b` で混入していた既存バグ
- 通常のアプリ操作経路は `getPositionService().getInitialBoard()` (Rust エンジン経由) を使うため踏まれていなかった
- `parseCsaMoves(contents)` を `initialBoard` 未指定で呼んだ場合のフォールバックは `getFallbackInitialPosition()` → 当該 SFEN を使うため、CSA インポートで 8 筋を絡む手 (`-8384FU` 等) が暗黙に skip されていた
- rshogi viewer MVP の Playwright 検証で発見

## 影響範囲

- 影響: `parseCsaMoves(csa)` (initialBoard 省略時) / その経由で `boardFromMoves` 等にフォールバックを渡しているケース
- 通常 UI 操作 / Rust バックエンド経由の経路は不変
- `STARTPOS_BOARD_SFEN` 定数自体はモジュール内 private なので外部 API シグネチャ変更なし

## Test plan

- [x] `pnpm typecheck` (workspace 全体) — 11 tasks successful
- [x] `pnpm --filter @shogi/app-core test` — 5 ファイル / 123 テスト全パス (board.test.ts 49 / csa.test.ts 11 含む)
- [x] `pnpm lint` — 既存の warnings 2 件のみ (本 PR と無関係、`engine-tauri/src/preview-session-service.test.ts` の non-null assertion)
- [x] タイポ前提で書かれている既存テストはなし（修正なし）
- [x] リポジトリ内に同タイポの他出現なし (`p1ppppppp` / `P1PPPPPPP` 全文検索 0 件)

## 補足

- workspace の `pnpm test` は `@shogi/api-contract` / `@shogi/match-protocol` で "No test files found" により先に落ちるが、これは既存の (本修正と無関係な) パッケージ構成事情。app-core 単体テストで網羅的に確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)