### PR TITLE
fix(desktop): @shogi/match-client を deps に追加して knip 検出を解消

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -19,6 +19,7 @@
         "@shogi/app-core": "workspace:*",
         "@shogi/design-system": "workspace:*",
         "@shogi/engine-tauri": "workspace:*",
+        "@shogi/match-client": "workspace:*",
         "@shogi/ui": "workspace:*",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-dialog": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@shogi/engine-tauri':
         specifier: workspace:*
         version: link:../../packages/engine-tauri
+      '@shogi/match-client':
+        specifier: workspace:*
+        version: link:../../packages/match-client
       '@shogi/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
## Summary
- `apps/desktop/src/components/rshogi-viewer/RshogiViewerListView.tsx` が `@shogi/match-client` を import しているが `apps/desktop/package.json` の dependencies に未宣言で、`pnpm knip` が Unlisted dependency として fail していた。
- workspace 内の他 `@shogi/*` と同じ `"workspace:*"` 記法で dependencies に追加し、`pnpm-lock.yaml` を再生成して link 解決済みにした。

Closes #31

## Test plan
- [x] `pnpm install` で lockfile が正しく更新される
- [x] `pnpm knip` が green
- [x] `pnpm --filter desktop exec tsc --noEmit` が pass
- [x] `pnpm --filter desktop lint` が pass (pre-existing な engine-tauri の warnings のみ)