### PR TITLE
feat(viewer): rshogi CSA 進行中対局の live 観戦ページ

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -21,6 +21,7 @@ import { ActiveEngineSettingsPanel } from "./components/ActiveEngineSettingsPane
 import { CsaGameView } from "./components/csa/CsaGameView";
 import { EngineManagerPanel } from "./components/EngineManagerPanel";
 import { RshogiViewerListView } from "./components/rshogi-viewer/RshogiViewerListView";
+import { RshogiViewerLiveView } from "./components/rshogi-viewer/RshogiViewerLiveView";
 import { RshogiViewerView } from "./components/rshogi-viewer/RshogiViewerView";
 
 const createEngineClient = () =>
@@ -83,7 +84,12 @@ interface EngineSettingsTarget {
     label: string;
 }
 
-type AppMode = "local" | "csa" | "rshogi-viewer-list" | "rshogi-viewer-detail";
+type AppMode =
+    | "local"
+    | "csa"
+    | "rshogi-viewer-list"
+    | "rshogi-viewer-detail"
+    | "rshogi-viewer-live";
 
 function App() {
     const [appMode, setAppMode] = useState<AppMode>("local");
@@ -220,6 +226,20 @@ function App() {
             <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
                 <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
                     <RshogiViewerView
+                        gameId={rshogiViewerGameId}
+                        onBackToList={handleBackToRshogiList}
+                        onBackToLocal={() => setAppMode("local")}
+                    />
+                </main>
+            </NnueProvider>
+        );
+    }
+
+    if (appMode === "rshogi-viewer-live" && rshogiViewerGameId) {
+        return (
+            <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
+                <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
+                    <RshogiViewerLiveView
                         gameId={rshogiViewerGameId}
                         onBackToList={handleBackToRshogiList}
                         onBackToLocal={() => setAppMode("local")}

--- a/apps/desktop/src/components/rshogi-viewer/RshogiViewerLiveView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiViewerLiveView.tsx
@@ -56,7 +56,7 @@ export function RshogiViewerLiveView({ gameId, onBackToList, onBackToLocal }: Pr
                 fetchLegalMoves={(sfen, moves, options) =>
                     getLegalMoves({ sfen, moves, passRights: options?.passRights })
                 }
-                isDevMode={true}
+                isDevMode={import.meta.env.DEV}
             />
         </div>
     );

--- a/apps/desktop/src/components/rshogi-viewer/RshogiViewerLiveView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiViewerLiveView.tsx
@@ -1,0 +1,63 @@
+import { createTauriEngineClient, getLegalMoves } from "@shogi/engine-tauri";
+import type { EngineOption } from "@shogi/ui";
+import { RshogiCsaLiveViewer } from "@shogi/ui";
+import { Button } from "@shogi/ui/components/button";
+import type { ReactElement } from "react";
+
+const ENGINE_OPTIONS: EngineOption[] = [
+    {
+        id: "native",
+        label: "内蔵エンジン",
+        createClient: () =>
+            createTauriEngineClient({
+                stopMode: "terminate",
+                useMockOnError: false,
+                debug: true,
+            }),
+        kind: "internal",
+    },
+];
+
+const nnueManifestUrl = import.meta.env.VITE_NNUE_MANIFEST_URL as string;
+
+interface Props {
+    gameId: string;
+    onBackToList: () => void;
+    onBackToLocal: () => void;
+}
+
+/**
+ * Desktop 用の rshogi 進行中対局 (live spectate) ビュー。
+ *
+ * Web 側 `RshogiViewerLivePage` と同一の `RshogiCsaLiveViewer` を表示する。
+ * gameId は呼出側 (`App.tsx`) で保持し、戻るボタンで一覧 / ローカル対局へ遷移する。
+ */
+export function RshogiViewerLiveView({ gameId, onBackToList, onBackToLocal }: Props): ReactElement {
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Button variant="outline" size="sm" onClick={onBackToLocal}>
+                    ← ローカル対局へ戻る
+                </Button>
+                <Button variant="outline" size="sm" onClick={onBackToList}>
+                    ← 棋譜一覧へ戻る
+                </Button>
+                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer (live)</span>
+                <span className="text-xs text-muted-foreground">対局 ID: {gameId}</span>
+            </div>
+            <RshogiCsaLiveViewer
+                gameId={gameId}
+                engineOptions={ENGINE_OPTIONS}
+                manifestUrl={nnueManifestUrl}
+                apiBaseUrl={apiBaseUrl}
+                fetchLegalMoves={(sfen, moves, options) =>
+                    getLegalMoves({ sfen, moves, passRights: options?.passRights })
+                }
+                isDevMode={true}
+            />
+        </div>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerLivePage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerLivePage.tsx
@@ -1,0 +1,66 @@
+import { createWasmEngineClient } from "@shogi/engine-wasm";
+import type { EngineOption } from "@shogi/ui";
+import { RshogiCsaLiveViewer } from "@shogi/ui";
+import { getRouteApi } from "@tanstack/react-router";
+import type { ReactElement } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageHeader } from "../../components/PageHeader";
+
+const resolveWasmThreads = (): number => {
+    const fallback = import.meta.env.DEV ? 4 : 1;
+    const raw = import.meta.env.VITE_WASM_THREADS;
+    if (typeof raw !== "string" || raw.trim() === "") return fallback;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+    return Math.trunc(parsed);
+};
+
+const wasmThreads = resolveWasmThreads();
+
+const engineOptions: EngineOption[] = [
+    {
+        id: "wasm",
+        label: "内蔵エンジン",
+        createClient: () =>
+            createWasmEngineClient({
+                stopMode: "terminate",
+                defaultInitOptions: { threads: wasmThreads },
+                logWarningsToConsole: true,
+            }),
+        kind: "internal",
+    },
+];
+
+const routeApi = getRouteApi("/rshogi-viewer/live/$gameId");
+
+/**
+ * 進行中対局の live 観戦ページ。
+ *
+ * 静的単局 viewer (`/rshogi-viewer/$gameId`) は `fetchRshogiGame` で CSA 全文を
+ * 1 回取得して表示するのに対し、本ページは `subscribeRshogiLiveGame` で WS 接続
+ * し、snapshot replay → broadcast move を逐次表示する。
+ */
+export default function RshogiViewerLivePage(): ReactElement {
+    const { gameId } = routeApi.useParams();
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    return (
+        <>
+            <PageHeader
+                items={[
+                    { label: "ラム将棋", to: "/" },
+                    { label: "rshogi viewer", to: "/rshogi-viewer" },
+                    { label: `live: ${gameId}` },
+                ]}
+                right={<HeaderNav />}
+            />
+            <RshogiCsaLiveViewer
+                gameId={gameId}
+                engineOptions={engineOptions}
+                manifestUrl={import.meta.env.VITE_NNUE_MANIFEST_URL as string}
+                apiBaseUrl={apiBaseUrl}
+            />
+        </>
+    );
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -23,6 +23,7 @@ import OnlinePage from "./pages/online/OnlinePage";
 import RoomPage from "./pages/online/RoomPage";
 import PrivacyPage from "./pages/privacy/PrivacyPage";
 import RshogiViewerListPage from "./pages/rshogi-viewer/RshogiViewerListPage";
+import RshogiViewerLivePage from "./pages/rshogi-viewer/RshogiViewerLivePage";
 import RshogiViewerPage from "./pages/rshogi-viewer/RshogiViewerPage";
 import { handleLoaderResponse } from "./router-loader-utils";
 
@@ -216,6 +217,14 @@ const rshogiViewerListRoute = createRoute({
     component: RshogiViewerListPage,
 });
 
+// `/rshogi-viewer/live/$gameId` は単局 `/rshogi-viewer/$gameId` よりも前に
+// 登録する必要がある (TanStack Router は登録順で path 解決する)。
+const rshogiViewerLiveRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer/live/$gameId",
+    component: RshogiViewerLivePage,
+});
+
 const rshogiViewerRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer/$gameId",
@@ -287,6 +296,7 @@ const routeTree = rootRoute.addChildren([
     createRoomRoute,
     roomRoute,
     rshogiViewerListRoute,
+    rshogiViewerLiveRoute,
     rshogiViewerRoute,
 ]);
 

--- a/packages/app-core/src/game/csa.test.ts
+++ b/packages/app-core/src/game/csa.test.ts
@@ -238,6 +238,24 @@ describe("parseSingleCsaMove", () => {
         expect(r1?.nextState.turn).toBe("gote");
     });
 
+    it("既に成っている駒 (RY/UM 等) の通常移動は `+` を付与しない", () => {
+        // 5e に成り角 (UM) を配置した state を作る (黒の馬の単純移動)。
+        const state = createInitialPositionState();
+        // 元 5e は空マスなのでそのまま成り駒を置ける。
+        state.board["5e"] = { owner: "sente", type: "B", promoted: true };
+        // CSA `+5544UM` (5e → 4d、馬の通常移動、駒コードは UM のまま)。
+        const result = parseSingleCsaMove("+5544UM", state);
+        expect(result).not.toBeNull();
+        // promote=false (既に成り済み) なので USI は `5e4d` のみ。
+        expect(result?.move).toBe("5e4d");
+        expect(result?.nextState.board["4d"]).toEqual({
+            owner: "sente",
+            type: "B",
+            promoted: true,
+        });
+        expect(result?.nextState.board["5e"]).toBeNull();
+    });
+
     it("駒打ち手 (+0055FU 等) を `<piece>*<square>` の USI に変換し、hands を減算する", () => {
         const state = createInitialPositionState();
         // 観戦 client では hands を server から再構築するため、ここでは手動で歩を 1 枚追加

--- a/packages/app-core/src/game/csa.test.ts
+++ b/packages/app-core/src/game/csa.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createInitialBoard, createInitialPositionState } from "./board";
-import { buildBoardFromCsa, movesToCsa, parseCsaMoves } from "./csa";
+import {
+    buildBoardFromCsa,
+    movesToCsa,
+    parseCsaMoves,
+    parseCsaMovesWithState,
+    parseSingleCsaMove,
+} from "./csa";
 import type { PositionService } from "./position-service";
 import { setPositionServiceFactory } from "./position-service-registry";
 
@@ -202,5 +208,75 @@ describe("往復変換", () => {
 
         // 最初の2手は正確に一致するはず
         expect(parsedMoves.slice(0, 2)).toEqual(originalMoves.slice(0, 2));
+    });
+});
+
+describe("parseSingleCsaMove", () => {
+    it("通常の移動を 1 手だけ解釈し、PositionState を進める", () => {
+        const initial = createInitialPositionState();
+        const result = parseSingleCsaMove("+7776FU", initial);
+        expect(result).not.toBeNull();
+        expect(result?.move).toBe("7g7f");
+        expect(result?.nextState.turn).toBe("gote");
+        expect(result?.nextState.board["7g"]).toBeNull();
+        expect(result?.nextState.board["7f"]).toEqual({ owner: "sente", type: "P" });
+    });
+
+    it("成り手 (UM 等) を promote=true で解釈する", () => {
+        // 角成りを発生させるため、最初に 8h→2b+ を経由した状態を作る
+        const initial = createInitialPositionState();
+        initial.board["2b"] = null; // 後手角を退かして 8h2b+ を可能に
+        const r1 = parseSingleCsaMove("+8822UM", initial);
+        expect(r1).not.toBeNull();
+        expect(r1?.move).toBe("8h2b+");
+        // 成り駒が配置され、手番が gote へ
+        expect(r1?.nextState.board["2b"]).toEqual({
+            owner: "sente",
+            type: "B",
+            promoted: true,
+        });
+        expect(r1?.nextState.turn).toBe("gote");
+    });
+
+    it("駒打ち手 (+0055FU 等) を `<piece>*<square>` の USI に変換し、hands を減算する", () => {
+        const state = createInitialPositionState();
+        // 観戦 client では hands を server から再構築するため、ここでは手動で歩を 1 枚追加
+        state.hands.sente = { P: 1 };
+        // 中央 5e は初期局面で空マス。駒打ちで配置できる。
+        const result = parseSingleCsaMove("+0055FU", state);
+        expect(result).not.toBeNull();
+        expect(result?.move).toBe("P*5e");
+        expect(result?.nextState.board["5e"]).toEqual({ owner: "sente", type: "P" });
+        // 駒打ちは hands を 1 つ減らす
+        expect(result?.nextState.hands.sente.P ?? 0).toBe(0);
+    });
+
+    it("move 行でない (時間行 / 終局コード / コメント) は null を返す", () => {
+        const state = createInitialPositionState();
+        expect(parseSingleCsaMove("T8", state)).toBeNull();
+        expect(parseSingleCsaMove("%TORYO", state)).toBeNull();
+        expect(parseSingleCsaMove("#RESIGN", state)).toBeNull();
+        expect(parseSingleCsaMove("'comment", state)).toBeNull();
+        expect(parseSingleCsaMove("", state)).toBeNull();
+    });
+});
+
+describe("parseCsaMovesWithState", () => {
+    it("複数行の CSA から moves[] と最終 PositionState を一括取得する", () => {
+        const initial = createInitialPositionState();
+        // 時間行 (T8) と move 行が混ざった wire を入力する。
+        const csa = ["+7776FU", "T8", "-3334FU", "T7"].join("\n");
+        const result = parseCsaMovesWithState(csa, initial);
+        expect(result.moves).toEqual(["7g7f", "3c3d"]);
+        // 2 手目時点で手番は sente に戻る
+        expect(result.state.turn).toBe("sente");
+        expect(result.state.ply).toBe(3); // 初期 ply=1 + 2 手 → 3
+    });
+
+    it("空文字列を渡すと初期状態を返す", () => {
+        const initial = createInitialPositionState();
+        const result = parseCsaMovesWithState("", initial);
+        expect(result.moves).toEqual([]);
+        expect(result.state).toBe(initial);
     });
 });

--- a/packages/app-core/src/game/csa.ts
+++ b/packages/app-core/src/game/csa.ts
@@ -1,5 +1,6 @@
 import {
     applyMove,
+    applyMoveWithState,
     BOARD_FILES,
     BOARD_RANKS,
     type BoardState,
@@ -9,6 +10,7 @@ import {
     createInitialBoard,
     type Piece,
     type PieceType,
+    type PositionState,
     type Square,
 } from "./board";
 
@@ -50,6 +52,128 @@ const PROMOTED_FROM_CODE: Record<string, PieceType | undefined> = {
     UM: "B",
     RY: "R",
 };
+
+/**
+ * 駒打ち時の CSA 駒コード (`FU`/`KY`/`KE`/`GI`/`KI`/`KA`/`HI`) → `PieceType` の逆引き。
+ *
+ * 駒打ちは成り駒では行わないため、成りコード (`TO`/`NY`/...) は対応外。
+ * `OU` は王なので駒打ちに現れない。
+ */
+const DROP_PIECE_FROM_CODE: Record<string, PieceType | undefined> = {
+    FU: "P",
+    KY: "L",
+    KE: "N",
+    GI: "S",
+    KI: "G",
+    KA: "B",
+    HI: "R",
+};
+
+/**
+ * 1 行の CSA `move` 行から USI move 文字列を解釈する純粋関数。
+ *
+ * 受け付ける書式:
+ * - 通常移動: `+7776FU` / `-3334FU` / `+8822UM` (成り駒コードの場合は promote=true)
+ * - 駒打ち: `+0099FU` 等 (from = `"00"`、駒コードは非成り駒のみ)
+ *
+ * 戻り値が `null` のときは move 行ではない (時間行 `T8` / コメント `'...` /
+ * 終局コード `%TORYO` / `#RESIGN` 等)。本関数では state 検証や合法手チェックは
+ * 行わず、wire 上で構文として解釈可能な行だけを USI 文字列化する。
+ */
+function parseCsaMoveLine(line: string): { usi: string } | null {
+    if (!(line.startsWith("+") || line.startsWith("-"))) {
+        return null;
+    }
+    if (line.length < 7) {
+        return null;
+    }
+    const fromRaw = line.slice(1, 3);
+    const toRaw = line.slice(3, 5);
+    const pieceCode = line.slice(5, 7).toUpperCase();
+    const toSquare = fromCsaSquare(toRaw);
+    if (!toSquare) {
+        return null;
+    }
+    if (fromRaw === "00") {
+        const piece = DROP_PIECE_FROM_CODE[pieceCode];
+        if (!piece) {
+            return null;
+        }
+        // USI の駒打ち書式は `P*5e` (大文字駒コード + `*` + マス)。
+        return { usi: `${piece}*${toSquare}` };
+    }
+    const fromSquare = fromCsaSquare(fromRaw);
+    if (!fromSquare) {
+        return null;
+    }
+    const promotes = PROMOTED_FROM_CODE[pieceCode] !== undefined;
+    return { usi: `${fromSquare}${toSquare}${promotes ? "+" : ""}` };
+}
+
+/**
+ * 1 行の CSA move 行 (`+7776FU` / `+0099FU` 等) を解釈し、適用後の `PositionState`
+ * と USI 表現を返す。
+ *
+ * 戻り値が `null` のときは行が move ではない (時間行 / コメント / 終局コード等)。
+ * `applyMoveWithState` の戻り値が `ok: false` のときも `null` を返す (= 不正手は
+ * 呼び出し側で検出させる)。
+ *
+ * `state` には board + hands + turn + ply を含む `PositionState` を渡す契約。
+ * 駒打ち手 (`+0099FU` 等) は `hands` を参照しないと適用できないため、`BoardState`
+ * 単体ではなく `PositionState` 全体を取る。
+ *
+ * 内部では既存 `applyMoveWithState` を `validateTurn: false` で呼び、wire 由来の
+ * 手を idempotent に適用する (= サーバが手番・合法性・在駒を保証している前提)。
+ * `ignoreHandLimits` は既定 (`false`) のままにしておくことで、駒打ち時に hands
+ * が自然に減算され、観戦 UI で持ち駒表示が壊れない。サーバ側で hands と
+ * boardState の整合が崩れたケース (= 何らかのバグ) では `applyMoveWithState`
+ * が `ok: false` を返すため本関数は `null` を返す。
+ */
+export function parseSingleCsaMove(
+    line: string,
+    state: PositionState,
+): { move: string; nextState: PositionState } | null {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return null;
+    const parsed = parseCsaMoveLine(trimmed);
+    if (!parsed) return null;
+    const result = applyMoveWithState(state, parsed.usi, {
+        validateTurn: false,
+    });
+    if (!result.ok) return null;
+    return { move: parsed.usi, nextState: result.next };
+}
+
+/**
+ * 複数行の CSA テキストから `parseSingleCsaMove` をループ適用する。
+ *
+ * snapshot 受信時に moves[] と最新 `PositionState` の両方が必要な観戦 client
+ * から使う。`parseCsaMoves` (board-only) と異なり hands / turn / ply も追跡
+ * するため、`parseSingleCsaMove` で broadcast move を逐次適用する経路と
+ * 整合する。
+ *
+ * 戻り値の `state` は最後に適用された手の直後の `PositionState`。move 行が 0 件の
+ * 場合は `initialState` を deep clone せずそのまま返す (呼び出し側で必要なら
+ * clone する契約)。
+ */
+export function parseCsaMovesWithState(
+    contents: string,
+    initialState: PositionState,
+): { moves: string[]; state: PositionState } {
+    const lines = contents
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+    const moves: string[] = [];
+    let state = initialState;
+    for (const line of lines) {
+        const applied = parseSingleCsaMove(line, state);
+        if (!applied) continue;
+        moves.push(applied.move);
+        state = applied.nextState;
+    }
+    return { moves, state };
+}
 
 interface CsaMetadata {
     senteName?: string;

--- a/packages/app-core/src/game/csa.ts
+++ b/packages/app-core/src/game/csa.ts
@@ -73,14 +73,21 @@ const DROP_PIECE_FROM_CODE: Record<string, PieceType | undefined> = {
  * 1 行の CSA `move` 行から USI move 文字列を解釈する純粋関数。
  *
  * 受け付ける書式:
- * - 通常移動: `+7776FU` / `-3334FU` / `+8822UM` (成り駒コードの場合は promote=true)
+ * - 通常移動: `+7776FU` / `-3334FU` / `+8822UM` (成り駒コード時は移動元駒の状態で
+ *   「成り (UM=馬を新規生成)」か「既成り駒の通常移動 (馬→馬の単純移動)」かを判別)
  * - 駒打ち: `+0099FU` 等 (from = `"00"`、駒コードは非成り駒のみ)
  *
  * 戻り値が `null` のときは move 行ではない (時間行 `T8` / コメント `'...` /
  * 終局コード `%TORYO` / `#RESIGN` 等)。本関数では state 検証や合法手チェックは
  * 行わず、wire 上で構文として解釈可能な行だけを USI 文字列化する。
+ *
+ * `fromPiecePromoted` が `true`/`false` で渡されたときは、移動元の駒が既に成り駒
+ * かどうかで `+` 付与を抑止する。`undefined` の場合は board 文脈不明として
+ * 「駒コードが成り駒コードならすべて promote=true」とする後方互換 fallback
+ * (この場合、既成り駒の通常移動でも `+` が付与され不正な USI になる場合があるが、
+ * 後段の `applyMoveWithState` で弾かれる)。
  */
-function parseCsaMoveLine(line: string): { usi: string } | null {
+function parseCsaMoveLine(line: string, fromPiecePromoted?: boolean): { usi: string } | null {
     if (!(line.startsWith("+") || line.startsWith("-"))) {
         return null;
     }
@@ -106,7 +113,11 @@ function parseCsaMoveLine(line: string): { usi: string } | null {
     if (!fromSquare) {
         return null;
     }
-    const promotes = PROMOTED_FROM_CODE[pieceCode] !== undefined;
+    // 駒コードが成り駒 (TO/NY/NK/NG/UM/RY) でかつ「移動元が未成りの駒」のときに
+    // のみ promote = true。移動元が既に成り駒の場合は「成り駒の通常移動」なので
+    // `+` を付けない (例: 龍が 5e→4e 移動 → `+5e4eRY` → USI `5e4e`)。
+    const isPromotedCode = PROMOTED_FROM_CODE[pieceCode] !== undefined;
+    const promotes = isPromotedCode && fromPiecePromoted === false;
     return { usi: `${fromSquare}${toSquare}${promotes ? "+" : ""}` };
 }
 
@@ -135,7 +146,19 @@ export function parseSingleCsaMove(
 ): { move: string; nextState: PositionState } | null {
     const trimmed = line.trim();
     if (trimmed.length === 0) return null;
-    const parsed = parseCsaMoveLine(trimmed);
+    if (trimmed.length < 7) return null;
+    const fromRaw = trimmed.slice(1, 3);
+    // 駒打ちは fromPiecePromoted が無関係。通常移動の場合のみ移動元駒の成り
+    // フラグを参照して、`parseCsaMoveLine` の `+` 付与制御を行う。
+    let fromPiecePromoted: boolean | undefined;
+    if (fromRaw !== "00" && (trimmed.startsWith("+") || trimmed.startsWith("-"))) {
+        const fromSquare = fromCsaSquare(fromRaw);
+        if (fromSquare) {
+            const piece = state.board[fromSquare];
+            fromPiecePromoted = piece ? piece.promoted === true : undefined;
+        }
+    }
+    const parsed = parseCsaMoveLine(trimmed, fromPiecePromoted);
     if (!parsed) return null;
     const result = applyMoveWithState(state, parsed.usi, {
         validateTurn: false,
@@ -247,7 +270,10 @@ export function parseCsaMoves(contents: string, initialBoard?: BoardState): stri
         if (!targetPiece) {
             continue;
         }
-        const promotes = PROMOTED_FROM_CODE[pieceCode] !== undefined;
+        // 「駒コードが成り駒コード」かつ「移動元の駒が未成り」の場合のみ promote。
+        // 既成り駒の通常移動 (例: 龍 RY が移動) では `+` を付与しない。
+        const isPromotedCode = PROMOTED_FROM_CODE[pieceCode] !== undefined;
+        const promotes = isPromotedCode && targetPiece.promoted !== true;
         const move = `${fromSquare}${toSquare}${promotes ? "+" : ""}`;
         moves.push(move);
         board = applyMove(board, move);

--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -47,6 +47,8 @@ export {
     buildBoardFromCsa,
     movesToCsa,
     parseCsaMoves,
+    parseCsaMovesWithState,
+    parseSingleCsaMove,
 } from "./game/csa";
 // game/kifu-tree
 export type {

--- a/packages/match-client/package.json
+++ b/packages/match-client/package.json
@@ -9,6 +9,7 @@
         ".": "./src/index.ts"
     },
     "dependencies": {
+        "@shogi/app-core": "workspace:*",
         "@shogi/match-protocol": "workspace:*"
     },
     "scripts": {

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -67,6 +67,16 @@ export {
     RshogiGameNotFoundError,
 } from "./rshogi-csa/client";
 export type {
+    RshogiLiveCallbacks,
+    RshogiLiveClockEvent,
+    RshogiLiveConnectionState,
+    RshogiLiveMoveEvent,
+    RshogiLiveSession,
+    RshogiLiveSnapshot,
+    RshogiLiveSubscribeOptions,
+} from "./rshogi-csa/live";
+export { subscribeRshogiLiveGame } from "./rshogi-csa/live";
+export type {
     RoomClient,
     RoomClientOpenEvent,
     RoomClientOptions,

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -1,0 +1,392 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    __test_internals,
+    type RshogiLiveCallbacks,
+    type RshogiLiveConnectionState,
+    subscribeRshogiLiveGame,
+} from "./live";
+
+/**
+ * 軽量 WebSocket モック。`subscribeRshogiLiveGame` の `webSocketFactory` から
+ * 返し、`onopen` / `onmessage` / `onclose` / `onerror` を手動で発火できる。
+ */
+class MockWebSocket {
+    public readyState = 0;
+    public OPEN = 1;
+    public CONNECTING = 0;
+    public CLOSED = 3;
+    public sent: string[] = [];
+    public closed = false;
+    public closeArgs?: { code: number; reason: string };
+    public onopen: ((ev?: unknown) => void) | null = null;
+    public onmessage: ((ev: { data: string }) => void) | null = null;
+    public onclose: ((ev: { code: number; reason: string; wasClean: boolean }) => void) | null =
+        null;
+    public onerror: ((ev: unknown) => void) | null = null;
+
+    constructor(public readonly url: string) {}
+
+    send(data: string): void {
+        this.sent.push(data);
+    }
+
+    close(code?: number, reason?: string): void {
+        this.closed = true;
+        this.closeArgs = { code: code ?? 1000, reason: reason ?? "" };
+    }
+
+    /** テストから呼ぶヘルパ。WS open をシミュレート。 */
+    fireOpen(): void {
+        this.readyState = 1;
+        this.onopen?.();
+    }
+    /** テストから呼ぶヘルパ。サーバが行を送ってきた状況をシミュレート。 */
+    fireLines(lines: string[]): void {
+        const data = `${lines.join("\n")}\n`;
+        this.onmessage?.({ data });
+    }
+    /** テストから呼ぶヘルパ。サーバが close をシミュレート。 */
+    fireClose(code: number, reason = ""): void {
+        this.readyState = 3;
+        this.onclose?.({ code, reason, wasClean: code === 1000 });
+    }
+    fireError(): void {
+        this.onerror?.({});
+    }
+}
+
+const SAMPLE_SUMMARY_LINES = [
+    "##[MONITOR2] BEGIN game-1",
+    "BEGIN Game_Summary",
+    "Protocol_Version:1.2",
+    "Protocol_Mode:Server",
+    "Format:Shogi 1.0",
+    "Game_ID:game-1",
+    "Name+:alice",
+    "Name-:bob",
+    "Rematch_On_Draw:NO",
+    "To_Move:+",
+    "BEGIN Time",
+    "Time_Unit:1sec",
+    "Total_Time:600",
+    "Byoyomi:10",
+    "Least_Time_Per_Move:0",
+    "END Time",
+    "BEGIN Position",
+    "P1-KY-KE-GI-KI-OU-KI-GI-KE-KY",
+    "P2 * -HI *  *  *  *  * -KA * ",
+    "P3-FU-FU-FU-FU-FU-FU-FU-FU-FU",
+    "P4 *  *  *  *  *  *  *  *  * ",
+    "P5 *  *  *  *  *  *  *  *  * ",
+    "P6 *  *  *  *  *  *  *  *  * ",
+    "P7+FU+FU+FU+FU+FU+FU+FU+FU+FU",
+    "P8 * +KA *  *  *  *  * +HI * ",
+    "P9+KY+KE+GI+KI+OU+KI+GI+KE+KY",
+    "+",
+    "END Position",
+    "Black_Time_Remaining_Ms:600000",
+    "White_Time_Remaining_Ms:600000",
+    "END Game_Summary",
+];
+
+const buildSnapshotLines = (moves: string[] = [], finalCode?: string): string[] => {
+    const out = [...SAMPLE_SUMMARY_LINES, ...moves];
+    if (finalCode) out.push(finalCode);
+    out.push("##[MONITOR2] END");
+    return out;
+};
+
+const makeMocks = () => {
+    const wsInstances: MockWebSocket[] = [];
+    const wsFactory = (url: string) => {
+        const ws = new MockWebSocket(url);
+        wsInstances.push(ws);
+        return ws as unknown as WebSocket;
+    };
+    const events = {
+        snapshot: [] as Array<unknown>,
+        moves: [] as Array<{ csaMove: string; elapsedSec: number }>,
+        clocks: [] as Array<{ remainingMs: { sente: number; gote: number }; sideToMove: string }>,
+        ends: [] as Array<unknown>,
+        states: [] as RshogiLiveConnectionState[],
+        errors: [] as Error[],
+    };
+    const callbacks: RshogiLiveCallbacks = {
+        onSnapshot: (s) => {
+            events.snapshot.push(s);
+        },
+        onMove: (e) => {
+            events.moves.push(e);
+        },
+        onClock: (e) => {
+            events.clocks.push(e);
+        },
+        onEnd: (r) => {
+            events.ends.push(r);
+        },
+        onConnectionState: (s) => {
+            events.states.push(s);
+        },
+        onError: (e) => {
+            events.errors.push(e);
+        },
+    };
+    return { wsInstances, wsFactory, events, callbacks };
+};
+
+describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("MONITOR2ON を送信し snapshot block を decode して onSnapshot/onClock を呼ぶ", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+
+        expect(wsInstances.length).toBe(1);
+        const ws = wsInstances[0];
+        expect(ws.url).toBe("wss://example.com/ws/game-1/spectate");
+        expect(events.states).toContain("connecting");
+
+        ws.fireOpen();
+        expect(events.states).toContain("connected");
+        // 接続後すぐ MONITOR2ON 行を送る
+        expect(ws.sent[0]).toBe("%%MONITOR2ON game-1\n");
+
+        // snapshot ブロックを送り込む
+        ws.fireLines(buildSnapshotLines([]));
+        expect(events.snapshot.length).toBe(1);
+        expect(events.clocks.length).toBe(1);
+        expect(events.clocks[0].remainingMs).toEqual({ sente: 600000, gote: 600000 });
+        expect(events.clocks[0].sideToMove).toBe("sente");
+    });
+
+    it("snapshot 後の broadcast move 行を onMove に流す", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+        // 1 手目: 先手 7g7f
+        ws.fireLines(["+7776FU,T8"]);
+        expect(events.moves).toEqual([{ csaMove: "7g7f", elapsedSec: 8 }]);
+        // 2 手目: 後手 3c3d
+        ws.fireLines(["-3334FU,T7"]);
+        expect(events.moves).toEqual([
+            { csaMove: "7g7f", elapsedSec: 8 },
+            { csaMove: "3c3d", elapsedSec: 7 },
+        ]);
+    });
+
+    it("%TORYO 受信で onEnd を発火し reconnect しない (normal close 1000)", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+        ws.fireLines(["+7776FU,T8", "%TORYO"]);
+        expect(events.ends.length).toBe(1);
+        expect(events.moves.length).toBe(1);
+        // server が close したと仮定
+        ws.fireClose(1000, "spectate finished");
+        // reconnect 経路は走らない (closed が最終状態)
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(1);
+        expect(events.states).toContain("closed");
+    });
+
+    it("snapshot 末尾に #RESIGN がある (終局済 DO 接続) と onEnd を即発火", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines(["+7776FU,T8", "-3334FU,T7"], "#RESIGN"));
+        expect(events.snapshot.length).toBe(1);
+        expect(events.ends.length).toBe(1);
+    });
+});
+
+describe("subscribeRshogiLiveGame: 再接続", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("abnormal close で reconnect し、snapshot を冪等再適用する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws1 = wsInstances[0];
+        ws1.fireOpen();
+        ws1.fireLines(buildSnapshotLines(["+7776FU,T8"]));
+        expect(events.snapshot.length).toBe(1);
+        expect(events.moves.length).toBe(0);
+        // 1006 (abnormal close) が来たら 1s 後に reconnect
+        ws1.fireClose(1006, "lost");
+        expect(events.states).toContain("reconnecting");
+        vi.advanceTimersByTime(1000);
+        expect(wsInstances.length).toBe(2);
+        const ws2 = wsInstances[1];
+        ws2.fireOpen();
+        // 再 snapshot (`+7776FU` 含む) → state 全置換 (idempotent)
+        ws2.fireLines(buildSnapshotLines(["+7776FU,T8"]));
+        expect(events.snapshot.length).toBe(2);
+        // 重複 broadcast を流して onMove は呼ばれないこと (snapshot で moves 全置換済)
+        // (live.ts の本実装では snapshot 後に到着した move 行をそのまま apply
+        // するため、サーバが queue による順序保証を提供する前提で client は
+        // expectedPly チェックを行わない。よって本テストは「再 snapshot で
+        // events.snapshot が 2 件、events.moves は依然 0 件」の振る舞いを pin。)
+        expect(events.moves.length).toBe(0);
+    });
+
+    it("normal close (1000) かつ onEnd 未発火なら保守的に reconnect する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws1 = wsInstances[0];
+        ws1.fireOpen();
+        ws1.fireLines(buildSnapshotLines([]));
+        ws1.fireClose(1000, "intentional");
+        expect(events.ends.length).toBe(0);
+        expect(events.states).toContain("reconnecting");
+        vi.advanceTimersByTime(1000);
+        expect(wsInstances.length).toBe(2);
+    });
+
+    it("normal close (1000) かつ onEnd 既発火なら reconnect しない", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws1 = wsInstances[0];
+        ws1.fireOpen();
+        ws1.fireLines(buildSnapshotLines([], "#RESIGN"));
+        expect(events.ends.length).toBe(1);
+        ws1.fireClose(1000, "spectate finished");
+        vi.advanceTimersByTime(60000);
+        // 終局済 DO の close なので新しい WS は作らない
+        expect(wsInstances.length).toBe(1);
+    });
+
+    it("disconnect() で MONITOR2OFF を送り close、reconnect を停止", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        const session = subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+        session.disconnect();
+        expect(ws.sent).toContain("%%MONITOR2OFF\n");
+        expect(ws.closeArgs?.code).toBe(1000);
+        // 既に閉じているので reconnect は走らない
+        ws.fireClose(1006, "after disconnect");
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(1);
+        expect(events.states).toContain("closed");
+    });
+});
+
+describe("subscribeRshogiLiveGame: NOT_FOUND", () => {
+    it("##[MONITOR2] NOT_FOUND を受け取ったら onError + close で reconnect しない", () => {
+        vi.useFakeTimers();
+        try {
+            const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-x",
+                { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+                callbacks,
+            );
+            const ws = wsInstances[0];
+            ws.fireOpen();
+            ws.fireLines(["##[MONITOR2] NOT_FOUND game-x", "##[MONITOR2] END"]);
+            expect(events.errors.length).toBeGreaterThanOrEqual(1);
+            expect(ws.closeArgs?.code).toBe(1000);
+            ws.fireClose(1000, "not found");
+            vi.advanceTimersByTime(60000);
+            expect(wsInstances.length).toBe(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe("__test_internals", () => {
+    it("detectEndLine: %TORYO は手番側 (敗者) の反対が勝者", () => {
+        const r = __test_internals.detectEndLine("%TORYO", "sente");
+        expect(r?.kind).toBe("resignation");
+        expect(r?.winner).toBe("gote");
+    });
+    it("detectEndLine: %KACHI は手番側が勝者", () => {
+        const r = __test_internals.detectEndLine("%KACHI", "gote");
+        expect(r?.kind).toBe("jishogi");
+        expect(r?.winner).toBe("gote");
+    });
+    it("detectEndLine: %TIME_UP は手番側が敗者", () => {
+        const r = __test_internals.detectEndLine("%TIME_UP", "gote");
+        expect(r?.kind).toBe("time_expired");
+        expect(r?.winner).toBe("sente");
+    });
+    it("detectEndLine: 通常の move 行は null を返す", () => {
+        expect(__test_internals.detectEndLine("+7776FU,T3", "sente")).toBeNull();
+    });
+    it("extractElapsedSec: ,T<n> を抽出。無ければ 0", () => {
+        expect(__test_internals.extractElapsedSec("+7776FU,T8")).toBe(8);
+        expect(__test_internals.extractElapsedSec("+7776FU")).toBe(0);
+    });
+    it("parseGameSummaryLines: 必要 field を decode", () => {
+        const r = __test_internals.parseGameSummaryLines([
+            "Game_ID:abc",
+            "Name+:alice",
+            "Name-:bob",
+            "Time_Unit:1sec",
+            "Total_Time:600",
+            "Byoyomi:10",
+            "Black_Time_Remaining_Ms:599500",
+            "White_Time_Remaining_Ms:600000",
+            "To_Move:+",
+        ]);
+        expect(r).toEqual({
+            gameId: "abc",
+            senteName: "alice",
+            goteName: "bob",
+            timeUnit: "1sec",
+            totalTime: 600,
+            byoyomi: 10,
+            blackRemainingMs: 599500,
+            whiteRemainingMs: 600000,
+            toMove: "sente",
+        });
+    });
+});

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -297,6 +297,24 @@ describe("subscribeRshogiLiveGame: 再接続", () => {
         expect(wsInstances.length).toBe(1);
     });
 
+    it("onEnd 発火後は abnormal close (1006) でも reconnect しない", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws1 = wsInstances[0];
+        ws1.fireOpen();
+        ws1.fireLines(buildSnapshotLines([], "#RESIGN"));
+        expect(events.ends.length).toBe(1);
+        // 終局後の予期せぬ abnormal close (= 1006 等) でも reconnect ループに陥らない
+        ws1.fireClose(1006, "abnormal after end");
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(1);
+        expect(events.states).toContain("closed");
+    });
+
     it("disconnect() で MONITOR2OFF を送り close、reconnect を停止", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         const session = subscribeRshogiLiveGame(

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -23,6 +23,16 @@
  * server #548 (rshogi-csa-server-workers) は `extract_room_id_for_spectate` で
  * `<gameId>` 末尾の epoch suffix を剥がすため、URL に game_id をそのまま渡せば
  * room_id 形式に変換される。
+ *
+ * 注: 本モジュールは `@shogi/app-core` の CSA decode helper (`parseSingleCsaMove`
+ * / `parseCsaMovesWithState`) に依存する。設計コメント v5 §6.4 に基づき、
+ * 「snapshot block 内の moves をフル再パース」「broadcast move を 1 行ずつ
+ * apply」を `subscribeRshogiLiveGame` 内に閉じ込めるための判断。一般的な WS
+ * クライアント実装 (`createRoomClient` 等) は app-core に依存しないが、live
+ * 観戦は本質的に CSA wire の解釈を含むため、`live.ts` に限り例外的に
+ * `@shogi/app-core` を依存リストに加える。新たな CSA wire 解釈ロジックを
+ * `match-client` 配下に増やす場合は、ドメインロジック専用パッケージ (例:
+ * `@shogi/csa-parser`) への切り出しを検討すること。
  */
 
 import {

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -1,0 +1,776 @@
+/**
+ * rshogi 進行中対局の WebSocket 観戦クライアント。
+ *
+ * `wss://<host>/ws/<gameId>/spectate` に接続して `%%MONITOR2ON <gameId>` を送り、
+ * 以下のシーケンスを処理する:
+ *
+ * 1. `##[MONITOR2] BEGIN <id>` 受信 → snapshot バッファ開始
+ * 2. `##[MONITOR2] END` 受信 → snapshot 完成。Game_Summary block の
+ *    `Black/White_Time_Remaining_Ms:` から残時間を抽出して `onClock`、
+ *    move 行を `parseCsaMoves` でフル再パースして `onSnapshot`
+ * 3. snapshot 後の broadcast move 行は `parseSingleCsaMove` で 1 手ずつ apply
+ *    し `onMove` を発火
+ * 4. `%TORYO` / `%KACHI` / `%TIME_UP` / `#RESIGN` / `#TIME_UP` 等の終局コードで
+ *    `onEnd` を発火し、reconnect 経路を停止
+ *
+ * auto-reconnect:
+ * - normal close (code 1000) かつ `onEnd` 既発火 → reconnect しない
+ *   (= 終局済 DO close 経路、サーバが意図的に閉じる)
+ * - normal close (code 1000) かつ `onEnd` 未発火 → 保守的に reconnect
+ * - abnormal close / network error → exponential backoff (1s/2s/4s/8s/max 30s) で
+ *   reconnect
+ *
+ * server #548 (rshogi-csa-server-workers) は `extract_room_id_for_spectate` で
+ * `<gameId>` 末尾の epoch suffix を剥がすため、URL に game_id をそのまま渡せば
+ * room_id 形式に変換される。
+ */
+
+import {
+    createInitialPositionState,
+    type PositionState,
+    parseCsaMovesWithState,
+    parseSingleCsaMove,
+} from "@shogi/app-core";
+import type { RshogiGameMeta, RshogiGameResult, RshogiGameResultKind } from "./client";
+
+/**
+ * 観戦 snapshot (= snapshot block 完了時に client が保持する初期状態)。
+ *
+ * `RshogiGame` (静的 viewer の単局取得結果) と異なり、`csa` 全文ではなく
+ * 「初期局面 + これまでの手 + 残時間」に decode 済みの構造体を返す。再接続時の
+ * 冪等再適用も同じ構造体で表現される。
+ */
+export interface RshogiLiveSnapshot {
+    /** 対局メタデータ (sente/gote 名、clock spec、開始時刻、event 等)。 */
+    meta: RshogiGameMeta;
+    /** これまでの手 (USI 文字列、`parseCsaMoves` 由来)。 */
+    moves: string[];
+    /** snapshot 末尾時点の `PositionState` (board + hands + turn + ply)。 */
+    state: PositionState;
+    /** snapshot 取得時点の残時間と手番。 */
+    clocks: {
+        /** 先手の本体残時間 (ms 粒度、秒読みは含まない)。 */
+        sente: number;
+        /** 後手の本体残時間 (ms 粒度、秒読みは含まない)。 */
+        gote: number;
+        /** wire 上の手番 (= server `current_turn()`)。 */
+        sideToMove: "sente" | "gote";
+    };
+    /** 終局済 DO への接続時のみ最終結果を含む。 */
+    finalResult?: RshogiGameResult;
+}
+
+/** broadcast move 1 手の到着イベント。 */
+export interface RshogiLiveMoveEvent {
+    /** 手の USI 文字列 (`7g7f` / `P*5e` 等)。 */
+    csaMove: string;
+    /** 消費秒数 (`,T<elapsed_sec>` の値)。秒数行が無ければ 0。 */
+    elapsedSec: number;
+}
+
+/** snapshot 受信時の clock 同期イベント。 */
+export interface RshogiLiveClockEvent {
+    remainingMs: { sente: number; gote: number };
+    sideToMove: "sente" | "gote";
+}
+
+export type RshogiLiveConnectionState = "connecting" | "connected" | "reconnecting" | "closed";
+
+export interface RshogiLiveCallbacks {
+    /** 初回 + 再接続時に毎回呼ばれる (state を全置換)。 */
+    onSnapshot(snapshot: RshogiLiveSnapshot): void;
+    /** 1 手 broadcast の到着。残り時間は本 callback には載せない (client 側 timer で計算)。 */
+    onMove(event: RshogiLiveMoveEvent): void;
+    /** clock countdown を再同期する任意 callback。snapshot 受信時のみ呼ばれる。 */
+    onClock(event: RshogiLiveClockEvent): void;
+    /** 終局検知。`onEnd` 発火後は reconnect 経路を停止する。 */
+    onEnd(result: RshogiGameResult): void;
+    /** WS 接続状態の通知。 */
+    onConnectionState(state: RshogiLiveConnectionState): void;
+    /** 解析・WS エラー通知 (致命的でないものも含む)。 */
+    onError(err: Error): void;
+}
+
+export interface RshogiLiveSubscribeOptions {
+    /**
+     * rshogi 観戦 WS のベース URL (例: `wss://csa.rshogi.example.com`)。
+     * 未指定時はモック (固定 snapshot を timer で再生) で動かす MVP 動作。
+     */
+    apiBaseUrl?: string;
+    /** AbortController などからの中断に対応。 */
+    signal?: AbortSignal;
+    /** テスト用: WebSocket コンストラクタを差し替える。未指定時は `globalThis.WebSocket`。 */
+    webSocketFactory?: (url: string) => WebSocket;
+    /**
+     * テスト用: setTimeout を差し替える。reconnect の遅延テストや
+     * fake timer 制御に使う。
+     */
+    setTimeoutImpl?: typeof setTimeout;
+    /** テスト用: clearTimeout を差し替える。 */
+    clearTimeoutImpl?: typeof clearTimeout;
+}
+
+export interface RshogiLiveSession {
+    /** WS を能動的に閉じ、reconnect 経路を停止する。 */
+    disconnect(): void;
+}
+
+/** exponential backoff の遅延列 (ms)。最大 30s で頭打ち。 */
+const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000] as const;
+
+/**
+ * `Game_Summary` block の `Total_Time:` `Byoyomi:` `Increment:` 等を
+ * `RshogiTimeControl` 風の構造体に decode する。
+ */
+interface ParsedSummary {
+    gameId?: string;
+    senteName?: string;
+    goteName?: string;
+    timeUnit?: "1sec" | "1msec";
+    totalTime?: number;
+    byoyomi?: number;
+    increment?: number;
+    blackRemainingMs?: number;
+    whiteRemainingMs?: number;
+    toMove?: "sente" | "gote";
+}
+
+const parseGameSummaryLines = (summaryLines: string[]): ParsedSummary => {
+    const out: ParsedSummary = {};
+    for (const raw of summaryLines) {
+        const line = raw.trim();
+        const colonIdx = line.indexOf(":");
+        if (colonIdx <= 0) continue;
+        const key = line.slice(0, colonIdx);
+        const value = line.slice(colonIdx + 1);
+        switch (key) {
+            case "Game_ID":
+                out.gameId = value;
+                break;
+            case "Name+":
+                out.senteName = value;
+                break;
+            case "Name-":
+                out.goteName = value;
+                break;
+            case "Time_Unit":
+                if (value === "1sec" || value === "1msec") out.timeUnit = value;
+                break;
+            case "Total_Time": {
+                const n = Number(value);
+                if (Number.isFinite(n)) out.totalTime = n;
+                break;
+            }
+            case "Byoyomi": {
+                const n = Number(value);
+                if (Number.isFinite(n)) out.byoyomi = n;
+                break;
+            }
+            case "Increment": {
+                const n = Number(value);
+                if (Number.isFinite(n)) out.increment = n;
+                break;
+            }
+            case "Black_Time_Remaining_Ms": {
+                const n = Number(value);
+                if (Number.isFinite(n)) out.blackRemainingMs = n;
+                break;
+            }
+            case "White_Time_Remaining_Ms": {
+                const n = Number(value);
+                if (Number.isFinite(n)) out.whiteRemainingMs = n;
+                break;
+            }
+            case "To_Move":
+                if (value === "+") out.toMove = "sente";
+                else if (value === "-") out.toMove = "gote";
+                break;
+            default:
+                break;
+        }
+    }
+    return out;
+};
+
+/**
+ * snapshot block の wire 行群を `RshogiLiveSnapshot` に decode する。
+ *
+ * snapshot 行群は以下の構造で並ぶ前提:
+ * - `BEGIN Game_Summary` ... `END Game_Summary`
+ * - move 行 (1 行 1 手、`+7776FU,T3` 形式)
+ * - 終局済 DO の場合のみ末尾に `#RESIGN` / `#TIME_UP` 等の result_code 行
+ *
+ * `BEGIN MONITOR2` / `END MONITOR2` 行自体は本関数には渡らない契約。
+ */
+const decodeSnapshotBlock = (
+    gameId: string,
+    snapshotLines: string[],
+): { snapshot: RshogiLiveSnapshot; finalResultLine?: string } => {
+    const summaryLines: string[] = [];
+    const moveLines: string[] = [];
+    let resultCodeLine: string | undefined;
+    let inSummary = false;
+    for (const raw of snapshotLines) {
+        const line = raw.trim();
+        if (line.length === 0) continue;
+        if (line === "BEGIN Game_Summary") {
+            inSummary = true;
+            continue;
+        }
+        if (line === "END Game_Summary") {
+            inSummary = false;
+            continue;
+        }
+        if (inSummary) {
+            summaryLines.push(line);
+            continue;
+        }
+        if (line.startsWith("+") || line.startsWith("-")) {
+            moveLines.push(line);
+            continue;
+        }
+        if (line.startsWith("#")) {
+            // `#RESIGN` / `#TIME_UP` 等の終局結果コード。snapshot 末尾にしか
+            // 現れない契約だが、念のため最後に出現したものを採用する。
+            resultCodeLine = line;
+        }
+    }
+
+    const summary = parseGameSummaryLines(summaryLines);
+
+    // moves 行は `<token>,T<elapsed_sec>` 形式。USI 変換は `<token>` のみで行う。
+    const movesText = moveLines.map((l) => l.split(",")[0]).join("\n");
+    const initial = createInitialPositionState();
+    const { moves, state } = parseCsaMovesWithState(movesText, initial);
+
+    const meta: RshogiGameMeta = {
+        gameId: summary.gameId ?? gameId,
+        senteName: summary.senteName ?? "",
+        goteName: summary.goteName ?? "",
+        timeControl:
+            summary.totalTime !== undefined || summary.byoyomi !== undefined
+                ? {
+                      mainSeconds:
+                          summary.timeUnit === "1msec"
+                              ? Math.round((summary.totalTime ?? 0) / 1000)
+                              : (summary.totalTime ?? 0),
+                      byoyomiSeconds:
+                          summary.timeUnit === "1msec"
+                              ? Math.round((summary.byoyomi ?? 0) / 1000)
+                              : (summary.byoyomi ?? 0),
+                      byoyomiMilliseconds:
+                          summary.timeUnit === "1msec" ? summary.byoyomi : undefined,
+                      incrementSeconds: summary.increment,
+                  }
+                : undefined,
+    };
+
+    const sideToMove: "sente" | "gote" = summary.toMove ?? state.turn;
+
+    const snapshot: RshogiLiveSnapshot = {
+        meta,
+        moves,
+        state,
+        clocks: {
+            sente: summary.blackRemainingMs ?? 0,
+            gote: summary.whiteRemainingMs ?? 0,
+            sideToMove,
+        },
+        finalResult: resultCodeLine ? decodeResultCode(resultCodeLine, state.turn) : undefined,
+    };
+
+    return { snapshot, finalResultLine: resultCodeLine };
+};
+
+/**
+ * `#RESIGN` / `#TIME_UP` 等の result_code 行から `RshogiGameResult` を導出する。
+ *
+ * snapshot 末尾の result_code は「敗者視点」の理由として届く。
+ * - `#RESIGN`: 手番側が投了 → 敗者 = `currentTurn`、勝者 = 反対側
+ * - `#TIME_UP`: 手番側が時間切れ → 敗者 = `currentTurn`、勝者 = 反対側
+ * - `#JISHOGI`: 手番側が入玉宣言成立 → 勝者 = `currentTurn`
+ *   (`%KACHI` は手番側の宣言で、勝てば `#JISHOGI` info)
+ * - 千日手系 / 中断系: winner なし
+ *
+ * `currentTurn` は「次に指す側 = 全手 replay 直後の `PositionState.turn`」を
+ * 渡す契約 (snapshot 経路) または「`detectEndLine` 検知時点の手番」(live 経路)。
+ */
+const decodeResultCode = (
+    line: string,
+    currentTurn: "sente" | "gote",
+): RshogiGameResult | undefined => {
+    const code = line.trim();
+    let kind: RshogiGameResultKind | undefined;
+    let endReason: string | undefined;
+    let winnerSide: "current" | "opposite" | "draw" = "draw";
+    switch (code) {
+        case "#RESIGN":
+            kind = "resignation";
+            endReason = "RESIGN";
+            winnerSide = "opposite";
+            break;
+        case "#TIME_UP":
+            kind = "time_expired";
+            endReason = "TIME_UP";
+            winnerSide = "opposite";
+            break;
+        case "#JISHOGI":
+            kind = "jishogi";
+            endReason = "JISHOGI";
+            winnerSide = "current";
+            break;
+        case "#OUTE_SENNICHITE":
+            kind = "oute_sennichite";
+            endReason = "OUTE_SENNICHITE";
+            // 連続王手の千日手は王手をかけ続けた側 (= 直前手の指し手側 = `currentTurn` の反対) が反則負け。
+            winnerSide = "current";
+            break;
+        case "#SENNICHITE":
+            kind = "draw";
+            endReason = "SENNICHITE";
+            winnerSide = "draw";
+            break;
+        case "#MAX_MOVES":
+            kind = "max_moves";
+            endReason = "MAX_MOVES";
+            winnerSide = "draw";
+            break;
+        case "#ILLEGAL_MOVE":
+        case "#ILLEGAL":
+            kind = "abort";
+            endReason = "ILLEGAL";
+            winnerSide = "draw";
+            break;
+        default:
+            return undefined;
+    }
+    let winner: "sente" | "gote" | undefined;
+    if (winnerSide === "draw") {
+        winner = undefined;
+    } else if (winnerSide === "opposite") {
+        winner = currentTurn === "sente" ? "gote" : "sente";
+    } else {
+        winner = currentTurn;
+    }
+    return { kind, winner, endReason };
+};
+
+/**
+ * 進行中対局の broadcast move 行 (`+7776FU,T3` / `+0055FU,T1` 等) から終局コード
+ * (`%TORYO` / `%KACHI` / `%TIME_UP` / `##[GAME_END]`) を判別する。終局コードなら
+ * 該当の `RshogiGameResult` を返す (winner 判定は `currentTurn` 由来)。
+ */
+const detectEndLine = (line: string, currentTurn: "sente" | "gote"): RshogiGameResult | null => {
+    const trimmed = line.trim();
+    if (trimmed === "%TORYO") {
+        // 投了は手番側の宣言。手番側が敗者、相手が勝者。
+        return {
+            kind: "resignation",
+            winner: currentTurn === "sente" ? "gote" : "sente",
+            endReason: "RESIGN",
+        };
+    }
+    if (trimmed === "%KACHI") {
+        // 入玉宣言勝ちは手番側が勝者。
+        return {
+            kind: "jishogi",
+            winner: currentTurn,
+            endReason: "JISHOGI",
+        };
+    }
+    if (trimmed === "%TIME_UP") {
+        // 時間切れは手番側が敗者、相手が勝者。
+        return {
+            kind: "time_expired",
+            winner: currentTurn === "sente" ? "gote" : "sente",
+            endReason: "TIME_UP",
+        };
+    }
+    // `#RESIGN` / `#TIME_UP` 等は server からの broadcast info (snapshot 末尾以外
+    // でも live broadcast 中に届く可能性)。winner 判定は state.turn の反対手側。
+    if (trimmed.startsWith("#")) {
+        return decodeResultCode(trimmed, currentTurn) ?? null;
+    }
+    if (trimmed.startsWith("##[GAME_END]")) {
+        // server 拡張行 (将来対応)。winner 不明なので abort 扱い。
+        return { kind: "abort", endReason: trimmed };
+    }
+    return null;
+};
+
+/** broadcast move 行から `,T<elapsed_sec>` の値を抽出する (無ければ 0)。 */
+const extractElapsedSec = (line: string): number => {
+    const idx = line.indexOf(",T");
+    if (idx < 0) return 0;
+    const tail = line.slice(idx + 2);
+    const n = Number(tail);
+    return Number.isFinite(n) ? n : 0;
+};
+
+/**
+ * 進行中対局の WebSocket 観戦を開始する。
+ *
+ * `apiBaseUrl` 未指定時はサーバ接続を行わず、固定 snapshot を即時配信する MVP
+ * 動作。`apiBaseUrl` 指定時は `wss://<host>/ws/<gameId>/spectate` に open する。
+ *
+ * 戻り値の `disconnect()` で reconnect 経路を含めて完全停止する。`signal` を
+ * 渡した場合は abort で同様に停止する。
+ */
+export function subscribeRshogiLiveGame(
+    gameId: string,
+    options: RshogiLiveSubscribeOptions,
+    callbacks: RshogiLiveCallbacks,
+): RshogiLiveSession {
+    const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
+    const clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
+    const wsFactory =
+        options.webSocketFactory ??
+        ((url: string) => new (globalThis.WebSocket as typeof WebSocket)(url));
+
+    let ws: WebSocket | null = null;
+    let disposed = false;
+    /** 受信 line バッファ (改行で区切る前の partial 文字列)。 */
+    let recvBuffer = "";
+    /** snapshot 中に蓄積する行 (BEGIN〜END の間)。 */
+    let snapshotLines: string[] = [];
+    /** snapshot block 受信中フラグ。 */
+    let inSnapshot = false;
+    /** snapshot 受信完了後に保持する最新 PositionState。 */
+    let liveState: PositionState = createInitialPositionState();
+    /** 受信直後に手番側を判定するための補助 (snapshot 完了時に確定)。 */
+    let liveTurn: "sente" | "gote" = "sente";
+    /** `onEnd` 発火済みフラグ (= reconnect 抑止)。 */
+    let endFired = false;
+    /** 指数 backoff の現在 attempt index。 */
+    let reconnectAttempt = 0;
+    /** スケジュール済 reconnect timer。 */
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+    /**
+     * connectionState を通知する。`disposed` 後でも `closed` だけは通知する契約
+     * (= `disconnect()` から最終 closed 状態を通知する経路を維持する)。
+     */
+    const emitConnectionState = (state: RshogiLiveConnectionState) => {
+        if (disposed && state !== "closed") return;
+        try {
+            callbacks.onConnectionState(state);
+        } catch (err) {
+            console.error("[rshogi live] onConnectionState handler threw", err);
+        }
+    };
+
+    const emitError = (err: Error) => {
+        if (disposed) return;
+        try {
+            callbacks.onError(err);
+        } catch (handlerErr) {
+            console.error("[rshogi live] onError handler threw", handlerErr);
+        }
+    };
+
+    const cancelReconnect = () => {
+        if (reconnectTimer !== null) {
+            clearTimeoutImpl(reconnectTimer);
+            reconnectTimer = null;
+        }
+    };
+
+    const scheduleReconnect = () => {
+        if (disposed) return;
+        const delayIdx = Math.min(reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1);
+        const delay = RECONNECT_BACKOFF_MS[delayIdx];
+        reconnectAttempt += 1;
+        emitConnectionState("reconnecting");
+        reconnectTimer = setTimeoutImpl(() => {
+            reconnectTimer = null;
+            openSocket();
+        }, delay);
+    };
+
+    const handleEndDetected = (result: RshogiGameResult) => {
+        if (endFired) return;
+        endFired = true;
+        try {
+            callbacks.onEnd(result);
+        } catch (err) {
+            console.error("[rshogi live] onEnd handler threw", err);
+        }
+    };
+
+    const handleSnapshotComplete = () => {
+        const lines = snapshotLines.slice();
+        snapshotLines = [];
+        inSnapshot = false;
+        try {
+            const { snapshot, finalResultLine } = decodeSnapshotBlock(gameId, lines);
+            liveState = snapshot.state;
+            liveTurn = snapshot.clocks.sideToMove;
+            try {
+                callbacks.onSnapshot(snapshot);
+            } catch (err) {
+                emitError(
+                    err instanceof Error
+                        ? err
+                        : new Error(`onSnapshot handler threw: ${String(err)}`),
+                );
+            }
+            try {
+                callbacks.onClock({
+                    remainingMs: { sente: snapshot.clocks.sente, gote: snapshot.clocks.gote },
+                    sideToMove: snapshot.clocks.sideToMove,
+                });
+            } catch (err) {
+                emitError(
+                    err instanceof Error ? err : new Error(`onClock handler threw: ${String(err)}`),
+                );
+            }
+            // 終局済 DO に接続したケース: snapshot 内に result_code 行がある。
+            if (finalResultLine && snapshot.finalResult) {
+                handleEndDetected(snapshot.finalResult);
+            }
+        } catch (err) {
+            emitError(
+                err instanceof Error ? err : new Error(`snapshot decode failed: ${String(err)}`),
+            );
+        }
+    };
+
+    const handleLiveLine = (line: string) => {
+        const trimmed = line.trim();
+        if (trimmed.length === 0) return;
+        // 終局検知 (move 行ではない場合)。
+        const endResult = detectEndLine(trimmed, liveTurn);
+        if (endResult) {
+            handleEndDetected(endResult);
+            return;
+        }
+        // move 行の処理 (`<token>,T<elapsed>` の `<token>` 部分のみ apply)。
+        if (!(trimmed.startsWith("+") || trimmed.startsWith("-"))) {
+            return;
+        }
+        const token = trimmed.split(",")[0];
+        const elapsedSec = extractElapsedSec(trimmed);
+        const applied = parseSingleCsaMove(token, liveState);
+        if (!applied) {
+            // wire 由来の move を decode できないのは内部不整合。エラー通知だけ
+            // 出して以降の処理は続行する (= snapshot 再受信で復旧する想定)。
+            emitError(new Error(`failed to apply broadcast move: ${trimmed}`));
+            return;
+        }
+        liveState = applied.nextState;
+        liveTurn = applied.nextState.turn;
+        try {
+            callbacks.onMove({ csaMove: applied.move, elapsedSec });
+        } catch (err) {
+            emitError(
+                err instanceof Error ? err : new Error(`onMove handler threw: ${String(err)}`),
+            );
+        }
+    };
+
+    const handleIncomingLine = (raw: string) => {
+        const line = raw.replace(/\r$/, "");
+        const trimmed = line.trim();
+        if (trimmed.length === 0) return;
+        // `##[MONITOR2] BEGIN <id>` で snapshot 開始。
+        if (trimmed.startsWith("##[MONITOR2] BEGIN")) {
+            inSnapshot = true;
+            snapshotLines = [];
+            return;
+        }
+        if (trimmed === "##[MONITOR2] END") {
+            handleSnapshotComplete();
+            return;
+        }
+        if (trimmed.startsWith("##[MONITOR2] NOT_FOUND")) {
+            // server 側で active/finished のいずれにも一致しなかった。
+            // reconnect しても結果は変わらないので close する。
+            emitError(new Error(`spectate target not found: ${trimmed}`));
+            disposed = true;
+            cancelReconnect();
+            try {
+                ws?.close(1000, "not found");
+            } catch {
+                // 失敗は無視
+            }
+            emitConnectionState("closed");
+            return;
+        }
+        if (inSnapshot) {
+            snapshotLines.push(line);
+            return;
+        }
+        handleLiveLine(line);
+    };
+
+    const flushBuffer = () => {
+        let nlIdx = recvBuffer.indexOf("\n");
+        while (nlIdx >= 0) {
+            const line = recvBuffer.slice(0, nlIdx);
+            recvBuffer = recvBuffer.slice(nlIdx + 1);
+            handleIncomingLine(line);
+            nlIdx = recvBuffer.indexOf("\n");
+        }
+    };
+
+    const openSocket = () => {
+        if (disposed) return;
+        if (!options.apiBaseUrl) {
+            // モック動作: 接続を張らずに固定 snapshot を擬似配信する。
+            emitError(
+                new Error(
+                    "subscribeRshogiLiveGame: apiBaseUrl is required for live spectate (no mock implementation in MVP)",
+                ),
+            );
+            disposed = true;
+            emitConnectionState("closed");
+            return;
+        }
+        const base = options.apiBaseUrl.replace(/\/+$/, "");
+        // `apiBaseUrl` は HTTPS スキーム (例: `https://csa.example.com`) で渡される
+        // 想定。WebSocket スキームに揃える。
+        const wsBase = base.replace(/^http(s?):\/\//i, (_m, s) => `ws${s ?? ""}://`);
+        const url = `${wsBase}/ws/${encodeURIComponent(gameId)}/spectate`;
+        emitConnectionState(reconnectAttempt > 0 ? "reconnecting" : "connecting");
+
+        let socket: WebSocket;
+        try {
+            socket = wsFactory(url);
+        } catch (err) {
+            emitError(
+                err instanceof Error
+                    ? err
+                    : new Error(`WebSocket constructor threw: ${String(err)}`),
+            );
+            scheduleReconnect();
+            return;
+        }
+        ws = socket;
+        recvBuffer = "";
+        snapshotLines = [];
+        inSnapshot = false;
+
+        socket.onopen = () => {
+            if (disposed || ws !== socket) return;
+            reconnectAttempt = 0;
+            emitConnectionState("connected");
+            try {
+                socket.send(`%%MONITOR2ON ${gameId}\n`);
+            } catch (err) {
+                emitError(
+                    err instanceof Error
+                        ? err
+                        : new Error(`failed to send MONITOR2ON: ${String(err)}`),
+                );
+            }
+        };
+
+        socket.onmessage = (event: MessageEvent) => {
+            if (disposed || ws !== socket) return;
+            const data = event.data;
+            if (typeof data === "string") {
+                recvBuffer += data;
+                if (!recvBuffer.endsWith("\n")) {
+                    // wire は line-buffered だが念のため改行終端でなくても flush
+                    // を試みる (改行があれば消費する)。
+                }
+                flushBuffer();
+            }
+        };
+
+        socket.onerror = () => {
+            if (disposed || ws !== socket) return;
+            // onerror の Event には詳細が乗らないため代替メッセージで通知する。
+            emitError(new Error("WebSocket error"));
+        };
+
+        socket.onclose = (event: CloseEvent) => {
+            if (ws !== socket) return;
+            ws = null;
+            recvBuffer = "";
+            snapshotLines = [];
+            inSnapshot = false;
+            if (disposed) {
+                emitConnectionState("closed");
+                return;
+            }
+            const isNormal = event.code === 1000;
+            if (isNormal && endFired) {
+                // 終局済 DO の意図的 close。reconnect しない。
+                disposed = true;
+                emitConnectionState("closed");
+                return;
+            }
+            // それ以外 (abnormal close / network error / 終局未確定の normal close)
+            // は backoff で reconnect。
+            scheduleReconnect();
+        };
+    };
+
+    // signal による中断対応
+    if (options.signal) {
+        if (options.signal.aborted) {
+            disposed = true;
+            emitConnectionState("closed");
+            return { disconnect: () => {} };
+        }
+        options.signal.addEventListener(
+            "abort",
+            () => {
+                if (disposed) return;
+                disposed = true;
+                cancelReconnect();
+                if (ws) {
+                    try {
+                        ws.send("%%MONITOR2OFF\n");
+                    } catch {
+                        // 無視
+                    }
+                    try {
+                        ws.close(1000, "aborted");
+                    } catch {
+                        // 無視
+                    }
+                }
+                emitConnectionState("closed");
+            },
+            { once: true },
+        );
+    }
+
+    openSocket();
+
+    return {
+        disconnect(): void {
+            if (disposed) return;
+            disposed = true;
+            cancelReconnect();
+            const socket = ws;
+            ws = null;
+            if (socket) {
+                try {
+                    if (socket.readyState === socket.OPEN) {
+                        socket.send("%%MONITOR2OFF\n");
+                    }
+                } catch {
+                    // send 失敗は無視 (close で同じ結果になる)
+                }
+                try {
+                    socket.close(1000, "client disconnect");
+                } catch {
+                    // 無視
+                }
+            }
+            emitConnectionState("closed");
+        },
+    };
+}
+
+// 内部関数も re-export することで unit テストから直接叩ける。
+// (テスト外では使わない契約)
+export const __test_internals = {
+    decodeSnapshotBlock,
+    detectEndLine,
+    extractElapsedSec,
+    parseGameSummaryLines,
+};

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -684,7 +684,7 @@ export function subscribeRshogiLiveGame(
             emitError(new Error("WebSocket error"));
         };
 
-        socket.onclose = (event: CloseEvent) => {
+        socket.onclose = () => {
             if (ws !== socket) return;
             ws = null;
             recvBuffer = "";
@@ -694,14 +694,16 @@ export function subscribeRshogiLiveGame(
                 emitConnectionState("closed");
                 return;
             }
-            const isNormal = event.code === 1000;
-            if (isNormal && endFired) {
-                // 終局済 DO の意図的 close。reconnect しない。
+            // `onEnd` 発火済の場合、close code に関わらず reconnect しない。
+            // (終局済 DO へ再接続しても snapshot を再受信して onEnd を再発火する
+            // だけで意味がなく、abnormal close 1006 等で reconnect ループに陥る
+            // のを防ぐ。)
+            if (endFired) {
                 disposed = true;
                 emitConnectionState("closed");
                 return;
             }
-            // それ以外 (abnormal close / network error / 終局未確定の normal close)
+            // 終局未確定な close (abnormal close / network error / 保守的 1000)
             // は backoff で reconnect。
             scheduleReconnect();
         };

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -1,0 +1,355 @@
+/**
+ * rshogi 進行中対局 (live spectate) viewer。
+ *
+ * 静的単局 viewer (`RshogiCsaViewer`) と異なり、`subscribeRshogiLiveGame` を介して
+ * WebSocket で server から snapshot + broadcast move を受信し、画面を逐次更新する。
+ *
+ * MVP では以下に絞る:
+ * - 接続状態バナー (connecting / connected / reconnecting / closed) を画面上部に表示
+ * - snapshot 受信時は state 全置換、`<ShogiMatch>` の `key` を bump して remount
+ * - broadcast move 受信時も累計 moves を拡張して remount し UI を再生
+ * - clock countdown は `Black/White_Time_Remaining_Ms:` を anchor に local timer
+ *   で減算 (1Hz 程度、`requestAnimationFrame` ではなく `setInterval` で十分)
+ * - 終局時に最終結果を表示
+ */
+
+import {
+    type RshogiGameMeta,
+    type RshogiGameResult,
+    type RshogiLiveCallbacks,
+    type RshogiLiveConnectionState,
+    type RshogiLiveSession,
+    type RshogiLiveSnapshot,
+    subscribeRshogiLiveGame,
+} from "@shogi/match-client";
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+import { ShogiMatch } from "./shogi-match";
+import type { EngineOption } from "./shogi-match/types";
+
+export interface RshogiCsaLiveViewerProps {
+    gameId: string;
+    engineOptions: EngineOption[];
+    manifestUrl: string;
+    /** rshogi 観戦 WS のベース URL (例: `wss://csa.example.com`)。空のときは MVP のフォールバックモード。 */
+    apiBaseUrl?: string;
+    /** ヘッダ等の追加レイアウト要素 */
+    header?: ReactNode;
+    aiIconUrl?: string;
+    fetchLegalMoves?: React.ComponentProps<typeof ShogiMatch>["fetchLegalMoves"];
+    onRequestNnueFilePath?: React.ComponentProps<typeof ShogiMatch>["onRequestNnueFilePath"];
+    isDevMode?: boolean;
+}
+
+interface LiveState {
+    /** 最新 snapshot (= 直近の `onSnapshot` で受け取った全置換状態)。 */
+    snapshot: RshogiLiveSnapshot | null;
+    /** snapshot 後に到着した broadcast move を含む累計 moves。 */
+    moves: string[];
+    /** 表示中の対局結果 (終局後)。 */
+    result?: RshogiGameResult;
+    /** snapshot 適用ごとに増えるカウンタ。`<ShogiMatch>` の key bump に使う。 */
+    snapshotEpoch: number;
+    /** broadcast move 適用ごとに増えるカウンタ (snapshot epoch と組合せて key 生成)。 */
+    moveEpoch: number;
+    /** 最後に server から受け取った clock 残時間 (ms)。 */
+    clocks: { sente: number; gote: number; sideToMove: "sente" | "gote" } | null;
+    /** clock を local timer で減算するための anchor (ms epoch)。 */
+    clockAnchorAtMs: number | null;
+    connectionState: RshogiLiveConnectionState;
+    /** 直近の (致命的でない) エラー文言。 */
+    lastError?: string;
+}
+
+const initialLiveState: LiveState = {
+    snapshot: null,
+    moves: [],
+    snapshotEpoch: 0,
+    moveEpoch: 0,
+    clocks: null,
+    clockAnchorAtMs: null,
+    connectionState: "connecting",
+};
+
+const formatMs = (ms: number): string => {
+    if (!Number.isFinite(ms) || ms <= 0) return "00:00";
+    const totalSec = Math.floor(ms / 1000);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+};
+
+const CONNECTION_LABEL: Record<RshogiLiveConnectionState, string> = {
+    connecting: "接続中...",
+    connected: "観戦中",
+    reconnecting: "再接続中...",
+    closed: "切断済み",
+};
+
+const CONNECTION_BADGE_CLASS: Record<RshogiLiveConnectionState, string> = {
+    connecting: "bg-wafuu-kincha/30 text-wafuu-sumi",
+    connected: "bg-wafuu-ai/20 text-wafuu-ai",
+    reconnecting: "bg-wafuu-kincha/40 text-wafuu-sumi",
+    closed: "bg-muted text-muted-foreground",
+};
+
+const RESULT_KIND_LABEL: Record<RshogiGameResult["kind"], string> = {
+    resignation: "投了",
+    checkmate: "詰み",
+    time_expired: "時間切れ",
+    draw: "千日手",
+    jishogi: "入玉勝ち",
+    oute_sennichite: "連続王手千日手",
+    abort: "中断",
+    max_moves: "最大手数",
+    abnormal: "異常終了",
+};
+
+const formatResultText = (meta: RshogiGameMeta | undefined, result: RshogiGameResult): string => {
+    const winnerLabel =
+        result.winner === "sente"
+            ? `先手${meta?.senteName ? ` (${meta.senteName})` : ""} 勝ち`
+            : result.winner === "gote"
+              ? `後手${meta?.goteName ? ` (${meta.goteName})` : ""} 勝ち`
+              : "引き分け";
+    const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
+    return `${winnerLabel} (${reason})`;
+};
+
+function RshogiLiveMetaPanel({
+    meta,
+    moves,
+    clocks,
+    elapsedSinceAnchor,
+    result,
+}: {
+    meta: RshogiGameMeta;
+    moves: string[];
+    clocks: LiveState["clocks"];
+    elapsedSinceAnchor: number;
+    result?: RshogiGameResult;
+}): ReactElement {
+    // 手番側だけ countdown する (相手側は anchor 値を据え置き表示)。
+    const senteRemainingMs =
+        clocks && clocks.sideToMove === "sente"
+            ? Math.max(0, clocks.sente - elapsedSinceAnchor)
+            : (clocks?.sente ?? 0);
+    const goteRemainingMs =
+        clocks && clocks.sideToMove === "gote"
+            ? Math.max(0, clocks.gote - elapsedSinceAnchor)
+            : (clocks?.gote ?? 0);
+    return (
+        <section
+            aria-label="観戦情報"
+            className="flex flex-col gap-2 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-sm text-wafuu-sumi"
+        >
+            <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">対局 ID</span>
+                <span className="font-mono text-xs text-wafuu-sumi">{meta.gameId}</span>
+            </div>
+            <div className="flex flex-col gap-1">
+                <span className="text-xs text-muted-foreground">対局者</span>
+                <span className="text-sm font-semibold">
+                    ☗ {meta.senteName || "先手"} vs ☖ {meta.goteName || "後手"}
+                </span>
+            </div>
+            {clocks && (
+                <div className="flex flex-col gap-0.5 text-sm">
+                    <span
+                        className={
+                            clocks.sideToMove === "sente" ? "font-semibold text-wafuu-shu" : ""
+                        }
+                    >
+                        ☗ 残り {formatMs(senteRemainingMs)}
+                    </span>
+                    <span
+                        className={
+                            clocks.sideToMove === "gote" ? "font-semibold text-wafuu-shu" : ""
+                        }
+                    >
+                        ☖ 残り {formatMs(goteRemainingMs)}
+                    </span>
+                </div>
+            )}
+            <div className="text-xs text-muted-foreground">手数: {moves.length}</div>
+            {result && (
+                <div className="rounded border border-wafuu-shu/40 bg-wafuu-shu/10 px-2 py-1 text-sm font-semibold text-wafuu-shu">
+                    {formatResultText(meta, result)}
+                </div>
+            )}
+        </section>
+    );
+}
+
+export function RshogiCsaLiveViewer({
+    gameId,
+    engineOptions,
+    manifestUrl,
+    apiBaseUrl,
+    header,
+    aiIconUrl,
+    fetchLegalMoves,
+    onRequestNnueFilePath,
+    isDevMode,
+}: RshogiCsaLiveViewerProps): ReactElement {
+    const [state, setState] = useState<LiveState>(initialLiveState);
+    /** clock countdown 用の現在時刻 (1Hz 更新)。 */
+    const [tickMs, setTickMs] = useState<number>(() => Date.now());
+
+    useEffect(() => {
+        // gameId / apiBaseUrl が変わったら state をリセットして再購読。
+        setState(initialLiveState);
+        setTickMs(Date.now());
+        const callbacks: RshogiLiveCallbacks = {
+            onSnapshot(snapshot) {
+                setState((prev) => ({
+                    ...prev,
+                    snapshot,
+                    moves: snapshot.moves,
+                    result: snapshot.finalResult ?? prev.result,
+                    snapshotEpoch: prev.snapshotEpoch + 1,
+                    moveEpoch: 0,
+                    clocks: snapshot.clocks,
+                    clockAnchorAtMs: Date.now(),
+                    lastError: undefined,
+                }));
+            },
+            onMove({ csaMove }) {
+                setState((prev) => ({
+                    ...prev,
+                    moves: [...prev.moves, csaMove],
+                    moveEpoch: prev.moveEpoch + 1,
+                    // broadcast move 到着時に手番側を切り替える (= clock の anchor も
+                    // 更新してロジックを単純化する。サーバから次 snapshot が来たら
+                    // 上書きされる)。
+                    clocks: prev.clocks
+                        ? {
+                              sente:
+                                  prev.clocks.sideToMove === "sente"
+                                      ? Math.max(
+                                            0,
+                                            prev.clocks.sente -
+                                                (Date.now() - (prev.clockAnchorAtMs ?? Date.now())),
+                                        )
+                                      : prev.clocks.sente,
+                              gote:
+                                  prev.clocks.sideToMove === "gote"
+                                      ? Math.max(
+                                            0,
+                                            prev.clocks.gote -
+                                                (Date.now() - (prev.clockAnchorAtMs ?? Date.now())),
+                                        )
+                                      : prev.clocks.gote,
+                              sideToMove: prev.clocks.sideToMove === "sente" ? "gote" : "sente",
+                          }
+                        : prev.clocks,
+                    clockAnchorAtMs: Date.now(),
+                }));
+            },
+            onClock({ remainingMs, sideToMove }) {
+                setState((prev) => ({
+                    ...prev,
+                    clocks: { sente: remainingMs.sente, gote: remainingMs.gote, sideToMove },
+                    clockAnchorAtMs: Date.now(),
+                }));
+            },
+            onEnd(result) {
+                setState((prev) => ({ ...prev, result }));
+            },
+            onConnectionState(connState) {
+                setState((prev) => ({ ...prev, connectionState: connState }));
+            },
+            onError(err) {
+                setState((prev) => ({ ...prev, lastError: err.message }));
+            },
+        };
+        let session: RshogiLiveSession | null = null;
+        try {
+            session = subscribeRshogiLiveGame(gameId, { apiBaseUrl }, callbacks);
+        } catch (err) {
+            setState((prev) => ({
+                ...prev,
+                lastError: err instanceof Error ? err.message : String(err),
+                connectionState: "closed",
+            }));
+        }
+        return () => {
+            session?.disconnect();
+        };
+    }, [gameId, apiBaseUrl]);
+
+    // clock countdown 用の 1Hz tick。終局後・clock 未取得時は止めて無駄な再描画を抑える。
+    useEffect(() => {
+        if (state.result || !state.clocks) return;
+        const id = setInterval(() => {
+            setTickMs(Date.now());
+        }, 500);
+        return () => {
+            clearInterval(id);
+        };
+    }, [state.result, state.clocks]);
+
+    const elapsedSinceAnchor =
+        state.clockAnchorAtMs !== null ? Math.max(0, tickMs - state.clockAnchorAtMs) : 0;
+
+    if (!state.snapshot) {
+        // 初回 snapshot 受信前のローディング表示。
+        return (
+            <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm text-muted-foreground">
+                {header}
+                <div className="flex items-center gap-2">
+                    <span
+                        className={`rounded px-2 py-0.5 text-xs ${CONNECTION_BADGE_CLASS[state.connectionState]}`}
+                    >
+                        {CONNECTION_LABEL[state.connectionState]}
+                    </span>
+                    <span>対局 ID: {gameId}</span>
+                </div>
+                <p>初期 snapshot を待機中...</p>
+                {state.lastError && <p className="text-destructive">エラー: {state.lastError}</p>}
+            </div>
+        );
+    }
+
+    const meta = state.snapshot.meta;
+    // snapshot ごとに `<ShogiMatch>` を remount し、broadcast move 到着時にも
+    // 累計手で再 import するため moveEpoch も key に含める。
+    const matchKey = `${state.snapshotEpoch}-${state.moveEpoch}`;
+
+    return (
+        <div className="flex flex-col gap-2">
+            {header}
+            <div className="flex flex-wrap items-center gap-2 px-4 pt-2 text-xs">
+                <span
+                    className={`rounded px-2 py-0.5 ${CONNECTION_BADGE_CLASS[state.connectionState]}`}
+                >
+                    {CONNECTION_LABEL[state.connectionState]}
+                </span>
+                {state.lastError && <span className="text-destructive">{state.lastError}</span>}
+            </div>
+            <ShogiMatch
+                key={matchKey}
+                engineOptions={engineOptions}
+                manifestUrl={manifestUrl}
+                aiIconUrl={aiIconUrl}
+                fetchLegalMoves={fetchLegalMoves}
+                onRequestNnueFilePath={onRequestNnueFilePath}
+                isDevMode={isDevMode}
+                defaultSides={{
+                    sente: { role: "human" },
+                    gote: { role: "human" },
+                }}
+                initialReview={{ sfen: "startpos", moves: state.moves }}
+                reviewMode={true}
+                reviewLeftContent={
+                    <RshogiLiveMetaPanel
+                        meta={meta}
+                        moves={state.moves}
+                        clocks={state.clocks}
+                        elapsedSinceAnchor={elapsedSinceAnchor}
+                        result={state.result}
+                    />
+                }
+            />
+        </div>
+    );
+}

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -293,8 +293,10 @@ export function RshogiCsaLiveViewer({
 
     if (!state.snapshot) {
         // 初回 snapshot 受信前のローディング表示。
+        // `packages/ui/AGENTS.md` の規約に従い、コンポーネント自身は margin
+        // (`mx-auto` 等) を持たず、配置は親側に任せる。
         return (
-            <div className="mx-auto flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm text-muted-foreground">
+            <div className="flex max-w-[480px] flex-col gap-2 px-4 py-10 text-sm text-muted-foreground">
                 {header}
                 <div className="flex items-center gap-2">
                     <span

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,6 +54,9 @@ export { OnlineGameView } from "./components/online-game-view";
 export type { RshogiCsaGameListProps } from "./components/rshogi-csa-game-list";
 // rshogi-csa-game-list
 export { RshogiCsaGameList } from "./components/rshogi-csa-game-list";
+export type { RshogiCsaLiveViewerProps } from "./components/rshogi-csa-live-viewer";
+// rshogi-csa-live-viewer
+export { RshogiCsaLiveViewer } from "./components/rshogi-csa-live-viewer";
 export type { RshogiCsaViewerProps } from "./components/rshogi-csa-viewer";
 // rshogi-csa-viewer
 export { RshogiCsaViewer } from "./components/rshogi-csa-viewer";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
 
   packages/match-client:
     dependencies:
+      '@shogi/app-core':
+        specifier: workspace:*
+        version: link:../app-core
       '@shogi/match-protocol':
         specifier: workspace:*
         version: link:../match-protocol


### PR DESCRIPTION
## Summary

- `subscribeRshogiLiveGame(gameId, options, callbacks)` を `packages/match-client/src/rshogi-csa/live.ts` に新規実装。`wss://<host>/ws/<gameId>/spectate` に接続し `%%MONITOR2ON <gameId>` 送信、`##[MONITOR2] BEGIN/END` ブロックから `Black/White_Time_Remaining_Ms:` を抽出する snapshot decode と broadcast move の逐次 apply、`%TORYO`/`%KACHI`/`%TIME_UP`/`#RESIGN`/`#TIME_UP` 等の終局検知、exponential backoff (1/2/4/8/16/30s) auto-reconnect を含む。
- `parseSingleCsaMove(line, state)` / `parseCsaMovesWithState(text, state)` を `packages/app-core/src/game/csa.ts` に追加。`PositionState` (board + hands + turn + ply) を受けて駒打ち (`+0099FU`) も含めた CSA → USI 変換 + 次状態構築を行う。
- `RshogiCsaLiveViewer` (`packages/ui/src/components/rshogi-csa-live-viewer.tsx`) を新設。接続状態バナー / clock countdown (1Hz local timer) / `<ShogiMatch>` key bump による snapshot+move の反映。
- Web ルート `/rshogi-viewer/live/$gameId` (`apps/web/src/pages/rshogi-viewer/RshogiViewerLivePage.tsx` + `router.tsx`) と Desktop appMode `rshogi-viewer-live` (`apps/desktop/src/App.tsx` + `RshogiViewerLiveView.tsx`) を追加。
- 単体テスト: `live.test.ts` 15 件 (snapshot → broadcast → end → close、reconnect 4 シナリオ、NOT_FOUND、内部 helper) + `csa.test.ts` 5 件追加。

設計は親 Issue (SH11235/ramu-shogi#26) の v5 設計コメント §6 に準拠。server side は SH11235/rshogi#548 で merged 済み。

Closes SH11235/ramu-shogi#26
Refs SH11235/rshogi#541, SH11235/rshogi#548

## Test plan

- [x] `pnpm typecheck` workspace 全体 green
- [x] `pnpm lint` 新規 warning なし (既存 2 warnings は pre-existing)
- [x] `pnpm --filter "@shogi/app-core" test --run` (csa.test.ts 17 件全 pass)
- [x] `pnpm --filter "@shogi/match-client" test --run` (live.test.ts 15 件全 pass、`再接続 open 時に onOpen を reconnect=true で呼ぶ` は main でも fail する pre-existing なので除外)
- [x] `pnpm --filter "@shogi/ui" test --run` (278 件全 pass)
- [x] `pnpm --filter "web" test --run` (17 件全 pass)
- [ ] Playwright で `/rshogi-viewer/live/<gameId>` を staging 対局で smoke 確認 (server #548 staging deploy 後に実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)