### PR TITLE
feat(deploy): scripts/deploy-web.sh に VITE_RSHOGI_API_BASE の mode 別 export を追加

### DIFF
--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE=${1:-}
+
+if [[ "$MODE" != "stg" && "$MODE" != "prod" ]]; then
+  echo "Usage: $0 <stg|prod>" >&2
+  exit 1
+fi
+
+# Vite 共通 env
+export VITE_BASE_PATH="/"
+
+# stg / prod で分岐: NNUE manifest URL も viewer API base URL も環境別に設定する。
+if [[ "$MODE" == "stg" ]]; then
+  export VITE_NNUE_MANIFEST_URL="https://stg.ramu-shogi.sh11235.com/nnue/manifest.json"
+  export VITE_RSHOGI_API_BASE="https://stg.rshogi-csa-server.sh11235.com/api/v1"
+else
+  export VITE_NNUE_MANIFEST_URL="https://ramu-shogi.sh11235.com/nnue/manifest.json"
+  export VITE_RSHOGI_API_BASE="https://rshogi-csa-server.sh11235.com/api/v1"
+fi
+
+# defense-in-depth: 空チェック (export 後でも 0 文字なら fail)
+for v in VITE_BASE_PATH VITE_NNUE_MANIFEST_URL VITE_RSHOGI_API_BASE; do
+  if [[ -z "${!v:-}" ]]; then
+    echo "$v is required" >&2
+    exit 1
+  fi
+done
+
+# 1. engine-wasm 以外の web 依存パッケージをビルド
+pnpm --filter "web^..." --filter '!@shogi/engine-wasm' build
+
+# 2. WASM production ビルド（WASM + TypeScript、1回のみ）
+pnpm --filter @shogi/engine-wasm build:production
+
+# 3. Web のみビルド
+pnpm --filter web build
+
+# 4. デプロイ
+if [[ "$MODE" == "stg" ]]; then
+  (cd apps/web && pnpx wrangler deploy --env stg)
+else
+  (cd apps/web && pnpx wrangler deploy)
+fi


### PR DESCRIPTION
## Summary

- `scripts/deploy-web.sh` を新規追加し、`stg` / `prod` 引数で `VITE_RSHOGI_API_BASE` と `VITE_NNUE_MANIFEST_URL` を環境別に export する。
- これまで viewer API base URL が export されていなかったため、deploy 後の ramu-shogi web は rshogi viewer API を叩けず mock fixture のままだった。
- defense-in-depth として export 済み env の空チェックループを追加し、未定義/0 文字なら fail させる。

## 変更点

- stg → `https://stg.ramu-shogi.sh11235.com/nnue/manifest.json` + `https://stg.rshogi-csa-server.sh11235.com/api/v1`
- prod → `https://ramu-shogi.sh11235.com/nnue/manifest.json` + `https://rshogi-csa-server.sh11235.com/api/v1`
- build / deploy step (`pnpm --filter web^...` / `engine-wasm build:production` / `pnpx wrangler deploy [--env stg]`) は元のローカル script から維持。

## Test plan

- [x] `bash -n scripts/deploy-web.sh` 構文チェック
- [ ] (任意) `scripts/deploy-web.sh stg` → staging deploy 後、viewer ページで `https://stg.rshogi-csa-server.sh11235.com/api/v1/games` が 200 を返すこと
- [ ] (任意) `scripts/deploy-web.sh prod` → 本番 deploy 後同様の確認

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)