### PR TITLE
chore(deps): desktop の rshogi-core を git rev に統一して二重ソースを解消

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -718,7 +718,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "rshogi-core 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rshogi-core",
  "rshogi-csa-client",
  "rustls",
  "serde",
@@ -3111,23 +3111,6 @@ dependencies = [
 [[package]]
 name = "rshogi-core"
 version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e86c1b671b17e6b8c20a58fd728db8a5188ef3dbfcc0330fb2bf44ddaf75fa"
-dependencies = [
- "anyhow",
- "getrandom 0.3.4",
- "libc",
- "log",
- "rand 0.9.4",
- "rand_xoshiro",
- "serde",
- "web-time",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "rshogi-core"
-version = "0.2.4"
 source = "git+https://github.com/SH11235/rshogi.git?rev=afd941abfb60488df89ac6abbe060aba170ef09c#afd941abfb60488df89ac6abbe060aba170ef09c"
 dependencies = [
  "anyhow",
@@ -3158,7 +3141,7 @@ dependencies = [
  "chrono",
  "libc",
  "log",
- "rshogi-core 0.2.4 (git+https://github.com/SH11235/rshogi.git?rev=afd941abfb60488df89ac6abbe060aba170ef09c)",
+ "rshogi-core",
  "rshogi-csa",
  "rshogi-csa-server",
  "rustls",
@@ -3177,7 +3160,7 @@ dependencies = [
  "chrono",
  "rand 0.9.4",
  "rand_xoshiro",
- "rshogi-core 0.2.4 (git+https://github.com/SH11235/rshogi.git?rev=afd941abfb60488df89ac6abbe060aba170ef09c)",
+ "rshogi-core",
  "rshogi-csa",
  "serde",
  "serde_json",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 # rshogi-csa-client (git only, crates.io 未公開) と同一ソースに統一して
 # Cargo.lock 上の rshogi-core 重複 (registry 版 vs git 版) を解消する。
+# rev を更新する場合は必ず rshogi-csa-client の rev と同じ値に揃えること。
 rshogi-core = { git = "https://github.com/SH11235/rshogi.git", rev = "afd941abfb60488df89ac6abbe060aba170ef09c" }
 rshogi-csa-client = { git = "https://github.com/SH11235/rshogi.git", rev = "afd941abfb60488df89ac6abbe060aba170ef09c", default-features = false, features = ["tcp", "websocket"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,7 +25,9 @@ tauri-plugin-dialog = "2"
 tauri-plugin-store = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-rshogi-core = "0.2"
+# rshogi-csa-client (git only, crates.io 未公開) と同一ソースに統一して
+# Cargo.lock 上の rshogi-core 重複 (registry 版 vs git 版) を解消する。
+rshogi-core = { git = "https://github.com/SH11235/rshogi.git", rev = "afd941abfb60488df89ac6abbe060aba170ef09c" }
 rshogi-csa-client = { git = "https://github.com/SH11235/rshogi.git", rev = "afd941abfb60488df89ac6abbe060aba170ef09c", default-features = false, features = ["tcp", "websocket"] }
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 toml = "0.8"


### PR DESCRIPTION
## Summary
PR #41 ([レビューコメント](https://github.com/SH11235/ramu-shogi/pull/41#discussion_r3167327874)) で指摘された `Cargo.lock` 上の `rshogi-core` 二重ソース問題を解消する。

### 背景
`apps/desktop/src-tauri/Cargo.lock` で `rshogi-core 0.2.4` が以下の 2 ソースから参照されていた:

| ソース | 経由 |
|---|---|
| `registry+https://github.com/rust-lang/crates.io-index` | `desktop` の直接依存 (`Cargo.toml` の `rshogi-core = "0.2"`) |
| `git+https://github.com/SH11235/rshogi.git?rev=afd941...` | `desktop` → `rshogi-csa-client` (git only) → `rshogi-core` (path dep) |

Cargo はこれらを別パッケージとして扱うため、
- `rshogi-core` が **2 回コンパイル** される (ビルド時間 + バイナリサイズ増)
- registry 版の型と git 版の型はクレート境界で **互換性なし** (現状コードでは顕在化していないが潜在リスク)

### 変更内容
`rshogi-csa-client` は crates.io 未公開 (git のみ) のため、**desktop 側の `rshogi-core` を git rev に揃える**のが唯一の統一手段。

```diff
- rshogi-core = "0.2"
+ rshogi-core = { git = "https://github.com/SH11235/rshogi.git", rev = "afd941abfb60488df89ac6abbe060aba170ef09c" }
```

`rev` は `rshogi-csa-client` と完全一致させて Cargo.lock 上の単一エントリに収束させる。

### 検証
- `cargo tree -p rshogi-core` → 単一エントリ (git rev) のみ
- `cargo check --workspace` → ✅ 成功
- `cargo test --release --workspace --test-threads=2` → ✅ 全テスト成功 (0 failed)
- `cargo audit` → 残存警告は本 PR スコープ外 (Tauri 上流の `rand 0.7.3` / GTK3 unmaintained 等)
- Cargo.lock 差分: -23 行 (rshogi-core registry エントリの削除)

## Test plan
- [x] `cargo check --workspace` 成功
- [x] `cargo test --release --workspace -- --test-threads=2` 成功
- [x] Cargo.lock 上の `rshogi-core` エントリが 1 つに統一
- [ ] CI (Rust CI / test-tauri / lint-tauri) が green になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)