### PR TITLE
docs(env): VITE_RSHOGI_API_BASE のコメントを /api/v1 仕様に揃える

### DIFF
--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -3,5 +3,9 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # Optional
 # VITE_DEFAULT_NNUE_PRESET=ramu
 # VITE_BASE_PATH=/
-# rshogi 棋譜配信 API (未設定なら viewer は組み込みモック fixture を返す)
-# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api
+# rshogi 棋譜配信 API のベース URL。
+# `fetchRshogiGame*` が `${VITE_RSHOGI_API_BASE}/games[/<id>]` の形で fetch するため、
+# `/api/v1` まで含めて指定すること。未設定なら viewer は組み込みモック fixture を返す。
+# 例 (本番):   VITE_RSHOGI_API_BASE=https://rshogi-csa-server.sh11235.com/api/v1
+# 例 (staging): VITE_RSHOGI_API_BASE=https://stg.rshogi-csa-server.sh11235.com/api/v1
+# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api/v1

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -4,5 +4,9 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # VITE_DEFAULT_NNUE_PRESET=ramu
 # VITE_BASE_PATH=/
 # VITE_ALLOWED_HOSTS=your-host.example.com,another-host.example.com
-# rshogi 棋譜配信 API (未設定なら viewer は組み込みモック fixture を返す)
-# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api
+# rshogi 棋譜配信 API のベース URL。
+# `fetchRshogiGame*` が `${VITE_RSHOGI_API_BASE}/games[/<id>]` の形で fetch するため、
+# `/api/v1` まで含めて指定すること。未設定なら viewer は組み込みモック fixture を返す。
+# 例 (本番):   VITE_RSHOGI_API_BASE=https://rshogi-csa-server.sh11235.com/api/v1
+# 例 (staging): VITE_RSHOGI_API_BASE=https://stg.rshogi-csa-server.sh11235.com/api/v1
+# VITE_RSHOGI_API_BASE=https://rshogi.example.com/api/v1


### PR DESCRIPTION
## 概要

`packages/match-client/src/rshogi-csa/client.ts::fetchRshogiGame*` は `${baseUrl}/games[/<id>]` の形で URL を組み立てるため、env として渡す `VITE_RSHOGI_API_BASE` は **`/api/v1` を含む値**でないとならない。`.env.example` のコメント例 (`/api`) が実装と食い違っていたので、本番・staging の URL 例と合わせて修正する。

## 変更点

- `apps/web/.env.example`: `VITE_RSHOGI_API_BASE` のコメント例を `/api/v1` を含む形に修正
- `apps/desktop/.env.example`: 同様

## 例

- 本番: `https://rshogi-csa-server.sh11235.com/api/v1`
- staging: `https://stg.rshogi-csa-server.sh11235.com/api/v1`

## 関連

- rshogi 側で `WS_ALLOWED_ORIGINS` に `https://ramu-shogi.sh11235.com` / `https://stg.ramu-shogi.sh11235.com` および Tauri origin を登録した: SH11235/rshogi#563 (merged)

## 残タスク (本 PR スコープ外)

ramu-shogi web 本番 deploy 時に `VITE_RSHOGI_API_BASE` が確実に注入される経路の確認が必要:

- 現状 `apps/web/.env.production` は `.gitignore` で除外
- `.github/workflows/deploy-web.yml` には `VITE_RSHOGI_API_BASE` 等 `VITE_*` の env inject ステップが存在せず、`scripts/check-env.mjs` が `VITE_NNUE_MANIFEST_URL` の有無を build 前に確認している

deploy 経路 (CI inject? GitHub Variables? 手動 deploy?) が確定したら、production 用 `VITE_RSHOGI_API_BASE` を反映する別 PR (workflow 改修 or `.env.production` 解禁) を出す。

## Non-goals

- production / staging deploy 経路の env injection 改修 (本 PR は documentation のみ)
- `.env.production` を gitignore から外す判断