### PR TITLE
fix: CSA Worker 由来 game_id を viewer で表示できるようにする (rshogi #613)

### DIFF
--- a/apps/web/src/pages/games/PublicGamePage.test.tsx
+++ b/apps/web/src/pages/games/PublicGamePage.test.tsx
@@ -1,0 +1,61 @@
+import type { GameRecordDetail } from "@shogi/api-contract";
+import { describe, expect, test, vi } from "vitest";
+import { resolveMoves } from "./PublicGamePage";
+
+function makeGame(overrides: Partial<GameRecordDetail> = {}): GameRecordDetail {
+    return {
+        id: "test-id",
+        roomId: null,
+        source: "online_room",
+        visibility: "public",
+        publicId: null,
+        status: "finished",
+        result: null,
+        participants: [],
+        createdAt: "2026-01-01T00:00:00Z",
+        finishedAt: null,
+        initialSfen: "startpos",
+        metadata: null,
+        moves: [],
+        kifuText: "",
+        startedAt: null,
+        ...overrides,
+    };
+}
+
+describe("resolveMoves", () => {
+    test("既存 moves があればそのまま返す", () => {
+        const moves = ["7g7f", "3c3d"];
+        expect(resolveMoves(makeGame({ moves }))).toBe(moves);
+    });
+
+    test("source が csa_relay 以外なら moves (空配列) を返す", () => {
+        expect(resolveMoves(makeGame({ source: "online_room", moves: [] }))).toEqual([]);
+    });
+
+    test("csa_relay でも kifuText が空なら moves を返す", () => {
+        const game = makeGame({ source: "csa_relay", kifuText: "" });
+        expect(resolveMoves(game)).toEqual([]);
+    });
+
+    test("csa_relay + 通常手で USI moves に変換", () => {
+        const csa = `V2.2\nN+Sente\nN-Gote\nPI\n+\n+7776FU\n-3334FU`;
+        const moves = resolveMoves(makeGame({ source: "csa_relay", kifuText: csa }));
+        expect(moves).toEqual(["7g7f", "3c3d"]);
+    });
+
+    test("csa_relay + 駒打ちを USI drop 形式に変換", () => {
+        const csa = `V2.2\nPI\n+\n+0055FU`;
+        const moves = resolveMoves(makeGame({ source: "csa_relay", kifuText: csa }));
+        expect(moves).toContain("P*5e");
+    });
+
+    test("不正な kifuText でも例外が漏れずフォールバックで [] を返す", () => {
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+        // `parseCsaMoves` の throw 経路は app-core 側 test でカバー済。ここでは
+        // `resolveMoves` が parse 失敗・無効入力で空配列フォールバックする挙動のみ確認する。
+        const moves = resolveMoves(makeGame({ source: "csa_relay", kifuText: "garbage" }));
+        expect(moves).toEqual([]);
+        errorSpy.mockRestore();
+    });
+});

--- a/apps/web/src/pages/games/PublicGamePage.tsx
+++ b/apps/web/src/pages/games/PublicGamePage.tsx
@@ -1,4 +1,5 @@
 import type { GameRecordDetail } from "@shogi/api-contract";
+import { parseCsaMoves } from "@shogi/app-core";
 import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { EngineOption } from "@shogi/ui";
 import { ShogiMatch } from "@shogi/ui";
@@ -56,8 +57,22 @@ function GameInfoPanel({ game }: { game: GameRecordDetail }): ReactElement {
     );
 }
 
+// CSA Worker (`source: 'csa_relay'`) 由来の棋譜は backend が USI moves を持たない
+// ため `moves: []` を返す (issue #613)。viewer 側で `kifuText` (CSA V2 本文) を
+// パースして USI moves を再構築する。
+function resolveMoves(game: GameRecordDetail): string[] {
+    if (game.moves.length > 0) return game.moves;
+    if (game.source !== "csa_relay" || !game.kifuText) return game.moves;
+    try {
+        return parseCsaMoves(game.kifuText);
+    } catch {
+        return [];
+    }
+}
+
 export default function PublicGamePage(): ReactElement {
     const game = routeApi.useLoaderData() as GameRecordDetail;
+    const moves = resolveMoves(game);
 
     return (
         <>
@@ -75,7 +90,7 @@ export default function PublicGamePage(): ReactElement {
                     }}
                     initialReview={{
                         sfen: game.initialSfen,
-                        moves: game.moves,
+                        moves,
                     }}
                     reviewMode={true}
                     reviewLeftContent={<GameInfoPanel game={game} />}

--- a/apps/web/src/pages/games/PublicGamePage.tsx
+++ b/apps/web/src/pages/games/PublicGamePage.tsx
@@ -60,12 +60,15 @@ function GameInfoPanel({ game }: { game: GameRecordDetail }): ReactElement {
 // CSA Worker (`source: 'csa_relay'`) 由来の棋譜は backend が USI moves を持たない
 // ため `moves: []` を返す (issue #613)。viewer 側で `kifuText` (CSA V2 本文) を
 // パースして USI moves を再構築する。
-function resolveMoves(game: GameRecordDetail): string[] {
+export function resolveMoves(game: GameRecordDetail): string[] {
     if (game.moves.length > 0) return game.moves;
     if (game.source !== "csa_relay" || !game.kifuText) return game.moves;
     try {
         return parseCsaMoves(game.kifuText);
-    } catch {
+    } catch (err) {
+        // CSA パース失敗は viewer 表示を空盤面で起動させる仕様だが、原因追跡のため
+        // 本番でも console に出力する。
+        console.error("[PublicGamePage] CSA moves parse failed:", err);
         return [];
     }
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,7 +8,13 @@ import type {
     ListPublicGamesResponse,
     RoomInfo,
 } from "@shogi/api-contract";
-import { createRootRoute, createRoute, createRouter, useNavigate } from "@tanstack/react-router";
+import {
+    createRootRoute,
+    createRoute,
+    createRouter,
+    redirect,
+    useNavigate,
+} from "@tanstack/react-router";
 import App from "./App";
 import { AppProviders } from "./AppProviders";
 import AuthPage from "./pages/auth/AuthPage";
@@ -82,11 +88,22 @@ const gamesRoute = createRoute({
     loader: fetchGamesLoaderData,
 });
 
+// CSA Worker (rshogi-csa-server-workers) が出力する game_id (`<room_id>-<unix_ms>`)
+// は UUID ではないため、auth 必須の `/api/games/<id>` ではなく公開ルート
+// `/public/games/<id>` 経由で取得する (issue #613)。
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 const gameDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/games/$gameId",
     component: GameDetailPage,
     loader: async ({ params: { gameId } }) => {
+        if (!UUID_RE.test(gameId)) {
+            throw redirect({
+                to: "/public/games/$publicId",
+                params: { publicId: gameId },
+            });
+        }
         const response = await fetch(`/api/games/${gameId}`, {
             credentials: "same-origin",
         });

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -88,9 +88,10 @@ const gamesRoute = createRoute({
     loader: fetchGamesLoaderData,
 });
 
-// CSA Worker (rshogi-csa-server-workers) が出力する game_id (`<room_id>-<unix_ms>`)
-// は UUID ではないため、auth 必須の `/api/games/<id>` ではなく公開ルート
-// `/public/games/<id>` 経由で取得する (issue #613)。
+// UUID 形式 = auth 必須の `/api/games/<id>` (online_room / local_app / import)。
+// 非 UUID 形式 = auth 不要の `/public/games/<id>` (csa_relay: `<room_id>-<unix_ms>`)。
+// この対応関係が変わる場合 (非 UUID の auth 必須 ID が増える / UUID の public ID が
+// 出る等) はルーティング戦略の見直しが必要 (issue #613)。
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const gameDetailRoute = createRoute({

--- a/packages/api-contract/src/generated/openapi.json
+++ b/packages/api-contract/src/generated/openapi.json
@@ -340,9 +340,7 @@
                     },
                     "gameId": {
                         "type": "string",
-                        "minLength": 1,
-                        "maxLength": 128,
-                        "pattern": "^[A-Za-z0-9_-]+$"
+                        "format": "uuid"
                     },
                     "label": {
                         "type": ["string", "null"]

--- a/packages/api-contract/src/generated/openapi.json
+++ b/packages/api-contract/src/generated/openapi.json
@@ -128,7 +128,9 @@
                 "properties": {
                     "id": {
                         "type": "string",
-                        "format": "uuid"
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "pattern": "^[A-Za-z0-9_-]+$"
                     },
                     "roomId": {
                         "type": ["string", "null"]
@@ -176,7 +178,7 @@
             },
             "GameRecordSource": {
                 "type": "string",
-                "enum": ["online_room", "local_app", "import"]
+                "enum": ["online_room", "local_app", "import", "csa_relay"]
             },
             "GameRecordVisibility": {
                 "type": "string",
@@ -338,7 +340,9 @@
                     },
                     "gameId": {
                         "type": "string",
-                        "format": "uuid"
+                        "minLength": 1,
+                        "maxLength": 128,
+                        "pattern": "^[A-Za-z0-9_-]+$"
                     },
                     "label": {
                         "type": ["string", "null"]
@@ -993,7 +997,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "format": "uuid"
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "gameId",
@@ -1042,7 +1048,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "format": "uuid"
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "gameId",
@@ -1111,7 +1119,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "format": "uuid"
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "gameId",
@@ -1158,7 +1168,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "format": "uuid"
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "gameId",
@@ -1227,7 +1239,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "format": "uuid"
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "gameId",
@@ -1742,8 +1756,9 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 8,
-                            "maxLength": 32
+                            "minLength": 1,
+                            "maxLength": 128,
+                            "pattern": "^[A-Za-z0-9_-]+$"
                         },
                         "required": true,
                         "name": "publicId",

--- a/packages/api-contract/src/generated/openapi.json
+++ b/packages/api-contract/src/generated/openapi.json
@@ -995,7 +995,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },
@@ -1046,7 +1046,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },
@@ -1117,7 +1117,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },
@@ -1166,7 +1166,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },
@@ -1237,7 +1237,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },
@@ -1754,7 +1754,7 @@
                     {
                         "schema": {
                             "type": "string",
-                            "minLength": 1,
+                            "minLength": 8,
                             "maxLength": 128,
                             "pattern": "^[A-Za-z0-9_-]+$"
                         },

--- a/packages/api-contract/src/generated/schema.ts
+++ b/packages/api-contract/src/generated/schema.ts
@@ -374,7 +374,6 @@ export interface components {
             games: components["schemas"]["GameRecordSummary"][];
         };
         GameRecordSummary: {
-            /** Format: uuid */
             id: string;
             roomId: string | null;
             source: components["schemas"]["GameRecordSource"];
@@ -387,7 +386,7 @@ export interface components {
             finishedAt: string | null;
         };
         /** @enum {string} */
-        GameRecordSource: "online_room" | "local_app" | "import";
+        GameRecordSource: "online_room" | "local_app" | "import" | "csa_relay";
         /** @enum {string} */
         GameRecordVisibility: "private" | "unlisted" | "public";
         /** @enum {string} */
@@ -426,7 +425,6 @@ export interface components {
         AnalysisSnapshotSummary: {
             /** Format: uuid */
             id: string;
-            /** Format: uuid */
             gameId: string;
             label: string | null;
             createdAt: string;

--- a/packages/api-contract/src/generated/schema.ts
+++ b/packages/api-contract/src/generated/schema.ts
@@ -425,6 +425,7 @@ export interface components {
         AnalysisSnapshotSummary: {
             /** Format: uuid */
             id: string;
+            /** Format: uuid */
             gameId: string;
             label: string | null;
             createdAt: string;

--- a/packages/app-core/src/game/csa.test.ts
+++ b/packages/app-core/src/game/csa.test.ts
@@ -105,6 +105,26 @@ PI
         expect(moves[1]).toBe("3c3d");
     });
 
+    it("駒打ち (from=00) を USI drop 形式に変換する", () => {
+        const initialBoard = createInitialBoard();
+        // 持ち駒として歩を sente に持たせるため 7g の歩を取り除く前提のシナリオは
+        // 単純化のため省略し、空マスへの drop が parse されることだけを検証する。
+        initialBoard["5e"] = null;
+
+        const csa = `V2.2
+N+Sente
+N-Gote
+PI
++
++0055FU
+-0044KA`;
+
+        const moves = parseCsaMoves(csa, initialBoard);
+
+        expect(moves).toContain("P*5e");
+        expect(moves).toContain("B*4d");
+    });
+
     it("成りの手を正しく解析する", () => {
         const initialBoard = createInitialBoard();
         // 歩を1cに配置

--- a/packages/app-core/src/game/csa.ts
+++ b/packages/app-core/src/game/csa.ts
@@ -51,6 +51,17 @@ const PROMOTED_FROM_CODE: Record<string, PieceType | undefined> = {
     RY: "R",
 };
 
+// CSA piece code → USI 駒打ち文字。駒打ち (`+0077FU` 等) を `P*7g` に変換する際に使う。
+const DROP_PIECE_FROM_CODE: Record<string, string | undefined> = {
+    FU: "P",
+    KY: "L",
+    KE: "N",
+    GI: "S",
+    KI: "G",
+    KA: "B",
+    HI: "R",
+};
+
 interface CsaMetadata {
     senteName?: string;
     goteName?: string;
@@ -113,12 +124,25 @@ export function parseCsaMoves(contents: string, initialBoard?: BoardState): stri
         if (line.length < 7) {
             continue;
         }
-        const fromSquare = fromCsaSquare(line.slice(1, 3));
+        const fromRaw = line.slice(1, 3);
         const toSquare = fromCsaSquare(line.slice(3, 5));
-        if (!fromSquare || !toSquare) {
+        if (!toSquare) {
             continue;
         }
         const pieceCode = line.slice(5, 7).toUpperCase();
+        // 駒打ち: CSA は from = "00"。USI `P*7g` 形式に変換し applyMove に渡す。
+        if (fromRaw === "00") {
+            const dropPiece = DROP_PIECE_FROM_CODE[pieceCode];
+            if (!dropPiece) continue;
+            const move = `${dropPiece}*${toSquare}`;
+            moves.push(move);
+            board = applyMove(board, move);
+            continue;
+        }
+        const fromSquare = fromCsaSquare(fromRaw);
+        if (!fromSquare) {
+            continue;
+        }
         const targetPiece = board[fromSquare];
         if (!targetPiece) {
             continue;


### PR DESCRIPTION
## Summary
- `/games/<id>` loader で UUID 以外を `/public/games/<id>` に redirect し、CSA Worker 由来の `<room_id>-<unix_ms>` 形式を auth 不要ルートで表示
- `PublicGamePage`: `source === 'csa_relay'` かつ `moves` が空のとき `parseCsaMoves(kifuText)` で USI moves を再構築
- `packages/app-core` の `parseCsaMoves` に駒打ち分岐 (CSA `from === "00"` → USI `P*5e`) を追加 (重要: CSA 棋譜の大半で駒打ちが含まれるため、これがないと viewer 表示が崩壊する)
- `resolveMoves` 単体テスト 6 件 + parseCsaMoves 駒打ちテスト 1 件追加
- `packages/api-contract` 再生成 (backend の `csa_relay` enum / publicId 緩和を反映)

Closes SH11235/rshogi#613

関連 PR: SH11235/ramu-shogi-backend#1

## 設計判断
- 代替 A: 既存 `/games/<id>` ルートを維持しつつ UUID 判定で公開ルートに redirect する形で最小侵襲化
- CSA → USI 変換はフロント側 `@shogi/app-core` の `parseCsaMoves` を再利用 (backend に CSA パーサを持ち込まない)
- `parseCsaMoves` 例外時は `console.error` を出して空配列フォールバック

## Test plan
- [x] `pnpm typecheck` (apps/web / packages/app-core / packages/api-contract) green
- [x] `pnpm test` (app-core 131/131 / web 21/21、RoomPage の事前環境問題は本 PR 無関係)

🤖 Generated with [Claude Code](https://claude.com/claude-code)