### PR TITLE
feat(viewer): rshogi CSA 棋譜一覧ページ + decode 層 (A 案 contract)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActiveEngineSettingsPanel } from "./components/ActiveEngineSettingsPanel";
 import { CsaGameView } from "./components/csa/CsaGameView";
 import { EngineManagerPanel } from "./components/EngineManagerPanel";
+import { RshogiViewerListView } from "./components/rshogi-viewer/RshogiViewerListView";
 import { RshogiViewerView } from "./components/rshogi-viewer/RshogiViewerView";
 
 const createEngineClient = () =>
@@ -82,10 +83,11 @@ interface EngineSettingsTarget {
     label: string;
 }
 
-type AppMode = "local" | "csa" | "rshogi-viewer";
+type AppMode = "local" | "csa" | "rshogi-viewer-list" | "rshogi-viewer-detail";
 
 function App() {
     const [appMode, setAppMode] = useState<AppMode>("local");
+    const [rshogiViewerGameId, setRshogiViewerGameId] = useState<string | null>(null);
 
     const handleSwitchToCsa = async () => {
         try {
@@ -101,7 +103,18 @@ function App() {
     };
 
     const handleSwitchToRshogiViewer = () => {
-        setAppMode("rshogi-viewer");
+        setRshogiViewerGameId(null);
+        setAppMode("rshogi-viewer-list");
+    };
+
+    const handleSelectRshogiGame = (gameId: string) => {
+        setRshogiViewerGameId(gameId);
+        setAppMode("rshogi-viewer-detail");
+    };
+
+    const handleBackToRshogiList = () => {
+        setRshogiViewerGameId(null);
+        setAppMode("rshogi-viewer-list");
     };
 
     const [panelPosition, setPanelPosition] = useState<{
@@ -189,11 +202,28 @@ function App() {
         );
     }
 
-    if (appMode === "rshogi-viewer") {
+    if (appMode === "rshogi-viewer-list") {
         return (
             <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
                 <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
-                    <RshogiViewerView onBackToLocal={() => setAppMode("local")} />
+                    <RshogiViewerListView
+                        onBackToLocal={() => setAppMode("local")}
+                        onSelectGame={handleSelectRshogiGame}
+                    />
+                </main>
+            </NnueProvider>
+        );
+    }
+
+    if (appMode === "rshogi-viewer-detail" && rshogiViewerGameId) {
+        return (
+            <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
+                <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
+                    <RshogiViewerView
+                        gameId={rshogiViewerGameId}
+                        onBackToList={handleBackToRshogiList}
+                        onBackToLocal={() => setAppMode("local")}
+                    />
                 </main>
             </NnueProvider>
         );

--- a/apps/desktop/src/components/rshogi-viewer/RshogiViewerListView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiViewerListView.tsx
@@ -1,0 +1,103 @@
+import type { RshogiGameSummary } from "@shogi/match-client";
+import { fetchRshogiGameList } from "@shogi/match-client";
+import { RshogiCsaGameList } from "@shogi/ui";
+import { Button } from "@shogi/ui/components/button";
+import { type ReactElement, useEffect, useState } from "react";
+
+const PAGE_LIMIT = 50;
+
+interface Props {
+    onBackToLocal: () => void;
+    onSelectGame: (gameId: string) => void;
+}
+
+export function RshogiViewerListView({ onBackToLocal, onSelectGame }: Props): ReactElement {
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    const [games, setGames] = useState<RshogiGameSummary[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setIsLoading(true);
+        setErrorMessage(null);
+        void (async () => {
+            try {
+                const page = await fetchRshogiGameList({
+                    baseUrl: apiBaseUrl,
+                    limit: PAGE_LIMIT,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                setGames(page.games);
+                setNextCursor(page.nextCursor);
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : `棋譜一覧の取得に失敗しました: ${String(error)}`,
+                );
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        })();
+        return () => {
+            controller.abort();
+        };
+    }, [apiBaseUrl]);
+
+    const handleLoadMore = async (): Promise<void> => {
+        if (!nextCursor || isLoading) return;
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const page = await fetchRshogiGameList({
+                baseUrl: apiBaseUrl,
+                cursor: nextCursor,
+                limit: PAGE_LIMIT,
+            });
+            setGames((prev) => [...prev, ...page.games]);
+            setNextCursor(page.nextCursor);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : `棋譜一覧の取得に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Button variant="outline" size="sm" onClick={onBackToLocal}>
+                    ← ローカル対局へ戻る
+                </Button>
+                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer</span>
+                <span className="text-xs text-muted-foreground">
+                    終局済みの CSA 棋譜を新着順で表示します。
+                </span>
+            </div>
+
+            {errorMessage && (
+                <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                    {errorMessage}
+                </div>
+            )}
+
+            <RshogiCsaGameList
+                games={games}
+                onSelect={onSelectGame}
+                onLoadMore={() => void handleLoadMore()}
+                isLoading={isLoading}
+                hasMore={nextCursor !== undefined}
+            />
+        </div>
+    );
+}

--- a/apps/desktop/src/components/rshogi-viewer/RshogiViewerView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiViewerView.tsx
@@ -1,8 +1,8 @@
 import { createTauriEngineClient, getLegalMoves } from "@shogi/engine-tauri";
 import type { EngineOption } from "@shogi/ui";
-import { listMockRshogiGameIds, RshogiCsaViewer } from "@shogi/ui";
+import { RshogiCsaViewer } from "@shogi/ui";
 import { Button } from "@shogi/ui/components/button";
-import { type ReactElement, useState } from "react";
+import type { ReactElement } from "react";
 
 const ENGINE_OPTIONS: EngineOption[] = [
     {
@@ -21,20 +21,14 @@ const ENGINE_OPTIONS: EngineOption[] = [
 const nnueManifestUrl = import.meta.env.VITE_NNUE_MANIFEST_URL as string;
 
 interface Props {
+    gameId: string;
+    onBackToList: () => void;
     onBackToLocal: () => void;
 }
 
-export function RshogiViewerView({ onBackToLocal }: Props): ReactElement {
-    const mockIds = listMockRshogiGameIds();
-    const [gameId, setGameId] = useState<string>(mockIds[0] ?? "sample-1");
-    const [draftGameId, setDraftGameId] = useState<string>(gameId);
+export function RshogiViewerView({ gameId, onBackToList, onBackToLocal }: Props): ReactElement {
     const apiBaseUrl =
         (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
-
-    const handleApply = () => {
-        const next = draftGameId.trim();
-        if (next.length > 0) setGameId(next);
-    };
 
     return (
         <div className="flex flex-col gap-3">
@@ -42,29 +36,11 @@ export function RshogiViewerView({ onBackToLocal }: Props): ReactElement {
                 <Button variant="outline" size="sm" onClick={onBackToLocal}>
                     ← ローカル対局へ戻る
                 </Button>
-                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer</span>
-                <span className="text-xs text-muted-foreground">
-                    対局 ID を指定して CSA 棋譜を再生します。
-                </span>
-            </div>
-            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-2">
-                <label className="text-xs text-muted-foreground" htmlFor="rshogi-game-id">
-                    対局 ID
-                </label>
-                <input
-                    id="rshogi-game-id"
-                    className="rounded border border-wafuu-border bg-background px-2 py-1 text-sm"
-                    value={draftGameId}
-                    onChange={(e) => setDraftGameId(e.target.value)}
-                />
-                <Button size="sm" onClick={handleApply}>
-                    再生
+                <Button variant="outline" size="sm" onClick={onBackToList}>
+                    ← 棋譜一覧へ戻る
                 </Button>
-                {mockIds.length > 0 && (
-                    <span className="text-xs text-muted-foreground">
-                        モック ID 例: {mockIds.join(", ")}
-                    </span>
-                )}
+                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer</span>
+                <span className="text-xs text-muted-foreground">対局 ID: {gameId}</span>
             </div>
             <RshogiCsaViewer
                 gameId={gameId}

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -1,0 +1,115 @@
+import type { RshogiGameSummary } from "@shogi/match-client";
+import { fetchRshogiGameList } from "@shogi/match-client";
+import { RshogiCsaGameList } from "@shogi/ui";
+import { useNavigate } from "@tanstack/react-router";
+import { type ReactElement, useEffect, useState } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageHeader } from "../../components/PageHeader";
+
+const PAGE_LIMIT = 50;
+
+const resolveApiBaseUrl = (): string | undefined => {
+    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
+    return raw?.trim() || undefined;
+};
+
+export default function RshogiViewerListPage(): ReactElement {
+    const navigate = useNavigate();
+    const apiBaseUrl = resolveApiBaseUrl();
+
+    const [games, setGames] = useState<RshogiGameSummary[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    // 初回ロード
+    useEffect(() => {
+        const controller = new AbortController();
+        setIsLoading(true);
+        setErrorMessage(null);
+        void (async () => {
+            try {
+                const page = await fetchRshogiGameList({
+                    baseUrl: apiBaseUrl,
+                    limit: PAGE_LIMIT,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                setGames(page.games);
+                setNextCursor(page.nextCursor);
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : `棋譜一覧の取得に失敗しました: ${String(error)}`,
+                );
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        })();
+        return () => {
+            controller.abort();
+        };
+    }, [apiBaseUrl]);
+
+    const handleLoadMore = async (): Promise<void> => {
+        if (!nextCursor || isLoading) return;
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const page = await fetchRshogiGameList({
+                baseUrl: apiBaseUrl,
+                cursor: nextCursor,
+                limit: PAGE_LIMIT,
+            });
+            // append (新→旧で連結)
+            setGames((prev) => [...prev, ...page.games]);
+            setNextCursor(page.nextCursor);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : `棋譜一覧の取得に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleSelect = (gameId: string): void => {
+        void navigate({ to: "/rshogi-viewer/$gameId", params: { gameId } });
+    };
+
+    return (
+        <>
+            <PageHeader
+                items={[{ label: "ラム将棋", to: "/" }, { label: "rshogi viewer" }]}
+                right={<HeaderNav />}
+            />
+            <main className="mx-auto flex w-full max-w-[960px] flex-col gap-4 px-4 py-6">
+                <div className="flex flex-col gap-1">
+                    <h1 className="text-lg font-semibold text-wafuu-sumi">rshogi 棋譜一覧</h1>
+                    <p className="text-xs text-muted-foreground">
+                        rshogi CSA サーバで終局した棋譜を新着順で表示します。クリックすると個別の
+                        viewer に遷移します。
+                    </p>
+                </div>
+
+                {errorMessage && (
+                    <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                        {errorMessage}
+                    </div>
+                )}
+
+                <RshogiCsaGameList
+                    games={games}
+                    onSelect={handleSelect}
+                    onLoadMore={() => void handleLoadMore()}
+                    isLoading={isLoading}
+                    hasMore={nextCursor !== undefined}
+                />
+            </main>
+        </>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
@@ -43,7 +43,7 @@ export default function RshogiViewerPage(): ReactElement {
             <PageHeader
                 items={[
                     { label: "ラム将棋", to: "/" },
-                    { label: "rshogi viewer" },
+                    { label: "rshogi viewer", to: "/rshogi-viewer" },
                     { label: gameId },
                 ]}
                 right={<HeaderNav />}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -22,6 +22,7 @@ import CreateRoomPage from "./pages/online/CreateRoomPage";
 import OnlinePage from "./pages/online/OnlinePage";
 import RoomPage from "./pages/online/RoomPage";
 import PrivacyPage from "./pages/privacy/PrivacyPage";
+import RshogiViewerListPage from "./pages/rshogi-viewer/RshogiViewerListPage";
 import RshogiViewerPage from "./pages/rshogi-viewer/RshogiViewerPage";
 import { handleLoaderResponse } from "./router-loader-utils";
 
@@ -209,6 +210,12 @@ const privacyRoute = createRoute({
     component: PrivacyPage,
 });
 
+const rshogiViewerListRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer",
+    component: RshogiViewerListPage,
+});
+
 const rshogiViewerRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer/$gameId",
@@ -279,6 +286,7 @@ const routeTree = rootRoute.addChildren([
     nnueFilesRoute,
     createRoomRoute,
     roomRoute,
+    rshogiViewerListRoute,
     rshogiViewerRoute,
 ]);
 

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -46,15 +46,22 @@ export {
     storeSeat,
 } from "./reconnect";
 export type {
+    FetchRshogiGameListOptions,
     FetchRshogiGameOptions,
+    RshogiClockKind,
+    RshogiEndReason,
     RshogiGame,
+    RshogiGameListPage,
     RshogiGameMeta,
     RshogiGameResult,
     RshogiGameResultKind,
+    RshogiGameSource,
+    RshogiGameSummary,
     RshogiTimeControl,
 } from "./rshogi-csa/client";
 export {
     fetchRshogiGame,
+    fetchRshogiGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
     fetchRshogiGame,
+    fetchRshogiGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,
@@ -11,6 +12,9 @@ describe("fetchRshogiGame (mock fallback)", () => {
         const game = await fetchRshogiGame("sample-1");
         expect(game.meta.gameId).toBe("sample-1");
         expect(game.meta.senteName).toBe("RAMU_TP");
+        expect(typeof game.meta.startedAtMs).toBe("number");
+        expect(typeof game.meta.endedAtMs).toBe("number");
+        expect(game.meta.timeControl?.kind).toBe("fischer");
         expect(game.csa).toContain("V2.2");
         expect(game.csa).toContain("+7776FU");
     });
@@ -32,14 +36,30 @@ describe("fetchRshogiGame (mock fallback)", () => {
 });
 
 describe("fetchRshogiGame (real baseUrl)", () => {
-    it("calls baseUrl/games/<id> and returns the parsed payload", async () => {
-        const payload = {
-            meta: { gameId: "abc", senteName: "S", goteName: "G" },
-            csa: "V2.2\nN+S\nN-G\nPI\n+\n",
+    it("decodes wire (snake_case + epoch_ms) into camelCase + epoch_ms domain types", async () => {
+        const wirePayload = {
+            game_id: "abc",
+            started_at_ms: 1777391025209,
+            ended_at_ms: 1777392877244,
+            black_handle: "alice",
+            white_handle: "bob",
+            result_kind: "WIN_BLACK",
+            end_reason: "RESIGN",
+            moves_count: 142,
+            clock: {
+                kind: "fischer",
+                total_sec: 300,
+                byoyomi_sec: 10,
+                byoyomi_ms: null,
+                increment_sec: 5,
+            },
+            source: "kifu",
+            event: "test event",
+            csa: "V2.2\nN+alice\nN-bob\nPI\n+\n",
         };
         const fetchImpl = vi.fn(
             async () =>
-                new Response(JSON.stringify(payload), {
+                new Response(JSON.stringify(wirePayload), {
                     status: 200,
                     headers: { "content-type": "application/json" },
                 }),
@@ -55,7 +75,190 @@ describe("fetchRshogiGame (real baseUrl)", () => {
             .calls[0][0];
         expect(calledUrl).toBe("https://rshogi.example.com/api/games/abc");
         expect(game.meta.gameId).toBe("abc");
+        // black=sente, white=gote
+        expect(game.meta.senteName).toBe("alice");
+        expect(game.meta.goteName).toBe("bob");
+        expect(game.meta.startedAtMs).toBe(1777391025209);
+        expect(game.meta.endedAtMs).toBe(1777392877244);
+        expect(game.meta.event).toBe("test event");
+        expect(game.meta.movesCount).toBe(142);
+        expect(game.meta.source).toBe("kifu");
+        expect(game.meta.timeControl).toEqual({
+            kind: "fischer",
+            mainSeconds: 300,
+            byoyomiSeconds: 10,
+            byoyomiMilliseconds: undefined,
+            incrementSeconds: 5,
+        });
+        expect(game.meta.result).toEqual({
+            kind: "resignation",
+            winner: "sente",
+            endReason: "RESIGN",
+        });
         expect(game.csa).toContain("V2.2");
+    });
+
+    it("decodes WIN_WHITE + TIME_UP into gote winner + time_expired", async () => {
+        const wirePayload = {
+            game_id: "g1",
+            started_at_ms: 1,
+            ended_at_ms: 2,
+            black_handle: "B",
+            white_handle: "W",
+            result_kind: "WIN_WHITE",
+            end_reason: "TIME_UP",
+            moves_count: 50,
+            clock: { kind: "countdown", total_sec: 60, byoyomi_sec: 30 },
+            source: "floodgate",
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g1", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.result).toEqual({
+            kind: "time_expired",
+            winner: "gote",
+            endReason: "TIME_UP",
+        });
+    });
+
+    it("decodes DRAW + SENNICHITE into draw without winner", async () => {
+        const wirePayload = {
+            game_id: "g2",
+            black_handle: "B",
+            white_handle: "W",
+            result_kind: "DRAW",
+            end_reason: "SENNICHITE",
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g2", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.result).toEqual({
+            kind: "draw",
+            winner: undefined,
+            endReason: "SENNICHITE",
+        });
+    });
+
+    it("decodes WIN_BLACK + JISHOGI into jishogi with sente winner", async () => {
+        const wirePayload = {
+            game_id: "g3",
+            black_handle: "B",
+            white_handle: "W",
+            result_kind: "WIN_BLACK",
+            end_reason: "JISHOGI",
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g3", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.result).toEqual({
+            kind: "jishogi",
+            winner: "sente",
+            endReason: "JISHOGI",
+        });
+    });
+
+    it("decodes WIN_WHITE + OUTE_SENNICHITE into oute_sennichite with gote winner", async () => {
+        const wirePayload = {
+            game_id: "g4",
+            black_handle: "B",
+            white_handle: "W",
+            result_kind: "WIN_WHITE",
+            end_reason: "OUTE_SENNICHITE",
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g4", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.result).toEqual({
+            kind: "oute_sennichite",
+            winner: "gote",
+            endReason: "OUTE_SENNICHITE",
+        });
+    });
+
+    it("normalizes stopwatch clock from total_min/byoyomi_min", async () => {
+        const wirePayload = {
+            game_id: "g5",
+            black_handle: "B",
+            white_handle: "W",
+            clock: { kind: "stopwatch", total_min: 30, byoyomi_min: 1 },
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g5", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.timeControl).toEqual({
+            kind: "stopwatch",
+            mainSeconds: 1800,
+            byoyomiSeconds: 60,
+            byoyomiMilliseconds: undefined,
+            incrementSeconds: undefined,
+        });
+    });
+
+    it("normalizes countdown_msec clock from total_ms/byoyomi_ms", async () => {
+        const wirePayload = {
+            game_id: "g6",
+            black_handle: "B",
+            white_handle: "W",
+            clock: { kind: "countdown_msec", total_ms: 30000, byoyomi_ms: 250 },
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g6", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.timeControl).toEqual({
+            kind: "countdown_msec",
+            mainSeconds: 30,
+            byoyomiSeconds: 0,
+            byoyomiMilliseconds: 250,
+            incrementSeconds: undefined,
+        });
     });
 
     it("maps 404 to RshogiGameNotFoundError", async () => {
@@ -78,6 +281,140 @@ describe("fetchRshogiGame (real baseUrl)", () => {
 
         await expect(
             fetchRshogiGame("boom", {
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+});
+
+describe("fetchRshogiGameList (mock fallback)", () => {
+    it("returns the mock list when no baseUrl is provided", async () => {
+        const page = await fetchRshogiGameList();
+        expect(page.games.length).toBeGreaterThan(0);
+        expect(page.games[0].gameId).toBeTruthy();
+        // すべて summary 形式 (camelCase + epoch_ms)
+        for (const game of page.games) {
+            expect(typeof game.senteName).toBe("string");
+            expect(typeof game.goteName).toBe("string");
+            if (game.startedAtMs !== undefined) {
+                expect(typeof game.startedAtMs).toBe("number");
+            }
+        }
+    });
+
+    it("respects limit and exposes nextCursor when more results exist", async () => {
+        const first = await fetchRshogiGameList({ limit: 2 });
+        expect(first.games).toHaveLength(2);
+        expect(first.nextCursor).toBe("2");
+        const second = await fetchRshogiGameList({ limit: 2, cursor: first.nextCursor });
+        expect(second.games.length).toBeGreaterThan(0);
+        expect(second.games[0].gameId).not.toBe(first.games[0].gameId);
+    });
+});
+
+describe("fetchRshogiGameList (real baseUrl)", () => {
+    it("calls baseUrl/games with cursor & limit query and decodes wire into RshogiGameListPage", async () => {
+        const wirePayload = {
+            games: [
+                {
+                    game_id: "room1-1777391025209",
+                    started_at_ms: 1777391025209,
+                    ended_at_ms: 1777392877244,
+                    black_handle: "alice",
+                    white_handle: "bob",
+                    result_kind: "WIN_BLACK",
+                    end_reason: "RESIGN",
+                    moves_count: 142,
+                    clock: {
+                        kind: "fischer",
+                        total_sec: 300,
+                        byoyomi_sec: 10,
+                        byoyomi_ms: null,
+                        increment_sec: null,
+                    },
+                    source: "kifu",
+                },
+            ],
+            next_cursor: "opaque-cursor",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+        ) as unknown as typeof fetch;
+
+        const page = await fetchRshogiGameList({
+            baseUrl: "https://rshogi.example.com/api/v1/",
+            cursor: "prev-cursor",
+            limit: 25,
+            fetchImpl,
+        });
+
+        const calledUrl = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+            .calls[0][0];
+        expect(calledUrl).toBe(
+            "https://rshogi.example.com/api/v1/games?cursor=prev-cursor&limit=25",
+        );
+        expect(page.nextCursor).toBe("opaque-cursor");
+        expect(page.games).toHaveLength(1);
+        expect(page.games[0]).toMatchObject({
+            gameId: "room1-1777391025209",
+            senteName: "alice",
+            goteName: "bob",
+            startedAtMs: 1777391025209,
+            endedAtMs: 1777392877244,
+            movesCount: 142,
+            source: "kifu",
+            result: {
+                kind: "resignation",
+                winner: "sente",
+                endReason: "RESIGN",
+            },
+            timeControl: {
+                kind: "fischer",
+                mainSeconds: 300,
+                byoyomiSeconds: 10,
+            },
+        });
+    });
+
+    it("omits null next_cursor", async () => {
+        const wirePayload = { games: [], next_cursor: null };
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify(wirePayload), { status: 200 }),
+        ) as unknown as typeof fetch;
+        const page = await fetchRshogiGameList({
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(page.games).toEqual([]);
+        expect(page.nextCursor).toBeUndefined();
+    });
+
+    it("throws RshogiGameFetchError on non-2xx", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response("boom", { status: 500, statusText: "Server Error" }),
+        ) as unknown as typeof fetch;
+        await expect(
+            fetchRshogiGameList({
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+
+    it("throws RshogiGameFetchError when payload has no games array", async () => {
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ unrelated: true }), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        await expect(
+            fetchRshogiGameList({
                 baseUrl: "https://rshogi.example.com",
                 fetchImpl,
             }),

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -1,45 +1,127 @@
 /**
- * rshogi CSA viewer 用 API クライアント (MVP モック)。
+ * rshogi CSA viewer 用 API クライアント。
  *
- * 配信 API 本体は別タスク (rshogi#542) で設計中のため、ここでは
- * モックの fixture を返すだけの薄い stub を 1 箇所に集約する。
- * 本実装に差し替える際は本ファイルの `fetchRshogiGame` 内の分岐を
- * 実 fetch に置き換えるだけで viewer Page 側を弄らずに済む構造を維持する。
+ * rshogi 側の配信 API (`/api/v1/games`, `/api/v1/games/:gameId`) と
+ * UI の間に「decode 層」を 1 か所だけ挟み、wire format (snake_case + epoch_ms)
+ * を UI が扱う camelCase + ドメイン型に変換する。decode 層の責務は本ファイルに集約する:
+ *
+ * - snake_case → camelCase 変換
+ * - epoch_ms はそのまま number で保持し、Date 化は UI 側に任せる (タイムゾーン事故防止)
+ * - 黒/白ハンドルは「黒 = 先手 (sente) / 白 = 後手 (gote)」マッピングで TS 名に reflect
+ * - `result_kind` + `end_reason` を `{kind, winner?, endReason?}` 構造体にまとめる
+ * - `clock.kind` を `RshogiTimeControl` の `kind` field として保持
+ *
+ * baseUrl 未指定時は `MOCK_RSHOGI_GAMES` のモック fixture を返す MVP 動作を維持し、
+ * 本実装に差し替えても viewer Page 側を弄らずに済むよう同じ TS 型に decode する。
  */
 
-import { MOCK_RSHOGI_GAMES } from "./fixtures";
+import type {
+    RshogiClockKindWire,
+    RshogiEndReasonWire,
+    RshogiGameSourceWire,
+    RshogiResultKindWire,
+} from "./fixtures";
+import { MOCK_RSHOGI_GAME_LIST, MOCK_RSHOGI_GAMES } from "./fixtures";
 
-export type RshogiGameResultKind = "resignation" | "checkmate" | "time_expired" | "draw" | "abort";
+/**
+ * 終局理由 (wire の `end_reason` をそのまま保持したいケース向け)。
+ *
+ * UI が独自に enum を増やす必要が出ないよう、サーバが追加する可能性を考慮して
+ * `string` も許容するワイドユニオン型にする。
+ */
+export type RshogiEndReason = RshogiEndReasonWire | (string & {});
+
+/** 持ち時間の方式 (Fischer / 秒読み / ストップウォッチ等)。 */
+export type RshogiClockKind = RshogiClockKindWire | (string & {});
+
+/** 棋譜のソース (kifu = ユーザー登録 / floodgate 等)。 */
+export type RshogiGameSource = RshogiGameSourceWire | (string & {});
+
+/**
+ * 終局結果。
+ *
+ * - `kind`: 既存 viewer 互換のラベル (`resignation` / `time_expired` / `draw` / `abort` / `checkmate` / その他)
+ * - `winner`: 勝敗 (引き分け・中断時は undefined)
+ * - `endReason`: サーバが返す `end_reason` をそのまま保持し、より詳細な理由表示に使える
+ */
+export type RshogiGameResultKind =
+    | "resignation"
+    | "checkmate"
+    | "time_expired"
+    | "draw"
+    | "jishogi"
+    | "oute_sennichite"
+    | "abort"
+    | "max_moves"
+    | "abnormal";
 
 export interface RshogiGameResult {
     kind: RshogiGameResultKind;
-    /** 勝者 (draw / abort 時は undefined) */
     winner?: "sente" | "gote";
+    endReason?: RshogiEndReason;
 }
 
 export interface RshogiTimeControl {
+    /** 持ち時間方式 (`fischer` / `countdown` / `stopwatch` 等)。サーバが返す値をそのまま保持する。 */
+    kind?: RshogiClockKind;
+    /** 基本持ち時間 (秒)。サーバの `total_sec` 由来。 */
     mainSeconds: number;
+    /** 秒読み (秒)。none の場合は 0。 */
     byoyomiSeconds: number;
+    /** 秒読み (ミリ秒)。サーバが `byoyomi_ms` を返したときのみ含まれる。 */
+    byoyomiMilliseconds?: number;
+    /** Fischer 加算 (秒)。 */
     incrementSeconds?: number;
 }
 
 export interface RshogiGameMeta {
     gameId: string;
+    /** 黒 (= 先手 / sente) のハンドル。 */
     senteName: string;
+    /** 白 (= 後手 / gote) のハンドル。 */
     goteName: string;
-    /** ISO 8601 UTC timestamp */
-    startedAt?: string;
-    /** ISO 8601 UTC timestamp */
-    endedAt?: string;
+    /** 開始時刻 (epoch ms)。Date 化は UI 側で行う (タイムゾーン事故防止)。 */
+    startedAtMs?: number;
+    /** 終了時刻 (epoch ms)。 */
+    endedAtMs?: number;
+    /** 大会名等の自由記述 (CSA `$EVENT`)。 */
     event?: string;
     timeControl?: RshogiTimeControl;
     result?: RshogiGameResult;
+    /** 棋譜のソース。 */
+    source?: RshogiGameSource;
+    /** 手数。 */
+    movesCount?: number;
 }
 
 export interface RshogiGame {
     meta: RshogiGameMeta;
     /** CSA V2.2 形式の棋譜全文 */
     csa: string;
+}
+
+/**
+ * 一覧 API (`GET /api/v1/games`) の 1 件分。
+ *
+ * 単局取得 (`RshogiGame.meta`) と同じ camelCase 規約で揃える。
+ * 一覧では CSA 棋譜本文は返らないため `csa` は持たない。
+ */
+export interface RshogiGameSummary {
+    gameId: string;
+    senteName: string;
+    goteName: string;
+    startedAtMs?: number;
+    endedAtMs?: number;
+    timeControl?: RshogiTimeControl;
+    result?: RshogiGameResult;
+    movesCount?: number;
+    source?: RshogiGameSource;
+}
+
+export interface RshogiGameListPage {
+    games: RshogiGameSummary[];
+    /** 次ページ取得用カーソル。null/undefined の場合は末尾。 */
+    nextCursor?: string;
 }
 
 export interface FetchRshogiGameOptions {
@@ -52,6 +134,13 @@ export interface FetchRshogiGameOptions {
     fetchImpl?: typeof fetch;
     /** AbortController などからの中断に対応 */
     signal?: AbortSignal;
+}
+
+export interface FetchRshogiGameListOptions extends FetchRshogiGameOptions {
+    /** 次ページ取得用カーソル。サーバが発行した opaque string をそのまま渡す。 */
+    cursor?: string;
+    /** 1 ページあたり件数 (1〜100、サーバ既定 50)。 */
+    limit?: number;
 }
 
 export class RshogiGameNotFoundError extends Error {
@@ -75,6 +164,206 @@ export class RshogiGameFetchError extends Error {
 }
 
 const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "");
+
+// ===== wire format (snake_case) =====
+// サーバが返す JSON 1 件分。decode 層の入力でしか使わないため module 内部に閉じる。
+
+interface ClockWire {
+    kind?: RshogiClockKindWire | string;
+    total_sec?: number | null;
+    /** countdown_msec 用。total_sec の代わりに使う。 */
+    total_ms?: number | null;
+    /** stopwatch 用。total_sec の代わりに使う (分単位)。 */
+    total_min?: number | null;
+    byoyomi_sec?: number | null;
+    byoyomi_ms?: number | null;
+    /** stopwatch 用。byoyomi_sec の代わりに使う (分単位)。 */
+    byoyomi_min?: number | null;
+    increment_sec?: number | null;
+}
+
+interface GameWireBase {
+    game_id: string;
+    started_at_ms?: number | null;
+    ended_at_ms?: number | null;
+    black_handle: string;
+    white_handle: string;
+    result_kind?: RshogiResultKindWire | string | null;
+    end_reason?: RshogiEndReasonWire | string | null;
+    moves_count?: number | null;
+    clock?: ClockWire | null;
+    source?: RshogiGameSourceWire | string | null;
+    event?: string | null;
+}
+
+interface GameDetailWire extends GameWireBase {
+    csa: string;
+}
+
+interface GameListResponseWire {
+    games?: GameWireBase[];
+    next_cursor?: string | null;
+}
+
+const decodeNumberOrUndefined = (value: number | null | undefined): number | undefined => {
+    if (typeof value !== "number") return undefined;
+    if (!Number.isFinite(value)) return undefined;
+    return value;
+};
+
+const decodeStringOrUndefined = (value: string | null | undefined): string | undefined => {
+    if (typeof value !== "string") return undefined;
+    if (value.length === 0) return undefined;
+    return value;
+};
+
+const decodeClock = (clock: ClockWire | null | undefined): RshogiTimeControl | undefined => {
+    if (!clock) return undefined;
+    const totalSec = decodeNumberOrUndefined(clock.total_sec);
+    const totalMs = decodeNumberOrUndefined(clock.total_ms);
+    const totalMin = decodeNumberOrUndefined(clock.total_min);
+    const byoyomiSec = decodeNumberOrUndefined(clock.byoyomi_sec);
+    const byoyomiMs = decodeNumberOrUndefined(clock.byoyomi_ms);
+    const byoyomiMin = decodeNumberOrUndefined(clock.byoyomi_min);
+    const inc = decodeNumberOrUndefined(clock.increment_sec);
+    const kind = decodeStringOrUndefined(clock.kind);
+    // 何もフィールドが入っていないなら timeControl ごと undefined にする
+    if (
+        totalSec === undefined &&
+        totalMs === undefined &&
+        totalMin === undefined &&
+        byoyomiSec === undefined &&
+        byoyomiMs === undefined &&
+        byoyomiMin === undefined &&
+        inc === undefined &&
+        kind === undefined
+    ) {
+        return undefined;
+    }
+    // kind に応じて主単位を秒に正規化する。サーバ実装 (rshogi-csa-server-workers
+    // games_index.rs::ClockSpec::from_server) は kind ごとに排他的に下記フィールドを
+    // 出すため、UI 側ではここで秒換算に揃える。
+    const mainSeconds =
+        totalSec ??
+        (totalMs !== undefined ? Math.round(totalMs / 1000) : undefined) ??
+        (totalMin !== undefined ? totalMin * 60 : undefined) ??
+        0;
+    const byoyomiSeconds =
+        byoyomiSec ??
+        (byoyomiMs !== undefined ? Math.round(byoyomiMs / 1000) : undefined) ??
+        (byoyomiMin !== undefined ? byoyomiMin * 60 : undefined) ??
+        0;
+    return {
+        kind,
+        mainSeconds,
+        byoyomiSeconds,
+        byoyomiMilliseconds: byoyomiMs,
+        incrementSeconds: inc,
+    };
+};
+
+/**
+ * `result_kind` + `end_reason` (wire) を UI 用の `{kind, winner?, endReason?}` に decode する。
+ *
+ * - `WIN_BLACK` → 先手勝ち、`WIN_WHITE` → 後手勝ち
+ * - 終了理由 (`end_reason`) を見て `kind` を resignation/time_expired/draw/abort 等に振り分ける
+ * - 不明な end_reason の場合は最も妥当な fallback (`abort` 等) を入れつつ生の値を `endReason` で残す
+ */
+const decodeResult = (
+    resultKind: string | null | undefined,
+    endReason: string | null | undefined,
+): RshogiGameResult | undefined => {
+    if (!resultKind) return undefined;
+    const winner: "sente" | "gote" | undefined =
+        resultKind === "WIN_BLACK" ? "sente" : resultKind === "WIN_WHITE" ? "gote" : undefined;
+
+    const reason = decodeStringOrUndefined(endReason ?? undefined);
+    let kind: RshogiGameResultKind;
+    switch (reason) {
+        case "RESIGN":
+            kind = "resignation";
+            break;
+        case "TIME_UP":
+            kind = "time_expired";
+            break;
+        case "ILLEGAL":
+            kind = "abort";
+            break;
+        case "JISHOGI":
+            // 入玉宣言勝ち。winner は server が WIN_BLACK / WIN_WHITE で示す。
+            kind = "jishogi";
+            break;
+        case "OUTE_SENNICHITE":
+            // 連続王手の千日手 (反則勝ち)。winner は server が WIN_* で示す。
+            kind = "oute_sennichite";
+            break;
+        case "SENNICHITE":
+            // 通常の千日手。result_kind = DRAW を伴う。
+            kind = "draw";
+            break;
+        case "MAX_MOVES":
+            kind = "max_moves";
+            break;
+        case "ABNORMAL":
+            kind = "abnormal";
+            break;
+        default:
+            // 終局種別だけ来て理由不明な場合のフォールバック
+            kind =
+                resultKind === "DRAW"
+                    ? "draw"
+                    : resultKind === "ABORT"
+                      ? "abort"
+                      : winner !== undefined
+                        ? "resignation"
+                        : "abort";
+            break;
+    }
+
+    return {
+        kind,
+        winner,
+        endReason: reason,
+    };
+};
+
+const decodeGameSummary = (wire: GameWireBase): RshogiGameSummary => ({
+    gameId: wire.game_id,
+    // black=sente, white=gote のマッピング (rshogi 側の命名と TS 側の慣習を橋渡しする)
+    senteName: wire.black_handle,
+    goteName: wire.white_handle,
+    startedAtMs: decodeNumberOrUndefined(wire.started_at_ms),
+    endedAtMs: decodeNumberOrUndefined(wire.ended_at_ms),
+    timeControl: decodeClock(wire.clock),
+    result: decodeResult(wire.result_kind, wire.end_reason),
+    movesCount: decodeNumberOrUndefined(wire.moves_count),
+    source: decodeStringOrUndefined(wire.source ?? undefined),
+});
+
+const decodeGameDetail = (wire: GameDetailWire): RshogiGame => {
+    const summary = decodeGameSummary(wire);
+    const meta: RshogiGameMeta = {
+        gameId: summary.gameId,
+        senteName: summary.senteName,
+        goteName: summary.goteName,
+        startedAtMs: summary.startedAtMs,
+        endedAtMs: summary.endedAtMs,
+        event: decodeStringOrUndefined(wire.event ?? undefined),
+        timeControl: summary.timeControl,
+        result: summary.result,
+        source: summary.source,
+        movesCount: summary.movesCount,
+    };
+    return { meta, csa: wire.csa };
+};
+
+const decodeGameListResponse = (wire: GameListResponseWire): RshogiGameListPage => {
+    const games = Array.isArray(wire.games) ? wire.games.map(decodeGameSummary) : [];
+    return {
+        games,
+        nextCursor: decodeStringOrUndefined(wire.next_cursor ?? undefined),
+    };
+};
 
 /**
  * rshogi の対局 ID から CSA 棋譜とメタを取得する。
@@ -117,12 +406,73 @@ export async function fetchRshogiGame(
         );
     }
 
-    const payload = (await response.json()) as Partial<RshogiGame> | null;
-    if (!payload || typeof payload.csa !== "string" || !payload.meta) {
-        throw new RshogiGameFetchError(gameId, "rshogi API response missing csa/meta");
+    const payload = (await response.json()) as Partial<GameDetailWire> | null;
+    if (!payload || typeof payload.csa !== "string" || typeof payload.game_id !== "string") {
+        throw new RshogiGameFetchError(gameId, "rshogi API response missing csa/game_id");
     }
-    return { csa: payload.csa, meta: payload.meta };
+    return decodeGameDetail(payload as GameDetailWire);
 }
+
+/**
+ * rshogi の棋譜一覧 (`GET /api/v1/games`) を取得する。
+ *
+ * @param options ページング・baseUrl の指定。`baseUrl` 未指定時はモック fixture を返す。
+ */
+export async function fetchRshogiGameList(
+    options: FetchRshogiGameListOptions = {},
+): Promise<RshogiGameListPage> {
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) {
+        // モック動作: cursor/limit に応じてスライス。
+        // 本実装ではサーバ側でやるため、ここはあくまで MVP 用の挙動。
+        return mockGameListPage(options.cursor, options.limit);
+    }
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError("", "fetch is not available in this environment");
+    }
+
+    const params = new URLSearchParams();
+    if (options.cursor) params.set("cursor", options.cursor);
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    const query = params.toString();
+    const url = `${trimTrailingSlash(baseUrl)}/games${query.length > 0 ? `?${query}` : ""}`;
+
+    const response = await fetchImpl(url, { signal: options.signal });
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            "",
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+
+    const payload = (await response.json()) as GameListResponseWire | null;
+    if (!payload || !Array.isArray(payload.games)) {
+        throw new RshogiGameFetchError("", "rshogi API response missing games array");
+    }
+    return decodeGameListResponse(payload);
+}
+
+const DEFAULT_MOCK_LIMIT = 50;
+const MAX_MOCK_LIMIT = 100;
+
+const mockGameListPage = (
+    cursor: string | undefined,
+    limit: number | undefined,
+): RshogiGameListPage => {
+    const list = MOCK_RSHOGI_GAME_LIST;
+    const startIndex = cursor ? Math.max(0, Number.parseInt(cursor, 10) || 0) : 0;
+    const requested = limit ?? DEFAULT_MOCK_LIMIT;
+    const clamped = Math.min(Math.max(1, requested), MAX_MOCK_LIMIT);
+    const slice = list.slice(startIndex, startIndex + clamped);
+    const next = startIndex + clamped;
+    return {
+        games: slice,
+        nextCursor: next < list.length ? String(next) : undefined,
+    };
+};
 
 /**
  * モック対局 ID 一覧。一覧/選択 UI などからの参照用。

--- a/packages/match-client/src/rshogi-csa/fixtures.ts
+++ b/packages/match-client/src/rshogi-csa/fixtures.ts
@@ -1,12 +1,34 @@
 /**
  * rshogi CSA viewer 用の組み込みモック棋譜。
  *
- * NOTE: 本実装に差し替える際はこのファイルではなく `client.ts` の
- * `fetchRshogiGame` を fetch ベースに置き換える。
- * fixture 自体は MVP 動作確認・テスト用としてそのまま残す想定。
+ * baseUrl 未指定時の MVP 動作 / テストの既定値として使う。
+ * decode 層が呼ばれないため、ここでは「decode 後」の TS 型 (camelCase + epoch_ms) で直接定義する。
  */
 
-import type { RshogiGame } from "./client";
+import type { RshogiGame, RshogiGameSummary } from "./client";
+
+/** 一覧 API の `result_kind` (wire) リテラル。 */
+export type RshogiResultKindWire = "WIN_BLACK" | "WIN_WHITE" | "DRAW" | "ABORT";
+
+/**
+ * 一覧 API の `end_reason` (wire) リテラル。サーバ実装
+ * (rshogi-csa-server-workers games_index.rs::classify_result) と一致させる。
+ */
+export type RshogiEndReasonWire =
+    | "RESIGN"
+    | "TIME_UP"
+    | "ILLEGAL"
+    | "JISHOGI"
+    | "OUTE_SENNICHITE"
+    | "SENNICHITE"
+    | "MAX_MOVES"
+    | "ABNORMAL";
+
+/** 一覧 API の `clock.kind` (wire) リテラル。 */
+export type RshogiClockKindWire = "fischer" | "countdown" | "countdown_msec" | "stopwatch";
+
+/** 一覧 API の `source` (wire) リテラル。 */
+export type RshogiGameSourceWire = "kifu" | "floodgate";
 
 const SAMPLE_1_CSA = [
     "V2.2",
@@ -52,17 +74,33 @@ const SAMPLE_2_CSA = [
     "%TORYO",
 ].join("\n");
 
+const SAMPLE_1_STARTED_AT_MS = Date.UTC(2026, 3, 29, 10, 0, 0);
+const SAMPLE_1_ENDED_AT_MS = Date.UTC(2026, 3, 29, 10, 18, 42);
+const SAMPLE_2_STARTED_AT_MS = Date.UTC(2026, 3, 30, 12, 0, 0);
+const SAMPLE_2_ENDED_AT_MS = Date.UTC(2026, 3, 30, 12, 9, 11);
+const SAMPLE_3_STARTED_AT_MS = Date.UTC(2026, 3, 28, 11, 30, 0);
+const SAMPLE_3_ENDED_AT_MS = Date.UTC(2026, 3, 28, 11, 47, 52);
+const SAMPLE_4_STARTED_AT_MS = Date.UTC(2026, 3, 27, 13, 0, 0);
+const SAMPLE_4_ENDED_AT_MS = Date.UTC(2026, 3, 27, 13, 12, 3);
+
 export const MOCK_RSHOGI_GAMES: Record<string, RshogiGame> = {
     "sample-1": {
         meta: {
             gameId: "sample-1",
             senteName: "RAMU_TP",
             goteName: "FFF-70k",
-            startedAt: "2026-04-29T10:00:00.000Z",
-            endedAt: "2026-04-29T10:18:42.000Z",
+            startedAtMs: SAMPLE_1_STARTED_AT_MS,
+            endedAtMs: SAMPLE_1_ENDED_AT_MS,
             event: "rshogi viewer mock sample",
-            timeControl: { mainSeconds: 600, byoyomiSeconds: 30 },
-            result: { kind: "resignation", winner: "sente" },
+            timeControl: {
+                kind: "fischer",
+                mainSeconds: 600,
+                byoyomiSeconds: 30,
+                incrementSeconds: 5,
+            },
+            result: { kind: "resignation", winner: "sente", endReason: "RESIGN" },
+            source: "kifu",
+            movesCount: 9,
         },
         csa: SAMPLE_1_CSA,
     },
@@ -71,12 +109,77 @@ export const MOCK_RSHOGI_GAMES: Record<string, RshogiGame> = {
             gameId: "sample-2",
             senteName: "PC1_save012",
             goteName: "RAMU_TP",
-            startedAt: "2026-04-30T12:00:00.000Z",
-            endedAt: "2026-04-30T12:09:11.000Z",
+            startedAtMs: SAMPLE_2_STARTED_AT_MS,
+            endedAtMs: SAMPLE_2_ENDED_AT_MS,
             event: "rshogi viewer mock sample 2",
-            timeControl: { mainSeconds: 300, byoyomiSeconds: 15 },
-            result: { kind: "resignation", winner: "sente" },
+            timeControl: {
+                kind: "countdown",
+                mainSeconds: 300,
+                byoyomiSeconds: 15,
+            },
+            result: { kind: "resignation", winner: "sente", endReason: "RESIGN" },
+            source: "kifu",
+            movesCount: 7,
         },
         csa: SAMPLE_2_CSA,
     },
 };
+
+const summaryFromMock = (gameId: string): RshogiGameSummary => {
+    const mock = MOCK_RSHOGI_GAMES[gameId];
+    if (!mock) {
+        throw new Error(`unknown mock rshogi game id: ${gameId}`);
+    }
+    const { meta } = mock;
+    return {
+        gameId: meta.gameId,
+        senteName: meta.senteName,
+        goteName: meta.goteName,
+        startedAtMs: meta.startedAtMs,
+        endedAtMs: meta.endedAtMs,
+        timeControl: meta.timeControl,
+        result: meta.result,
+        movesCount: meta.movesCount,
+        source: meta.source,
+    };
+};
+
+/**
+ * モック一覧 API の応答セット。新着順 (新→旧) に並べる。
+ * 単局 fixture (sample-1, sample-2) を含めつつ、リスト UI を試せるよう数件追加する。
+ */
+export const MOCK_RSHOGI_GAME_LIST: RshogiGameSummary[] = [
+    summaryFromMock("sample-2"),
+    summaryFromMock("sample-1"),
+    {
+        gameId: "sample-3",
+        senteName: "GreatBlue",
+        goteName: "RAMU_TP",
+        startedAtMs: SAMPLE_3_STARTED_AT_MS,
+        endedAtMs: SAMPLE_3_ENDED_AT_MS,
+        timeControl: {
+            kind: "fischer",
+            mainSeconds: 300,
+            byoyomiSeconds: 0,
+            incrementSeconds: 10,
+        },
+        result: { kind: "time_expired", winner: "gote", endReason: "TIME_UP" },
+        movesCount: 84,
+        source: "floodgate",
+    },
+    {
+        gameId: "sample-4",
+        senteName: "RAMU_TP",
+        goteName: "Tester99",
+        startedAtMs: SAMPLE_4_STARTED_AT_MS,
+        endedAtMs: SAMPLE_4_ENDED_AT_MS,
+        timeControl: {
+            kind: "stopwatch",
+            mainSeconds: 0,
+            byoyomiSeconds: 60,
+        },
+        result: { kind: "draw", endReason: "SENNICHITE" },
+        movesCount: 124,
+        source: "kifu",
+    },
+];

--- a/packages/ui/src/components/rshogi-csa-game-list.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-game-list.test.tsx
@@ -1,0 +1,85 @@
+import type { RshogiGameSummary } from "@shogi/match-client";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RshogiCsaGameList } from "./rshogi-csa-game-list";
+
+const SAMPLE_GAMES: RshogiGameSummary[] = [
+    {
+        gameId: "room-1-1234",
+        senteName: "alice",
+        goteName: "bob",
+        startedAtMs: Date.UTC(2026, 3, 28, 12, 34),
+        endedAtMs: Date.UTC(2026, 3, 28, 13, 0),
+        timeControl: {
+            kind: "fischer",
+            mainSeconds: 300,
+            byoyomiSeconds: 0,
+            incrementSeconds: 10,
+        },
+        result: { kind: "resignation", winner: "sente", endReason: "RESIGN" },
+        movesCount: 142,
+        source: "kifu",
+    },
+    {
+        gameId: "room-2-9999",
+        senteName: "carol",
+        goteName: "dave",
+        startedAtMs: Date.UTC(2026, 3, 27, 9, 0),
+        timeControl: {
+            kind: "countdown",
+            mainSeconds: 600,
+            byoyomiSeconds: 30,
+        },
+        result: { kind: "draw", endReason: "DRAW_REPETITION" },
+        movesCount: 100,
+    },
+];
+
+describe("RshogiCsaGameList", () => {
+    it("renders one row per game with sente/gote names and result label", () => {
+        render(<RshogiCsaGameList games={SAMPLE_GAMES} onSelect={vi.fn()} />);
+        expect(screen.getByText("☗ alice vs ☖ bob")).toBeDefined();
+        expect(screen.getByText("☗ carol vs ☖ dave")).toBeDefined();
+        expect(screen.getByText(/☗勝/)).toBeDefined();
+        expect(screen.getByText(/引分/)).toBeDefined();
+    });
+
+    it("invokes onSelect with the gameId when a row is clicked", () => {
+        const onSelect = vi.fn();
+        render(<RshogiCsaGameList games={SAMPLE_GAMES} onSelect={onSelect} />);
+        const button = screen.getByText("☗ alice vs ☖ bob").closest("button");
+        expect(button).toBeDefined();
+        if (button) fireEvent.click(button);
+        expect(onSelect).toHaveBeenCalledWith("room-1-1234");
+    });
+
+    it("shows empty message when there are no games and not loading", () => {
+        render(<RshogiCsaGameList games={[]} onSelect={vi.fn()} emptyMessage="該当なし" />);
+        expect(screen.getByText("該当なし")).toBeDefined();
+    });
+
+    it("shows load-more button only when hasMore=true and onLoadMore is provided", () => {
+        const onLoadMore = vi.fn();
+        const { rerender } = render(
+            <RshogiCsaGameList
+                games={SAMPLE_GAMES}
+                onSelect={vi.fn()}
+                onLoadMore={onLoadMore}
+                hasMore={true}
+            />,
+        );
+        const button = screen.getByText("もっと読み込む");
+        fireEvent.click(button);
+        expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+        rerender(
+            <RshogiCsaGameList
+                games={SAMPLE_GAMES}
+                onSelect={vi.fn()}
+                onLoadMore={onLoadMore}
+                hasMore={false}
+            />,
+        );
+        expect(screen.queryByText("もっと読み込む")).toBeNull();
+    });
+});

--- a/packages/ui/src/components/rshogi-csa-game-list.tsx
+++ b/packages/ui/src/components/rshogi-csa-game-list.tsx
@@ -1,0 +1,157 @@
+/**
+ * rshogi CSA 棋譜一覧コンポーネント。
+ *
+ * Web/Desktop 両方から共通で使う。表示用のフォーマットだけ担当し、
+ * fetch / state 管理 (cursor, ページング) は呼び出し側 (Page) で行う。
+ *
+ * 入力データ (`RshogiGameSummary`) は match-client の decode 層通過後の
+ * camelCase + epoch_ms 形式で受け取る前提。
+ */
+
+import type { RshogiGameSummary, RshogiTimeControl } from "@shogi/match-client";
+import type { ReactElement } from "react";
+
+export interface RshogiCsaGameListProps {
+    games: RshogiGameSummary[];
+    /** 行クリック時に gameId を返す。 */
+    onSelect: (gameId: string) => void;
+    /** 「もっと読み込む」押下時に呼ばれる。`hasMore=true` のときのみ表示。 */
+    onLoadMore?: () => void;
+    /** 初回 / ページ追加読み込み中フラグ。 */
+    isLoading?: boolean;
+    /** 次ページが存在するか。 */
+    hasMore?: boolean;
+    /** 一覧が空のときに出すメッセージ (省略時はデフォルト)。 */
+    emptyMessage?: string;
+}
+
+const pad2 = (n: number): string => n.toString().padStart(2, "0");
+
+/** 既存 ramu-shogi の慣習に揃えた `YYYY-MM-DD HH:mm` (ローカル時刻) フォーマット。 */
+const formatStartedAt = (epochMs: number | undefined): string => {
+    if (epochMs === undefined) return "不明";
+    const d = new Date(epochMs);
+    if (Number.isNaN(d.getTime())) return "不明";
+    return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+};
+
+const CLOCK_KIND_LABEL: Record<string, string> = {
+    fischer: "Fischer",
+    countdown: "秒読み",
+    countdown_msec: "秒読み(ms)",
+    stopwatch: "ストップウォッチ",
+};
+
+const formatClockSummary = (clock: RshogiTimeControl | undefined): string => {
+    if (!clock) return "持ち時間: 不明";
+    const kindLabel = clock.kind ? (CLOCK_KIND_LABEL[clock.kind] ?? clock.kind) : "持ち時間";
+    const mainMin = Math.round(clock.mainSeconds / 60);
+    const main = mainMin > 0 ? `${mainMin}min` : "";
+    const inc =
+        clock.incrementSeconds && clock.incrementSeconds > 0 ? `+${clock.incrementSeconds}s` : "";
+    // byoyomi は秒値を優先、ms 値はサーバが ms 精度で返した countdown_msec 系のために
+    // <1 秒のときだけ ms 単位で表示する。
+    let byoyomi = "";
+    if (clock.byoyomiSeconds > 0) {
+        byoyomi = `+秒読み${clock.byoyomiSeconds}s`;
+    } else if (clock.byoyomiMilliseconds && clock.byoyomiMilliseconds > 0) {
+        byoyomi = `+秒読み${clock.byoyomiMilliseconds}ms`;
+    }
+    const tail = [main, inc, byoyomi].filter((s) => s.length > 0).join(" ");
+    return tail.length > 0 ? `${kindLabel} ${tail}` : kindLabel;
+};
+
+const RESULT_KIND_LABEL: Record<string, string> = {
+    resignation: "投了",
+    checkmate: "詰み",
+    time_expired: "時間切れ",
+    draw: "千日手",
+    jishogi: "入玉勝ち",
+    oute_sennichite: "連続王手千日手",
+    abort: "中断",
+    max_moves: "最大手数",
+    abnormal: "異常終了",
+};
+
+const formatResultSummary = (game: RshogiGameSummary): string => {
+    const result = game.result;
+    if (!result) return "結果: 未確定";
+    const winnerLabel =
+        result.winner === "sente" ? "☗勝" : result.winner === "gote" ? "☖勝" : "引分";
+    const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
+    return `${winnerLabel} (${reason})`;
+};
+
+export function RshogiCsaGameList({
+    games,
+    onSelect,
+    onLoadMore,
+    isLoading,
+    hasMore,
+    emptyMessage,
+}: RshogiCsaGameListProps): ReactElement {
+    const empty = games.length === 0;
+
+    return (
+        <div className="flex flex-col gap-3">
+            {empty && !isLoading && (
+                <div className="rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-4 text-sm text-muted-foreground">
+                    {emptyMessage ?? "棋譜がまだありません。"}
+                </div>
+            )}
+
+            {empty && isLoading && (
+                <div className="rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-4 text-sm text-muted-foreground">
+                    読み込み中...
+                </div>
+            )}
+
+            {!empty && (
+                <ul className="flex flex-col gap-2" aria-label="rshogi 棋譜一覧">
+                    {games.map((game) => (
+                        <li key={game.gameId}>
+                            <button
+                                type="button"
+                                onClick={() => onSelect(game.gameId)}
+                                className="flex w-full flex-col gap-1 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-left transition-colors hover:bg-wafuu-kincha/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wafuu-shu"
+                            >
+                                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                    <span className="text-sm font-semibold text-wafuu-sumi">
+                                        ☗ {game.senteName} vs ☖ {game.goteName}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                        {formatStartedAt(game.startedAtMs)}
+                                    </span>
+                                </div>
+                                <div className="flex flex-wrap gap-3 text-xs text-muted-foreground">
+                                    <span>{formatResultSummary(game)}</span>
+                                    <span>{formatClockSummary(game.timeControl)}</span>
+                                    {game.movesCount !== undefined && (
+                                        <span>{game.movesCount}手</span>
+                                    )}
+                                    {game.source && <span>source: {game.source}</span>}
+                                </div>
+                                <div className="text-[11px] font-mono text-muted-foreground/80">
+                                    {game.gameId}
+                                </div>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {hasMore && onLoadMore && (
+                <div className="flex justify-center">
+                    <button
+                        type="button"
+                        onClick={onLoadMore}
+                        disabled={isLoading}
+                        className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {isLoading ? "読み込み中..." : "もっと読み込む"}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/rshogi-csa-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.tsx
@@ -5,8 +5,8 @@
  * フェッチ・パース・読み込み中表示までをここで集約し、本体の盤面/棋譜は
  * 既存の `<ShogiMatch>` の `initialReview + reviewMode` に委譲する。
  *
- * 配信 API は別タスク (rshogi#542) で設計中のため、`fetchRshogiGame` は
- * モックを返す stub。本実装に差し替える際はこのコンポーネントは触らずに済む。
+ * API contract は match-client 側の decode 層で snake_case → camelCase / epoch_ms 保持に
+ * 変換される。本コンポーネントは decode 後の TS 型のみを扱う。
  */
 
 import { parseCsaMoves } from "@shogi/app-core";
@@ -39,10 +39,10 @@ interface LoadState {
     errorMessage?: string;
 }
 
-const formatTimestamp = (value: string | undefined): string => {
-    if (!value) return "不明";
+const formatTimestampMs = (value: number | undefined): string => {
+    if (value === undefined) return "不明";
     const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return value;
+    if (Number.isNaN(date.getTime())) return "不明";
     return date.toLocaleString("ja-JP");
 };
 
@@ -57,6 +57,18 @@ const formatTimeControl = (value: RshogiGame["meta"]["timeControl"]): string => 
     return `持ち時間: ${main}${byoyomi}${inc}`;
 };
 
+const RESULT_KIND_LABEL: Record<NonNullable<RshogiGame["meta"]["result"]>["kind"], string> = {
+    resignation: "投了",
+    checkmate: "詰み",
+    time_expired: "時間切れ",
+    draw: "千日手",
+    jishogi: "入玉勝ち",
+    oute_sennichite: "連続王手千日手",
+    abort: "中断",
+    max_moves: "最大手数",
+    abnormal: "異常終了",
+};
+
 const formatResult = (meta: RshogiGame["meta"]): string => {
     const result = meta.result;
     if (!result) return "結果: 不明";
@@ -66,14 +78,8 @@ const formatResult = (meta: RshogiGame["meta"]): string => {
             : result.winner === "gote"
               ? `後手 (${meta.goteName}) 勝ち`
               : "引き分け";
-    const reason: Record<typeof result.kind, string> = {
-        resignation: "投了",
-        checkmate: "詰み",
-        time_expired: "時間切れ",
-        draw: "引き分け",
-        abort: "中断",
-    };
-    return `結果: ${winnerLabel} (${reason[result.kind]})`;
+    const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
+    return `結果: ${winnerLabel} (${reason})`;
 };
 
 function RshogiGameMetaPanel({ game }: { game: RshogiGame }): ReactElement {
@@ -100,8 +106,8 @@ function RshogiGameMetaPanel({ game }: { game: RshogiGame }): ReactElement {
                 </div>
             )}
             <div className="flex flex-col gap-0.5 text-xs text-muted-foreground">
-                <span>開始: {formatTimestamp(meta.startedAt)}</span>
-                <span>終了: {formatTimestamp(meta.endedAt)}</span>
+                <span>開始: {formatTimestampMs(meta.startedAtMs)}</span>
+                <span>終了: {formatTimestampMs(meta.endedAtMs)}</span>
             </div>
             <div className="text-xs text-muted-foreground">
                 {formatTimeControl(meta.timeControl)}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -51,6 +51,9 @@ export type { RemoteNnueFile, RemoteNnueManager } from "./components/nnue/types"
 export type { AnalysisMoveResult, OnlineAnalysis } from "./components/online-game-view";
 // online-game-view
 export { OnlineGameView } from "./components/online-game-view";
+export type { RshogiCsaGameListProps } from "./components/rshogi-csa-game-list";
+// rshogi-csa-game-list
+export { RshogiCsaGameList } from "./components/rshogi-csa-game-list";
 export type { RshogiCsaViewerProps } from "./components/rshogi-csa-viewer";
 // rshogi-csa-viewer
 export { RshogiCsaViewer } from "./components/rshogi-csa-viewer";


### PR DESCRIPTION
親 Issue: SH11235/ramu-shogi#25
親 Epic: SH11235/rshogi#541
依存: SH11235/rshogi#547 (server /api/v1/games、merged)

## Summary

server `/api/v1/games` の wire format (snake_case + epoch_ms + result_kind/end_reason 分離 + clock.kind enum) を camelCase + sente/gote + 構造化 result に変換する decode 層を fetchRshogiGameList / fetchRshogiGame に集約し、棋譜一覧ページを Web/Desktop 両方に実装する。API contract A 案に準拠。

## 主な変更

### match-client (`packages/match-client/src/rshogi-csa/`)

- `fetchRshogiGameList(options)`: cursor + limit ベースのページング。`baseUrl` 未指定時はモック fixture、指定時は `/api/v1/games?cursor=&limit=` fetch + decode。
- `decodeClock`: kind に応じて `total_sec` / `total_ms` / `total_min` と `byoyomi_sec` / `byoyomi_ms` / `byoyomi_min` を秒に正規化 (Fischer/countdown/countdown_msec/stopwatch すべて対応)。
- `decodeResult`: WIN_BLACK / WIN_WHITE / DRAW / ABORT × RESIGN / TIME_UP / ILLEGAL / **JISHOGI** / **OUTE_SENNICHITE** / **SENNICHITE** / MAX_MOVES / ABNORMAL を全網羅 (`SENNICHITE` を `draw`、`JISHOGI` / `OUTE_SENNICHITE` を独立 kind で表現)。
- 統合テスト 19 件 (5 件追加: SENNICHITE / JISHOGI / OUTE_SENNICHITE / stopwatch (total_min/byoyomi_min) / countdown_msec (total_ms/byoyomi_ms) ).

### UI (`packages/ui/src/components/`)

- 新規 `RshogiCsaGameList`: 1 行 = 開始日時 / 手数 / 結果 / 持ち時間 / 対局者。`hasMore` のとき末尾「もっと読み込む」、押下で `onLoadMore`。テスト 4 件。
- 既存 `RshogiCsaViewer` のラベル表に `jishogi` (入玉勝ち) と `oute_sennichite` (連続王手千日手) を追加し draw/千日手の分離を反映。
- `formatClockSummary` で `byoyomiMilliseconds` も拾うように拡張。

### Web (`apps/web/`)

- `/rshogi-viewer` (一覧) ルートを `router.tsx` に追加。行クリックで既存 `/rshogi-viewer/\$gameId` に遷移。
- `pages/rshogi-viewer/RshogiViewerListPage.tsx` 新設 (cursor 管理 + AbortController による cleanup)。

### Desktop (`apps/desktop/`)

- `App.tsx` の appMode に `rshogi-viewer-list` / `rshogi-viewer-detail` を追加。
- `components/rshogi-viewer/RshogiViewerListView.tsx` 新設、選択時に既存 `RshogiViewerView` (個別) に切替。

## 検証

- `pnpm --filter @shogi/match-client test --run rshogi-csa`: 19 pass
- `pnpm --filter @shogi/ui test --run rshogi-csa-game-list`: 4 pass
- `pnpm typecheck` (force, 11 packages): success
- `pnpm lint` (force): web 既存 warning 2 件のみ、本 PR 関連無し
- ローカルレビュー (general-purpose subagent) で APPROVE 取得 (修正必須 2 件 + nitpick 1 件を反映済)

## Non-goals (別 Issue)

- live spectate (SH11235/ramu-shogi#26)
- 認証 / private 棋譜
- 検索 / 期間フィルタ
- 評価値グラフ

## API contract reference

https://github.com/SH11235/rshogi/issues/542#issuecomment-4338125621

Closes SH11235/ramu-shogi#25

🤖 Generated with [Claude Code](https://claude.com/claude-code)