### PR TITLE
feat(match-client): viewer API へ X-Client header と VITE_APP_VERSION 注入を追加

### DIFF
--- a/apps/desktop/.env.example
+++ b/apps/desktop/.env.example
@@ -9,3 +9,10 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # 例 (本番):   VITE_RSHOGI_API_BASE=https://rshogi-csa-server.sh11235.com/api/v1
 # 例 (staging): VITE_RSHOGI_API_BASE=https://stg.rshogi-csa-server.sh11235.com/api/v1
 # VITE_RSHOGI_API_BASE=https://rshogi.example.com/api/v1
+
+# クライアント種識別子。viewer 配信 API のリクエスト header `X-Client: <kind>/<version>` で送信される。
+# 未設定なら header を送らない (= server 側ログでは `unknown` 扱い)。
+# version 部分は vite.config.ts が package.json::version を build 時に literal 置換する。
+# web build: VITE_CLIENT_KIND=ramu-shogi-web
+# desktop build: VITE_CLIENT_KIND=ramu-shogi-desktop
+# VITE_CLIENT_KIND=ramu-shogi-desktop

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -7,8 +8,17 @@ import { defineConfig } from "vite";
 const host = process.env.TAURI_DEV_HOST;
 const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
+// build 時に package.json::version を読み、`import.meta.env.VITE_APP_VERSION` として
+// literal 置換する。viewer API への X-Client ヘッダ (rshogi#564) でクライアント version を識別するために使う。
+const pkg = JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf-8")) as {
+    version: string;
+};
+
 // https://vite.dev/config/
 export default defineConfig(async () => ({
+    define: {
+        "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkg.version),
+    },
     plugins: [
         tailwindcss(),
         react({

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -10,3 +10,10 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # 例 (本番):   VITE_RSHOGI_API_BASE=https://rshogi-csa-server.sh11235.com/api/v1
 # 例 (staging): VITE_RSHOGI_API_BASE=https://stg.rshogi-csa-server.sh11235.com/api/v1
 # VITE_RSHOGI_API_BASE=https://rshogi.example.com/api/v1
+
+# クライアント種識別子。viewer 配信 API のリクエスト header `X-Client: <kind>/<version>` で送信される。
+# 未設定なら header を送らない (= server 側ログでは `unknown` 扱い)。
+# version 部分は vite.config.ts が package.json::version を build 時に literal 置換する。
+# web build: VITE_CLIENT_KIND=ramu-shogi-web
+# desktop build: VITE_CLIENT_KIND=ramu-shogi-desktop
+# VITE_CLIENT_KIND=ramu-shogi-web

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import tailwindcss from "@tailwindcss/vite";
@@ -10,11 +11,20 @@ const rootDir = path.dirname(fileURLToPath(import.meta.url));
 // ANALYZE=true でバンドル分析レポートを生成
 const isAnalyze = process.env.ANALYZE === "true";
 
+// build 時に package.json::version を読み、`import.meta.env.VITE_APP_VERSION` として
+// literal 置換する。viewer API への X-Client ヘッダ (rshogi#564) でクライアント version を識別するために使う。
+const pkg = JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf-8")) as {
+    version: string;
+};
+
 // https://vite.dev/config/
 export default defineConfig(({ command, mode }) => {
     const env = loadEnv(mode, rootDir, "");
 
     return {
+        define: {
+            "import.meta.env.VITE_APP_VERSION": JSON.stringify(pkg.version),
+        },
         // Cloudflare Workers 配信では "/" を使う。過去の GitHub Pages 向け fallback は維持するが、
         // 実際の値は .env.production などから loadEnv で解決する。
         base: env.VITE_BASE_PATH || (command === "build" ? "/ramu-shogi/" : "/"),

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     fetchRshogiGame,
     fetchRshogiGameList,
@@ -6,6 +6,17 @@ import {
     RshogiGameFetchError,
     RshogiGameNotFoundError,
 } from "./client";
+
+// production code 側は `import.meta.env` → `process.env` の順で読むため、テストでは
+// `vi.stubEnv` で両方を上書きする (Vitest 4 では `vi.stubEnv` が `import.meta.env` と
+// `process.env` の両方に反映される)。
+const setEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) {
+        vi.stubEnv(key, "");
+    } else {
+        vi.stubEnv(key, value);
+    }
+};
 
 describe("fetchRshogiGame (mock fallback)", () => {
     it("returns the embedded fixture when no baseUrl is provided", async () => {
@@ -419,5 +430,73 @@ describe("fetchRshogiGameList (real baseUrl)", () => {
                 fetchImpl,
             }),
         ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+});
+
+describe("fetchRshogiGame* X-Client header (rshogi#564)", () => {
+    beforeEach(() => {
+        setEnv("VITE_CLIENT_KIND", undefined);
+        setEnv("VITE_APP_VERSION", undefined);
+    });
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    const okPayload = {
+        game_id: "x1",
+        black_handle: "B",
+        white_handle: "W",
+        csa: "V2.2\n",
+    };
+
+    it("does not attach X-Client header when VITE_CLIENT_KIND is unset", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify(okPayload), { status: 200 }),
+        ) as unknown as typeof fetch;
+        await fetchRshogiGame("x1", { baseUrl: "https://rshogi.example.com", fetchImpl });
+        const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+            .calls[0][1];
+        expect(init).toEqual({ signal: undefined });
+        expect((init as { headers?: unknown }).headers).toBeUndefined();
+    });
+
+    it("attaches X-Client: <kind>/<version> when both env are set", async () => {
+        setEnv("VITE_CLIENT_KIND", "ramu-shogi-web");
+        setEnv("VITE_APP_VERSION", "1.2.3");
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify(okPayload), { status: 200 }),
+        ) as unknown as typeof fetch;
+        await fetchRshogiGame("x1", { baseUrl: "https://rshogi.example.com", fetchImpl });
+        const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+            .calls[0][1];
+        expect((init as { headers?: Record<string, string> }).headers).toEqual({
+            "X-Client": "ramu-shogi-web/1.2.3",
+        });
+    });
+
+    it("attaches X-Client: <kind> when only VITE_CLIENT_KIND is set", async () => {
+        setEnv("VITE_CLIENT_KIND", "ramu-shogi-desktop");
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ games: [], next_cursor: null }), { status: 200 }),
+        ) as unknown as typeof fetch;
+        await fetchRshogiGameList({ baseUrl: "https://rshogi.example.com", fetchImpl });
+        const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+            .calls[0][1];
+        expect((init as { headers?: Record<string, string> }).headers).toEqual({
+            "X-Client": "ramu-shogi-desktop",
+        });
+    });
+
+    it("does not attach header when VITE_CLIENT_KIND is empty/whitespace", async () => {
+        setEnv("VITE_CLIENT_KIND", "   ");
+        setEnv("VITE_APP_VERSION", "1.0.0");
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify(okPayload), { status: 200 }),
+        ) as unknown as typeof fetch;
+        await fetchRshogiGame("x1", { baseUrl: "https://rshogi.example.com", fetchImpl });
+        const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
+            .calls[0][1];
+        expect((init as { headers?: unknown }).headers).toBeUndefined();
     });
 });

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -165,6 +165,57 @@ export class RshogiGameFetchError extends Error {
 
 const trimTrailingSlash = (value: string): string => value.replace(/\/+$/, "");
 
+/**
+ * `VITE_*` env を読む。
+ *
+ * - 本番 (Vite build): `vite.config.ts::define` 経由で `import.meta.env.VITE_APP_VERSION` が
+ *   literal 置換され、`VITE_CLIENT_KIND` は `.env*` / shell export 経由で `import.meta.env` に乗る
+ * - Vitest 上: `import.meta.env` は提供されるが `vi.stubEnv` の反映タイミングに依存するため、
+ *   Node 環境にある `process.env` も fallback として読む
+ *
+ * 値が undefined または空文字なら次のソースを試す。最終的にどこにも無ければ undefined を返す。
+ */
+const readViteEnv = (key: "VITE_CLIENT_KIND" | "VITE_APP_VERSION"): string | undefined => {
+    const importMetaEnv = (import.meta as unknown as { env?: Record<string, string | undefined> })
+        .env;
+    const fromImport = importMetaEnv?.[key];
+    if (fromImport !== undefined && fromImport !== "") return fromImport;
+    const proc = (
+        globalThis as unknown as { process?: { env?: Record<string, string | undefined> } }
+    ).process;
+    return proc?.env?.[key];
+};
+
+/**
+ * `X-Client` header を組み立てる。
+ *
+ * - `VITE_CLIENT_KIND` と `VITE_APP_VERSION` の両方が set なら `X-Client: <kind>/<version>`
+ * - `VITE_CLIENT_KIND` のみ set なら `X-Client: <kind>`
+ * - kind が未設定 (空文字含む) ならヘッダ自体を付与しない (= 既存挙動互換、サーバログでは `unknown` 扱い)
+ */
+const buildClientHeaders = (): Record<string, string> => {
+    const kind = readViteEnv("VITE_CLIENT_KIND")?.trim();
+    if (!kind) return {};
+    const version = readViteEnv("VITE_APP_VERSION")?.trim();
+    return {
+        "X-Client": version ? `${kind}/${version}` : kind,
+    };
+};
+
+/**
+ * `RequestInit` を組み立てるヘルパ。
+ *
+ * 既存テストは fetch を `(url, { signal })` の固定形で検証するため、`X-Client` を
+ * 付与する必要がない場合は `headers` を含めない (= 既存挙動完全互換)。
+ */
+const buildRequestInit = (signal: AbortSignal | undefined): RequestInit => {
+    const headers = buildClientHeaders();
+    if (Object.keys(headers).length === 0) {
+        return { signal };
+    }
+    return { signal, headers };
+};
+
 // ===== wire format (snake_case) =====
 // サーバが返す JSON 1 件分。decode 層の入力でしか使わないため module 内部に閉じる。
 
@@ -394,7 +445,7 @@ export async function fetchRshogiGame(
     }
 
     const url = `${trimTrailingSlash(baseUrl)}/games/${encodeURIComponent(gameId)}`;
-    const response = await fetchImpl(url, { signal: options.signal });
+    const response = await fetchImpl(url, buildRequestInit(options.signal));
     if (response.status === 404) {
         throw new RshogiGameNotFoundError(gameId);
     }
@@ -439,7 +490,7 @@ export async function fetchRshogiGameList(
     const query = params.toString();
     const url = `${trimTrailingSlash(baseUrl)}/games${query.length > 0 ? `?${query}` : ""}`;
 
-    const response = await fetchImpl(url, { signal: options.signal });
+    const response = await fetchImpl(url, buildRequestInit(options.signal));
     if (!response.ok) {
         throw new RshogiGameFetchError(
             "",

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -10,6 +10,9 @@ fi
 
 # Vite 共通 env
 export VITE_BASE_PATH="/"
+# X-Client header 用のクライアント種識別子 (rshogi#564)。stg / prod で同値。
+# 未設定でも build 自体は通るが、viewer API のログで client_kind=unknown 扱いになるため明示しておく。
+export VITE_CLIENT_KIND="ramu-shogi-web"
 
 # stg / prod で分岐: NNUE manifest URL も viewer API base URL も環境別に設定する。
 if [[ "$MODE" == "stg" ]]; then


### PR DESCRIPTION
## Summary
- `fetchRshogiGame` / `fetchRshogiGameList` の共通 fetch helper に `X-Client: <kind>/<version>` ヘッダを付与する。`VITE_CLIENT_KIND` 未設定時は既存挙動と互換 (header を送らない)
- `apps/web/vite.config.ts` と `apps/desktop/vite.config.ts` の `define:` で `package.json::version` を `import.meta.env.VITE_APP_VERSION` に build 時 literal 置換
- `apps/web/.env.example` / `apps/desktop/.env.example` に `VITE_CLIENT_KIND` の用途と推奨値を documentation
- `scripts/deploy-web.sh` の共通 export に `VITE_CLIENT_KIND="ramu-shogi-web"` を追加 (stg / prod 共通)

`Refs SH11235/rshogi#564`

リリース順序: rshogi server 側 PR (`SH11235/rshogi#566`) は既に main merged 済 / staging へ自動 deploy 進行中。本 PR は ramu-shogi 側のクライアント実装で、設計 v4 §5 (実装 PR ramu-shogi 側) のスコープに対応する。

## Test plan
- [x] `pnpm --filter @shogi/match-client typecheck`
- [x] `pnpm --filter @shogi/match-client run test --run` で X-Client 関連 4 ケース (kind+version / kind-only / unset / whitespace) と既存 32 ケース全て pass
- [x] `pnpm --filter web typecheck`
- [x] `pnpm exec biome check` (errors 0)
- [x] `bash -n scripts/deploy-web.sh`
- [ ] CI green (pnpm typecheck/lint/test)
- [ ] (手動・ユーザー責務) staging deploy → ブラウザ DevTools で `X-Client: ramu-shogi-web/<version>` の送出を確認 → server logfmt の `client_kind=ramu-shogi-web` を確認

## Notes
- `VITE_CLIENT_KIND` 未設定時の互換性: `buildRequestInit` は env 未設定なら `{ signal }` のみ返すため、既存テストの `(url, { signal })` 形式は壊れない
- `readViteEnv` は `import.meta.env` → `process.env` の順で読む。Vitest 上で `vi.stubEnv` の反映タイミングに依存しないようにする補助
- desktop deploy は別経路 (Tauri build) のため、本 PR では `apps/desktop/.env.example` への documentation 追加のみ。実際のビルド時は環境変数で渡す前提