### PR TITLE
feat(csa): CSA 対局 UI で SFEN/棋譜の visual 盤面表示を実装する

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -13,6 +13,8 @@
         "lint": "pnpm --workspace-root exec biome check .",
         "lint:fix": "pnpm --workspace-root exec biome check --write --files-ignore-unknown=true",
         "lint:fix:unsafe": "pnpm --workspace-root exec biome check --write --unsafe --files-ignore-unknown=true",
+        "typecheck": "tsc -p tsconfig.json --noEmit",
+        "test": "vitest run",
         "tauri": "tauri"
     },
     "dependencies": {
@@ -30,12 +32,15 @@
     "devDependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "@tauri-apps/cli": "^2",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.2",
         "babel-plugin-react-compiler": "^1.0.0",
+        "happy-dom": "^20.0.11",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
-        "vite": "^7.3.0"
+        "vite": "^7.3.0",
+        "vitest": "^4.0.15"
     }
 }

--- a/apps/desktop/src/components/csa/CsaBoardDisplay.test.tsx
+++ b/apps/desktop/src/components/csa/CsaBoardDisplay.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * CsaBoardDisplay のテスト。
+ *
+ * `setPositionServiceFactory` で fake `PositionService` を差し込み、
+ * SFEN 解析の loading / 成功 / エラーパス、初期局面フォールバック、
+ * SFEN 切替時の挙動、後手視点反転、最終手導出を検証する。
+ */
+import {
+    createEmptyHands,
+    createInitialBoard,
+    type PositionService,
+    type PositionState,
+    setPositionServiceFactory,
+} from "@shogi/app-core";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ShogiBoard / HandPiecesDisplay は実 DOM 描画ではなく props 検証のため軽量モックする
+const shogiBoardMock = vi.hoisted(() => vi.fn());
+const handPiecesDisplayMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@shogi/ui", () => ({
+    boardToGrid: vi.fn(() => [[{ id: "1a", piece: null }]]),
+    ShogiBoard: (props: Record<string, unknown>): ReactElement => {
+        shogiBoardMock(props);
+        return <div data-testid="shogi-board" />;
+    },
+    HandPiecesDisplay: (props: Record<string, unknown>): ReactElement => {
+        handPiecesDisplayMock(props);
+        return <div data-testid={`hand-${props.owner as string}`} />;
+    },
+}));
+
+import { CsaBoardDisplay } from "./CsaBoardDisplay";
+
+const STARTPOS_SFEN = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+function makeInitialPosition(): PositionState {
+    return {
+        board: createInitialBoard(),
+        hands: createEmptyHands(),
+        turn: "sente",
+        ply: 1,
+    };
+}
+
+interface FakeServiceOptions {
+    parseSfen?: (sfen: string) => Promise<PositionState>;
+}
+
+function makeFakeService(options: FakeServiceOptions = {}): {
+    service: PositionService;
+    parseSfen: ReturnType<typeof vi.fn>;
+} {
+    const parseSfen = vi.fn(
+        options.parseSfen ?? ((_sfen: string) => Promise.resolve(makeInitialPosition())),
+    );
+    const service: PositionService = {
+        getInitialBoard: () => Promise.resolve(makeInitialPosition()),
+        parseSfen: (sfen: string) => parseSfen(sfen),
+        boardToSfen: () => Promise.resolve("startpos"),
+        getLegalMoves: () => Promise.resolve([]),
+        replayMovesStrict: (_sfen, moves) =>
+            Promise.resolve({
+                applied: moves,
+                lastPly: moves.length,
+                position: makeInitialPosition(),
+            }),
+    };
+    return { service, parseSfen };
+}
+
+function installFakeService(options: FakeServiceOptions = {}): {
+    parseSfen: ReturnType<typeof vi.fn>;
+} {
+    const { service, parseSfen } = makeFakeService(options);
+    setPositionServiceFactory(() => service);
+    return { parseSfen };
+}
+
+describe("CsaBoardDisplay", () => {
+    beforeEach(() => {
+        shogiBoardMock.mockClear();
+        handPiecesDisplayMock.mockClear();
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("renders_loading_state_initially: parseSfen pending 中は読込中表示", () => {
+        // never resolve → loading 状態のまま
+        installFakeService({ parseSfen: () => new Promise<PositionState>(() => {}) });
+        render(<CsaBoardDisplay sfen={STARTPOS_SFEN} lastMoveUsi={null} myColor="black" />);
+
+        expect(screen.getByText("局面読込中...")).toBeTruthy();
+        expect(screen.queryByTestId("shogi-board")).toBeNull();
+    });
+
+    it("renders_board_after_parse_sfen_resolves: parseSfen resolve 後に ShogiBoard を描画", async () => {
+        installFakeService();
+        render(<CsaBoardDisplay sfen={STARTPOS_SFEN} lastMoveUsi={null} myColor="black" />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId("shogi-board")).toBeTruthy();
+        });
+        expect(screen.queryByText("局面読込中...")).toBeNull();
+    });
+
+    it("renders_error_state_when_parse_sfen_rejects: reject 時はエラー表示", async () => {
+        installFakeService({ parseSfen: () => Promise.reject(new Error("invalid sfen")) });
+        render(<CsaBoardDisplay sfen="garbage" lastMoveUsi={null} myColor="black" />);
+
+        await waitFor(() => {
+            expect(screen.getByText(/SFEN 解析エラー/)).toBeTruthy();
+        });
+        expect(screen.queryByTestId("shogi-board")).toBeNull();
+    });
+
+    it("falls_back_to_startpos_when_sfen_null: sfen=null で STARTPOS_SFEN を渡す", async () => {
+        const { parseSfen } = installFakeService();
+        render(<CsaBoardDisplay sfen={null} lastMoveUsi={null} myColor="black" />);
+
+        await waitFor(() => {
+            expect(parseSfen).toHaveBeenCalledWith(STARTPOS_SFEN);
+        });
+    });
+
+    it("keeps_previous_position_when_sfen_changes: SFEN 切替中もロードフラッシュなし", async () => {
+        // 1 回目: 即時 resolve、2 回目: 制御可能な promise で保留
+        type ResolveFn = (p: PositionState) => void;
+        const resolveSecondRef: { current: ResolveFn | null } = { current: null };
+        const parseSfenImpl = vi
+            .fn<(sfen: string) => Promise<PositionState>>()
+            .mockImplementationOnce(() => Promise.resolve(makeInitialPosition()))
+            .mockImplementationOnce(
+                () =>
+                    new Promise<PositionState>((resolve) => {
+                        resolveSecondRef.current = resolve;
+                    }),
+            );
+        installFakeService({ parseSfen: parseSfenImpl });
+
+        const { rerender } = render(
+            <CsaBoardDisplay sfen={STARTPOS_SFEN} lastMoveUsi={null} myColor="black" />,
+        );
+        await waitFor(() => expect(screen.getByTestId("shogi-board")).toBeTruthy());
+
+        // 別 SFEN に切替
+        rerender(
+            <CsaBoardDisplay
+                sfen="lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL w - 2"
+                lastMoveUsi="7g7f"
+                myColor="black"
+            />,
+        );
+
+        // 2 回目の parseSfen が pending 中でも、旧 position がそのまま残り loading に戻らない
+        expect(screen.queryByText("局面読込中...")).toBeNull();
+        expect(screen.getByTestId("shogi-board")).toBeTruthy();
+
+        // 後始末: pending promise を resolve し、state 反映を待つ
+        // (act warning 回避のため waitFor で state 更新を呑み込む)
+        resolveSecondRef.current?.(makeInitialPosition());
+        await waitFor(() => expect(parseSfenImpl).toHaveBeenCalledTimes(2));
+    });
+
+    it("flips_board_for_white_player: myColor='white' で flipBoard=true", async () => {
+        installFakeService();
+        render(<CsaBoardDisplay sfen={STARTPOS_SFEN} lastMoveUsi={null} myColor="white" />);
+
+        await waitFor(() => expect(shogiBoardMock).toHaveBeenCalled());
+        const lastCallProps = shogiBoardMock.mock.calls.at(-1)?.[0] as { flipBoard?: boolean };
+        expect(lastCallProps.flipBoard).toBe(true);
+    });
+
+    it("derives_last_move_from_usi: lastMoveUsi='7g7f' で from/to を導出", async () => {
+        installFakeService();
+        render(<CsaBoardDisplay sfen={STARTPOS_SFEN} lastMoveUsi="7g7f" myColor="black" />);
+
+        await waitFor(() => expect(shogiBoardMock).toHaveBeenCalled());
+        const lastCallProps = shogiBoardMock.mock.calls.at(-1)?.[0] as {
+            lastMove?: { from?: string; to?: string };
+        };
+        expect(lastCallProps.lastMove).toEqual({ from: "7g", to: "7f" });
+    });
+});

--- a/apps/desktop/src/components/csa/CsaBoardDisplay.tsx
+++ b/apps/desktop/src/components/csa/CsaBoardDisplay.tsx
@@ -13,7 +13,7 @@ import { type ReactElement, useEffect, useState } from "react";
 
 const STARTPOS_SFEN = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
 
-export interface CsaBoardDisplayProps {
+interface CsaBoardDisplayProps {
     /** 表示対象 SFEN (null/未到着時は初期局面でフォールバック) */
     sfen: string | null;
     /** 直近の指し手 USI (lastMove ハイライト用) */

--- a/apps/desktop/src/components/csa/CsaBoardDisplay.tsx
+++ b/apps/desktop/src/components/csa/CsaBoardDisplay.tsx
@@ -1,0 +1,102 @@
+/**
+ * CSA 対局用の visual 盤面表示コンポーネント。
+ *
+ * `sfen` を `getPositionService().parseSfen()` で `PositionState` に変換し、
+ * `ShogiBoard` + `HandPiecesDisplay` で描画する。
+ *
+ * sfen が null (game_summary 直後 〜 1 手目前) の場合は STARTPOS_SFEN にフォールバック。
+ * 駒落ち局面の初期表示は本実装の scope 外 (game_summary event payload 拡張が必要)。
+ */
+import { deriveLastMove, getPositionService, type PositionState } from "@shogi/app-core";
+import { boardToGrid, HandPiecesDisplay, ShogiBoard } from "@shogi/ui";
+import { type ReactElement, useEffect, useState } from "react";
+
+const STARTPOS_SFEN = "lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPPP/1B5R1/LNSGKGSNL b - 1";
+
+export interface CsaBoardDisplayProps {
+    /** 表示対象 SFEN (null/未到着時は初期局面でフォールバック) */
+    sfen: string | null;
+    /** 直近の指し手 USI (lastMove ハイライト用) */
+    lastMoveUsi: string | null;
+    /** 自分の手番 ("white" のときは盤面反転) */
+    myColor: "black" | "white" | null;
+}
+
+/**
+ * SFEN を非同期解析し ShogiBoard で描画するコンポーネント。
+ * SFEN 切替時は旧 position を残したまま新 position を反映するため、ロード中フラッシュが発生しない。
+ */
+export function CsaBoardDisplay({
+    sfen,
+    lastMoveUsi,
+    myColor,
+}: CsaBoardDisplayProps): ReactElement {
+    const targetSfen = sfen ?? STARTPOS_SFEN;
+    const [position, setPosition] = useState<PositionState | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setError(null);
+        getPositionService()
+            .parseSfen(targetSfen)
+            .then((pos) => {
+                if (!cancelled) setPosition(pos);
+            })
+            .catch((e: unknown) => {
+                if (!cancelled) setError(e instanceof Error ? e.message : String(e));
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [targetSfen]);
+
+    if (error) {
+        return <div className="text-xs text-destructive">SFEN 解析エラー: {error}</div>;
+    }
+    if (!position) {
+        return <div className="text-xs text-muted-foreground">局面読込中...</div>;
+    }
+
+    const grid = boardToGrid(position.board);
+    const derived = lastMoveUsi ? deriveLastMove(lastMoveUsi) : undefined;
+    // ShogiBoard の lastMove は { from?: string | null; to?: string | null }
+    // app-core の LastMove (from?: Square | null; to?: Square) を変換する
+    const lastMove = derived ? { from: derived.from ?? undefined, to: derived.to } : undefined;
+    const flipBoard = myColor === "white";
+
+    // flipBoard 時は ShogiBoard の grid 自体は反転しない（ShogiBoard 内部で駒の向きのみ反転）
+    // ため、上下の HandPiecesDisplay の owner も flipBoard で入れ替える
+    const topOwner = flipBoard ? "sente" : "gote";
+    const bottomOwner = flipBoard ? "gote" : "sente";
+
+    return (
+        <div className="flex flex-col items-center gap-2" data-testid="csa-board-display">
+            {/* 上側 (相手) の持ち駒 */}
+            <HandPiecesDisplay
+                owner={topOwner}
+                hand={position.hands[topOwner]}
+                selectedPiece={null}
+                isActive={false}
+                onHandSelect={noop}
+                isMatchRunning
+                flipBoard={flipBoard}
+                size="medium"
+            />
+            <ShogiBoard grid={grid} lastMove={lastMove} flipBoard={flipBoard} showBoardLabels />
+            {/* 下側 (自分) の持ち駒 */}
+            <HandPiecesDisplay
+                owner={bottomOwner}
+                hand={position.hands[bottomOwner]}
+                selectedPiece={null}
+                isActive={false}
+                onHandSelect={noop}
+                isMatchRunning
+                flipBoard={flipBoard}
+                size="medium"
+            />
+        </div>
+    );
+}
+
+const noop = (): void => {};

--- a/apps/desktop/src/components/csa/CsaGameView.tsx
+++ b/apps/desktop/src/components/csa/CsaGameView.tsx
@@ -3,7 +3,7 @@
  *
  * useCsaGame フックを使用し、対局ステータスに応じた UI を表示する。
  * idle: 設定パネル / connecting: スピナー / waiting: 対局情報 /
- * playing: 盤面+探索情報 / finished: 結果 / error: エラー表示
+ * playing: visual 盤面 + 探索情報 / finished: 結果 / error: エラー表示
  *
  * resume 経路では `resumeState.lastSfen` を盤面表示の起点として使用する。
  */
@@ -12,6 +12,7 @@ import { Button } from "@shogi/ui/components/button";
 import { Spinner } from "@shogi/ui/components/spinner";
 import type { ReactElement } from "react";
 
+import { CsaBoardDisplay } from "./CsaBoardDisplay";
 import { CsaSettingsPanel } from "./CsaSettingsPanel";
 import type { CsaGameState, CsaResumeState, CsaSearchInfo, UseCsaGameReturn } from "./useCsaGame";
 import { useCsaGame } from "./useCsaGame";
@@ -177,14 +178,16 @@ function PlayingView({
                 </div>
             )}
 
-            {/* 盤面（テキスト表示）— resume 時は last_sfen が起点 */}
+            {/* 盤面（visual 表示）— resume 時は last_sfen が起点 */}
             <div className="bg-muted/20 rounded-lg p-3">
                 <p className="text-xs text-muted-foreground mb-1">
                     局面 (手数: {state.moves.length})
                 </p>
-                <pre className="text-xs font-mono text-wafuu-sumi break-all whitespace-pre-wrap">
-                    {state.sfen ?? "（初期局面）"}
-                </pre>
+                <CsaBoardDisplay
+                    sfen={state.sfen}
+                    lastMoveUsi={state.moves.at(-1) ?? null}
+                    myColor={state.myColor}
+                />
             </div>
 
             {/* 指し手履歴（直近5手） */}

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+    test: {
+        environment: "happy-dom",
+        globals: true,
+    },
+    resolve: {
+        alias: [
+            {
+                find: /^@shogi\/app-core$/,
+                replacement: path.resolve(rootDir, "../../packages/app-core/src"),
+            },
+            {
+                find: /^@shogi\/design-system$/,
+                replacement: path.resolve(rootDir, "../../packages/design-system/src"),
+            },
+            {
+                find: /^@shogi\/ui$/,
+                replacement: path.resolve(rootDir, "../../packages/ui/src"),
+            },
+            {
+                find: /^@shogi\/engine-client$/,
+                replacement: path.resolve(rootDir, "../../packages/engine-client/src"),
+            },
+            {
+                find: /^@shogi\/engine-tauri$/,
+                replacement: path.resolve(rootDir, "../../packages/engine-tauri/src"),
+            },
+            {
+                find: /^@shogi\/match-client$/,
+                replacement: path.resolve(rootDir, "../../packages/match-client/src"),
+            },
+        ],
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.9.4
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/react':
         specifier: ^19.2.7
         version: 19.2.7
@@ -78,6 +81,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
+      happy-dom:
+        specifier: ^20.0.11
+        version: 20.7.0
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
@@ -87,6 +93,9 @@ importers:
       vite:
         specifier: ^7.3.0
         version: 7.3.0(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^4.0.15
+        version: 4.0.15(@types/node@24.10.1)(happy-dom@20.7.0)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/web:
     dependencies:
@@ -4773,7 +4782,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
       '@testing-library/dom': 10.4.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)


### PR DESCRIPTION
## Summary

- `CsaBoardDisplay` コンポーネントを新設し、CSA 対局の `PlayingView` で SFEN テキスト表示の代わりに `ShogiBoard` + `HandPiecesDisplay` で視覚的に盤面を描画するようにした。
- `sfen` が null (game_summary 直後) の場合は startpos にフォールバックし、`myColor === "white"` のときは盤面を反転、直近指し手 (`state.moves.at(-1)`) は `lastMoveUsi` ハイライトとして表示する。
- desktop アプリに vitest 設定 (test / typecheck script、vitest.config.ts、`@testing-library/react` / `happy-dom` / `vitest` devDeps) を追加し、`CsaBoardDisplay.test.tsx` で 7 ケース (loading / 成功 / エラー / null フォールバック / SFEN 切替時の position 保持 / 後手反転 / 最終手導出) を検証する。

## Implementation notes

- `getPositionService().parseSfen()` の解析結果は state に保持し、SFEN 切替中も旧 position を残して loading フラッシュを抑止する (`OnlineGameView` と同じアプローチ)。
- `LastMove` (app-core: `from?: Square | null; to?: Square`) → `ShogiBoard.lastMove` (`from?: string | null; to?: string | null`) は `PCBoardContent` 既存実装と同じく `from: derived.from ?? undefined` で変換する。
- `HandPiecesDisplay` は `PvPreviewDialog` の view-only 用法 (`isActive=false`, `onHandSelect=noop`, `selectedPiece=null`) を踏襲。CSA 対局中は持ち駒のうち 0 枚の駒種を非表示にしたいため `isMatchRunning` を立て、サイズはモバイル親和性を優先して `medium`。
- 駒落ち局面の初期表示は scope 外（game_summary event payload に handicap 情報がまだ流れていないため）。

## Bundle size

baseline `dist/assets/index-*.js`: 888.07 kB → with changes: 889.93 kB (+1.86 kB)。+200 kB 閾値を十分下回る。

## Test plan

- [x] `pnpm --filter desktop typecheck`
- [x] `pnpm --filter desktop lint`
- [x] `pnpm --filter desktop test` (7 / 7 passed)
- [x] `pnpm --filter desktop build` (dev build, +1.86 kB)
- [ ] CSA 通信対局を実機 (`pnpm tauri dev`) で開始し、`PlayingView` で盤面が SFEN テキストではなく駒画像で描画されること、後手着席時に flip されること、最後の指し手に highlight が乗ることを目視確認

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)