### PR TITLE
feat(infra): ROOM_DO_SECRET を Pulumi ESC + secret-sync workflow で管理 (Phase 2-D 補完)

### DIFF
--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -1,0 +1,227 @@
+# ramu-shogi (frontend Worker) secret 同期 workflow (Phase 2-D 補完 / issue #52)。
+#
+# Cloudflare IaC umbrella rshogi #675 の Phase 2-D 補完。
+# **secret 値の single source of truth を Pulumi ESC に集約**し、本 workflow が
+# `esc env open` で取得した JSON を `wrangler secret bulk` に流して
+# Cloudflare Worker secret に反映する。
+#
+# ## 経緯 (Phase 2-D 補完)
+#
+# Phase 2-D 初版では ramu-shogi-backend / nnue-lab / rshogi の 3 リポのみで
+# secret-sync workflow を整備し、ramu-shogi (frontend Worker) は対象外としていた。
+# しかし frontend の `RoomDO.persistGameRecord` が backend `/internal/game-records`
+# に Service Binding 経由で POST する際に `x-room-do-secret` ヘッダを付与しており、
+# **frontend Worker にも `ROOM_DO_SECRET` を secret として持たせる必要がある**
+# ことが Playwright 検証で発覚した (frontend に未設定 → DO log 401 silent fail)。
+#
+# 本 workflow で frontend Worker の `ROOM_DO_SECRET` を ESC で一元管理し、
+# backend と値を同期する運用に揃える。
+#
+# ## 採用アーキテクチャ (兄弟 repo と統一)
+#
+# - secret の格納先: **Pulumi ESC** (per-repo per-env)
+#   - `sh11235/ramu-shogi-staging`
+#   - `sh11235/ramu-shogi-production`
+# - 反映トリガー: **GitHub Actions の `workflow_dispatch`** で手動 kick
+#   (CI / CD パイプラインに自動で組み込まない。secret は意図的な操作で更新)
+# - 反映手段: **`wrangler secret bulk <file>` (1-call で複数 secret を一括 put)**
+#
+# ## 対象 secret (per env、計 1 / 1 env)
+#
+# - `ROOM_DO_SECRET` (frontend Worker → backend Worker の internal API 認証共有 secret)
+#
+# 兄弟 repo (ramu-shogi-backend) の同名 secret と **値を一致させること**
+# (Service Binding を跨いだ HMAC ヘッダ照合のため)。値変更時は backend / frontend を
+# 順次 rotation する手順を docs/iac.md §8.1 に明記する運用契約。
+#
+# ## ESC environment YAML 構造 (両 env 共通)
+#
+# ```yaml
+# values:
+#   workerSecrets:
+#     ROOM_DO_SECRET:
+#       fn::secret:
+#         ciphertext: <encrypted>
+# ```
+#
+# `esc env open --format json` は decrypt 済 plain JSON を stdout に
+# 吐く。`jq '.workerSecrets'` で抜き出した object を `wrangler secret bulk` の
+# 入力 (`{"KEY": "value", ...}`) として渡す。
+#
+# ## 二重ガード設計 (pulumi-preview.yml と同方針)
+#
+# - `workflow_dispatch` のみ (push / PR では発火しない)
+# - `if: github.ref == 'refs/heads/main'` で main 以外の ref からの dispatch
+#   を job レベルで skip (workflow file 強制、リポジトリ設定不要)
+# - `environment: ${{ inputs.environment }}` で GitHub Environment protection
+#   (Required reviewers / Deployment branches) を gate として利用可能
+# - `permissions: contents: read` のみ (write 系一切持たない)
+#
+# ## wrangler env 命名注意
+#
+# `apps/web/wrangler.toml` の env 構造:
+# - **production** = top-level (default、`--env` フラグなし)
+# - **staging** = `env.stg` (wrangler 上の env 名は `stg`)
+#
+# 本 workflow の input `environment` (staging/production) と wrangler の
+# `--env` マッピング:
+# - `staging` → `--env stg`
+# - `production` → (フラグなし)
+#
+# ## 必要な repo secret
+#
+# - `PULUMI_ACCESS_TOKEN`: Pulumi Cloud token (pulumi-preview.yml で設定済)
+# - `CLOUDFLARE_API_TOKEN`: wrangler が secret put に使う token
+#   (Workers Scripts: Edit + 当該 account 範囲)
+#   * 未設定の場合は `wrangler secret bulk` が auth error で失敗する
+#   * 本 token は **wrangler 用** (Pulumi 用 R2 token とは独立に発行推奨)
+# - `CLOUDFLARE_ACCOUNT_ID`: wrangler 4.x が `/memberships` API call を
+#   skip するために必要 (token に User → Memberships → Read を持たせない代替経路、
+#   Cloudflare 公式 docs 推奨)。
+
+name: Secret Sync (ESC -> wrangler)
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment (staging / production)"
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+
+permissions:
+  contents: read
+
+concurrency:
+  # env ごとに独立 group。staging dispatch 中に production dispatch を投げても
+  # blocking されない。同 env の連続 dispatch は queue する (cancel-in-progress: false):
+  # `wrangler secret bulk` の atomicity が保証されないため、途中 cancel で
+  # 一部 secret のみ更新済の中間状態を残すリスクを避ける。兄弟 repo (rshogi #690 /
+  # nnue-lab #7 / ramu-shogi-backend #7) と判断を揃える。
+  group: secret-sync-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    name: sync ${{ inputs.environment }} secrets
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: ${{ inputs.environment }}
+    env:
+      WORKER_DIR: apps/web
+      ESC_ENV: sh11235/ramu-shogi-${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@91ab88e2619ed1f46221f0ba42d1492c02baf788 # v6.0.6
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24.15.0"
+          cache: "pnpm"
+
+      - name: Install workspace deps
+        run: pnpm install --frozen-lockfile
+
+      # ESC CLI (standalone `esc` バイナリ) を install。`environment` / `keys`
+      # 入力を渡さず pure install モードで動かし、後続 step で `esc env open ...`
+      # を直接叩く (env 変数の自動 export は使わない、明示 jq 抽出する)。
+      # 兄弟 repo (rshogi #690 / nnue-lab #7 / ramu-shogi-backend #7) と install 方式を揃える。
+      - uses: pulumi/esc-action@6cf9520e68354d86f81c455e8d43eabd58f5c9f5 # v1.5.0 (2025-10-07)
+
+      # ESC env を decrypt して JSON dump → workerSecrets を抽出。
+      # 出力先は /tmp 配下 (job runner ephemeral) に限定。runner 終了で破棄。
+      # `esc env open` は env 全体の plain JSON を吐くので、
+      # values.workerSecrets を jq で取り出して wrangler secret bulk 入力形式
+      # (`{"KEY": "value", ...}`) に整形する。
+      # CLI 注意: `pulumi/esc-action` は standalone ESC CLI のみ install するため、
+      # コマンド形式は `esc env ...` を使う。代替 CLI 形式 (full Pulumi CLI 同梱時) の対比は docs/iac.md §8.2 を参照。
+      - name: Open ESC environment and extract workerSecrets
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${PULUMI_ACCESS_TOKEN:-}" ]; then
+            echo "::error::PULUMI_ACCESS_TOKEN secret is not configured."
+            exit 1
+          fi
+          esc env open "$ESC_ENV" --format json > /tmp/esc.json
+          # workerSecrets の型 + 非空を厳格チェック (string / array / null すり抜け防止)
+          if ! jq -e '.workerSecrets | type == "object" and length > 0' /tmp/esc.json > /dev/null; then
+            echo "::error::ESC environment '$ESC_ENV' に非空 object の 'workerSecrets' が見つかりません。"
+            echo "Expected YAML shape: values.workerSecrets.{KEY}.fn::secret.ciphertext"
+            exit 1
+          fi
+          # 必須 key の欠落チェック (本リポは 1 件固定。追加時は本 list を同時更新する運用契約)。
+          required_keys=(ROOM_DO_SECRET)
+          missing=$(jq -r --argjson req "$(printf '%s\n' "${required_keys[@]}" | jq -R . | jq -s .)" \
+            '($req - (.workerSecrets | keys)) | join(", ")' /tmp/esc.json)
+          if [ -n "${missing}" ]; then
+            echo "::error::ESC environment '$ESC_ENV' に必須 key 不足: ${missing}"
+            exit 1
+          fi
+          # secret 値そのものはログに出さない (object のキーだけ表示して可視化)
+          echo "Secrets to sync:"
+          jq -r '.workerSecrets | keys | .[]' /tmp/esc.json
+          jq '.workerSecrets' /tmp/esc.json > /tmp/secrets.json
+          # /tmp/esc.json は env 全体の plain JSON、/tmp/secrets.json は workerSecrets を
+          # 抽出した JSON。両者とも plain text の secret を含むため permissions を 600 に絞る。
+          chmod 600 /tmp/esc.json /tmp/secrets.json
+
+      # wrangler env 名マッピング (input → wrangler --env):
+      # - production → (フラグなし、default env)
+      # - staging    → --env stg
+      - name: Resolve wrangler --env flag
+        id: wrangler_env
+        run: |
+          set -euo pipefail
+          case "${{ inputs.environment }}" in
+            production)
+              echo "flag=" >> "$GITHUB_OUTPUT"
+              ;;
+            staging)
+              echo "flag=--env stg" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown environment: ${{ inputs.environment }}"
+              exit 1
+              ;;
+          esac
+
+      # `wrangler secret bulk <file>` で Cloudflare Worker secret に一括反映。
+      # bulk API は冪等 (同名 secret 上書き)。差分検出は wrangler 側がやる。
+      # `--no-install` 相当として `npx --no-install` を使い、`pnpm install` で
+      # 解決済の wrangler を呼ぶ (新規 fetch を避ける、固定バージョン使用を強制)。
+      - name: Push secrets via wrangler secret bulk
+        working-directory: ${{ env.WORKER_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # CLOUDFLARE_ACCOUNT_ID は wrangler 4.x が `/memberships` API call を
+          # skip するために必要 (token に User → Memberships → Read 権限を持たせない
+          # 代わり、Cloudflare 公式 docs 推奨経路)。本 secret 名で repo secret に
+          # 登録すると wrangler が自動で env var を読む。
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          missing=()
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then missing+=("CLOUDFLARE_API_TOKEN"); fi
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then missing+=("CLOUDFLARE_ACCOUNT_ID"); fi
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::必須 repo secret が未設定: ${missing[*]}"
+            echo "詳細は docs/iac.md §8.6 を参照してください。"
+            exit 1
+          fi
+          # shellcheck disable=SC2086
+          npx --no-install wrangler secret bulk /tmp/secrets.json ${{ steps.wrangler_env.outputs.flag }}
+
+      # /tmp/secrets.json は runner 終了で破棄されるが、明示的にも削除しておく
+      # (post-step が失敗しても plain text が残らない保険)。
+      - name: Clean up secret file
+        if: always()
+        run: rm -f /tmp/secrets.json /tmp/esc.json

--- a/.github/workflows/secret-sync.yml
+++ b/.github/workflows/secret-sync.yml
@@ -151,7 +151,13 @@ jobs:
             echo "::error::PULUMI_ACCESS_TOKEN secret is not configured."
             exit 1
           fi
+          # /tmp/esc.json / /tmp/secrets.json は plain text の secret を含むため、
+          # 作成直後に umask 077 + chmod 600 を当てて他ユーザの読み取りを塞ぐ。
+          # GitHub Actions の ubuntu-latest runner は単一ユーザの ephemeral VM で
+          # リスクは小さいが、self-hosted runner や将来の sidecar 拡張への保険。
+          umask 077
           esc env open "$ESC_ENV" --format json > /tmp/esc.json
+          chmod 600 /tmp/esc.json
           # workerSecrets の型 + 非空を厳格チェック (string / array / null すり抜け防止)
           if ! jq -e '.workerSecrets | type == "object" and length > 0' /tmp/esc.json > /dev/null; then
             echo "::error::ESC environment '$ESC_ENV' に非空 object の 'workerSecrets' が見つかりません。"
@@ -170,9 +176,7 @@ jobs:
           echo "Secrets to sync:"
           jq -r '.workerSecrets | keys | .[]' /tmp/esc.json
           jq '.workerSecrets' /tmp/esc.json > /tmp/secrets.json
-          # /tmp/esc.json は env 全体の plain JSON、/tmp/secrets.json は workerSecrets を
-          # 抽出した JSON。両者とも plain text の secret を含むため permissions を 600 に絞る。
-          chmod 600 /tmp/esc.json /tmp/secrets.json
+          chmod 600 /tmp/secrets.json
 
       # wrangler env 名マッピング (input → wrangler --env):
       # - production → (フラグなし、default env)
@@ -219,6 +223,34 @@ jobs:
           fi
           # shellcheck disable=SC2086
           npx --no-install wrangler secret bulk /tmp/secrets.json ${{ steps.wrangler_env.outputs.flag }}
+
+      # `wrangler secret bulk` 後に Worker 上の secret 名を listing して、
+      # 必須 key が確実に登録されたことを CI ログ上で可視化する。
+      # `secret list` は **値を表示しない** (key 名と type のみ) ため、
+      # ログ漏洩リスクなしで sync 成否を確認できる。
+      - name: Verify secrets synced
+        working-directory: ${{ env.WORKER_DIR }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          listing=$(npx --no-install wrangler secret list ${{ steps.wrangler_env.outputs.flag }} 2>&1)
+          echo "$listing"
+          # 必須 key が登録されているか確認 (key 名のみ照合、値は触らない)
+          required_keys=(ROOM_DO_SECRET)
+          missing=()
+          for key in "${required_keys[@]}"; do
+            if ! echo "$listing" | grep -q "\"name\":[[:space:]]*\"$key\""; then
+              missing+=("$key")
+            fi
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::sync 後の Worker secret listing に欠落あり: ${missing[*]}"
+            exit 1
+          fi
+          echo "::notice::All required secrets present on Worker (${#required_keys[@]} key)"
 
       # /tmp/secrets.json は runner 終了で破棄されるが、明示的にも削除しておく
       # (post-step が失敗しても plain text が残らない保険)。

--- a/docs/iac.md
+++ b/docs/iac.md
@@ -232,8 +232,9 @@ Worker (`ramu-shogi-stg`) も同じ `shogi-nnue` バケットを読み書きす�
 
 ### 4.3 secret 値の追加 / rotation
 
-Phase 1.5 時点では Worker secret (将来の `ADMIN_API_TOKEN` 等) は
-**wrangler 経由のみ**で管理する:
+**`ROOM_DO_SECRET` のみ Pulumi ESC 管理 (Phase 2-D 補完 / issue #52)**。
+それ以外の Worker secret (将来の `ADMIN_API_TOKEN` 等) は **wrangler 経由のみ**で
+管理する:
 
 ```bash
 cd apps/web
@@ -243,7 +244,8 @@ pnpm exec wrangler secret put <SECRET_NAME>
 pnpm exec wrangler secret put <SECRET_NAME> --env stg
 ```
 
-Phase 2 で Pulumi config / Pulumi ESC への移行を検討する。
+`ROOM_DO_SECRET` の追加 / rotation 手順は §8 を参照。新規 secret も Pulumi ESC
+管理に乗せる場合は §8.1 を踏襲して `secret-sync.yml` の `required_keys` を更新する。
 
 ### 4.4 bootstrap (新規 stack / 別環境 / state 復旧)
 
@@ -380,7 +382,176 @@ Self-managed backend (R2 / S3 等) を使う場合は `PULUMI_CONFIG_PASSPHRASE`
 依存になり commit 可否が変わるので、Phase 2 で backend 移行する場合は
 本セクションを更新する。
 
-## 8. 参考
+## 8. Pulumi ESC + secret-sync workflow (Phase 2-D 補完 / issue #52)
+
+`ROOM_DO_SECRET` を Pulumi ESC で一元管理し、`.github/workflows/secret-sync.yml`
+が `wrangler secret bulk` で Cloudflare Worker secret に反映する仕組み。
+兄弟 repo (rshogi #690 / nnue-lab #7 / ramu-shogi-backend #7) と統一した
+Phase 2-D pattern を frontend Worker にも展開した実装。
+
+### 8.0 経緯 (2026-05-10 postmortem)
+
+Phase 2-D 初版は ramu-shogi-backend / nnue-lab / rshogi の 3 リポを対象とし、
+ramu-shogi (frontend Worker) は対象外としていた。Playwright での対局完走検証で
+backend D1 に game record が永続化されない事象が判明し、原因は **frontend Worker
+側の `RoomDO.persistGameRecord` で `ROOM_DO_SECRET` が `undefined` のまま
+`x-room-do-secret` ヘッダを生成 → backend `/internal/game-records` 401 silent
+fail** だった (DO console error は `wrangler tail` に出ず、UI 上も対局終了 UX は
+正常に進行する設計のため検出が遅れた)。
+
+frontend Worker と backend Worker は別リポ・別 wrangler だが、
+`ROOM_DO_SECRET` は **同じ値を共有**する HMAC ヘッダ (Service Binding 越し
+internal API 認証) なので、両側を ESC で一元管理する判断とした。
+
+| 項目                 | frontend (本リポ)                     | backend (兄弟 repo)                                |
+| -------------------- | ------------------------------------- | -------------------------------------------------- |
+| ESC env (staging)    | `sh11235/ramu-shogi-staging`          | `sh11235/ramu-shogi-backend-staging`               |
+| ESC env (production) | `sh11235/ramu-shogi-production`       | `sh11235/ramu-shogi-backend-production`            |
+| 管理 secret          | `ROOM_DO_SECRET`                      | `ROOM_DO_SECRET` + 他 3 件 (Google OAuth / cookie) |
+| 値の制約             | backend と一致 (Service Binding HMAC) | frontend と一致                                    |
+
+**運用契約**: `ROOM_DO_SECRET` を rotation する場合は両 ESC env (`ramu-shogi-*` /
+`ramu-shogi-backend-*`) を **同じ値で同時更新** → 各 repo で `secret-sync.yml`
+を即座に連続 dispatch する (推奨順は backend → frontend、低トラフィック時間帯)。
+どちらの順でも短時間 401 window が発生する現状制約と、`back-to-back dispatch` で
+window を最小化する根拠は §8.1 を参照。
+
+### 8.1 ROOM_DO_SECRET の追加 / rotation 手順
+
+1. **新値を生成** (`openssl rand -base64 48` 等)
+2. **両 ESC env を同時更新**
+   ```bash
+   # backend (兄弟 repo) と frontend (本リポ) の両方を更新
+   esc env set sh11235/ramu-shogi-backend-staging \
+     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+   esc env set sh11235/ramu-shogi-backend-production \
+     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+   esc env set sh11235/ramu-shogi-staging \
+     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+   esc env set sh11235/ramu-shogi-production \
+     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+   ```
+3. **secret-sync を即座に連続 dispatch** (backend → frontend、staging → production の順):
+   - ramu-shogi-backend `Secret Sync (ESC -> wrangler)` workflow を staging で dispatch
+   - **キックしたら待たずに** ramu-shogi (本リポ) `Secret Sync (ESC -> wrangler)` workflow を staging で dispatch
+   - 同 production も同順
+4. **動作確認**: staging で対局 1 局完走 → backend D1 `game_records` に新 row が
+   作られたら成功 (401 silent fail が無いことを確認)。
+
+> **rotation 中は短時間 401 window が発生する (現状制約)**: backend / frontend
+> どちらの順で更新しても、両側が同じ新 secret を持つまでの間は HMAC mismatch で
+> `/internal/game-records` が 401 を返す。`persistGameRecord` は silent fail
+> 設計のため UI には影響しないが、その window 中に終局した対局は backend D1 に
+> 永続化されない (KV / R2 に game_records 復旧経路が無いため復元不可)。
+> back-to-back dispatch (typically 1〜2 分以内に両 workflow 完了) で window を
+> 最小化するのが運用上のベストプラクティス。低トラフィック時間帯 (深夜等) を
+> 選んで rotation する。
+>
+> backend → frontend の順を推奨する理由は **検証側を先に更新** すると、frontend
+> 旧 secret 経由のリクエストは 401 になり問題顕在化が早い (=サイレントに古い
+> 値を使い続ける状態を避けられる) こと。逆順 (frontend 先) は frontend 新 →
+> backend 旧で同じく 401 だが、frontend deploy 直後の新 secret が backend に
+> 認識されるまでの間にバッチで失敗 row が増える可能性がある。
+>
+> **完全な zero-downtime rotation が必要な場合**: backend を dual-secret 対応
+> (新旧 2 つの secret を allowlist して比較) に改修する必要がある (本 PR スコープ外。
+> 別 issue で議論)。現状は短時間 window を許容する運用契約とする。
+
+### 8.2 ESC CLI と Pulumi CLI の違い
+
+`pulumi/esc-action@v1.5.0` は **standalone ESC CLI のみ** を install する。
+コマンド形式は `esc env open` / `esc env set` を使う (代替 CLI 形式は
+`pulumi env open` / `pulumi env set`、これは full Pulumi CLI 同梱時のみ)。
+
+ローカル運用で `pulumi` バイナリしか持たない環境では `pulumi env ...` を、
+CI runner や `pulumi/esc-action` install 環境では `esc env ...` を使う。両者は
+等価 (back-end は同じ Pulumi Cloud ESC API)。
+
+### 8.3 ESC environment YAML 構造
+
+```yaml
+values:
+  workerSecrets:
+    ROOM_DO_SECRET:
+      fn::secret:
+        ciphertext: <encrypted>
+```
+
+`workerSecrets` は flat object (ネスト無し)。`fn::secret` で暗号化された
+ciphertext を保持する。`esc env open --format json` 実行時に decrypt 済 plain
+JSON が出力され、workflow が `jq '.workerSecrets'` で抜き出して
+`wrangler secret bulk` の入力 (`{"KEY": "value", ...}`) として渡す。
+
+### 8.4 必要な repo secret (GitHub Actions)
+
+`secret-sync.yml` 実行に必要な repo secret:
+
+| Secret 名               | 用途                                                                                                              |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `PULUMI_ACCESS_TOKEN`   | ESC env decrypt 用 Pulumi Cloud token (pulumi-preview.yml で設定済)                                               |
+| `CLOUDFLARE_API_TOKEN`  | wrangler が secret put に使う token (Workers Scripts: Edit + Account Settings: Read、Pulumi 用 R2 token とは独立) |
+| `CLOUDFLARE_ACCOUNT_ID` | wrangler 4.x が `/memberships` API call を skip するために必要 (`d5d9818649d8722f73cd798c3b1ffb70`)               |
+
+`CLOUDFLARE_ACCOUNT_ID` は **secret として登録** することを兄弟 repo と揃える
+(env var として読まれる。public 値だが env var inject の便宜上 secret 扱い)。
+
+### 8.5 wrangler env 命名マッピング
+
+`apps/web/wrangler.toml` の env 構造:
+
+| input `environment` | wrangler --env フラグ | Worker 名        |
+| ------------------- | --------------------- | ---------------- |
+| `production`        | (フラグなし)          | `ramu-shogi`     |
+| `staging`           | `--env stg`           | `ramu-shogi-stg` |
+
+workflow 内 `Resolve wrangler --env flag` step で input → flag をマッピング。
+
+### 8.6 トラブルシューティング
+
+**`ESC environment 'sh11235/ramu-shogi-...' に必須 key 不足: ROOM_DO_SECRET`**
+ESC env の `workerSecrets` から key が抜けている。`esc env set` で再投入する
+(§8.1 の値設定コマンド参照)。
+
+**`wrangler secret bulk` が `Authentication error code: 10000`**
+`CLOUDFLARE_API_TOKEN` の scope に `Workers Scripts: Edit` (+ `Account Settings:
+Read`) が含まれていない、または expire している。Cloudflare Dashboard で再発行
+→ repo secret 更新。
+
+**`Binding name 'ROOM_DO_SECRET' already in use [code: 10053]`**
+Worker 上で同名 vars binding が既に存在する状態で secret に切り替えようとして
+発生する (本リポでは Phase 2-D 補完時点で `ROOM_DO_SECRET` は既に secret 化
+済みのため通常発生しないが、ESC 経由で新規 secret を追加するときは注意)。
+発生時は wrangler.toml から該当 vars 宣言を削除 → `wrangler deploy` →
+`secret-sync.yml` の順で対処。
+
+**Worker secret に反映されたか確認したい**
+
+```bash
+cd apps/web
+pnpm exec wrangler secret list --env stg     # staging
+pnpm exec wrangler secret list                # production
+```
+
+key 名のみ表示される (値は表示されない、Cloudflare 側でも復元不可)。
+
+### 8.7 ローカルから手動で secret を流し込みたい場合
+
+CI を経由せずローカルから ESC → wrangler に流す場合 (緊急 rotation 等):
+
+```bash
+cd apps/web
+# ESC から JSON 取得
+esc env open sh11235/ramu-shogi-staging --format json | jq '.workerSecrets' > /tmp/secrets.json
+chmod 600 /tmp/secrets.json
+# wrangler secret bulk
+pnpm exec wrangler secret bulk /tmp/secrets.json --env stg
+rm -f /tmp/secrets.json
+```
+
+通常運用は GitHub Actions workflow を dispatch する (audit log と secret 漏洩
+リスクを CI runner に閉じ込めるため)。
+
+## 9. 参考
 
 - 設計判断 / 背景: [issue #50](https://github.com/SH11235/ramu-shogi/issues/50)
 - 同 pattern の rshogi 実装: [rshogi PR #677](https://github.com/SH11235/rshogi/pull/677) / [docs/csa-server/iac.md](https://github.com/SH11235/rshogi/blob/main/docs/csa-server/iac.md)

--- a/docs/iac.md
+++ b/docs/iac.md
@@ -423,13 +423,13 @@ window を最小化する根拠は §8.1 を参照。
    ```bash
    # backend (兄弟 repo) と frontend (本リポ) の両方を更新
    esc env set sh11235/ramu-shogi-backend-staging \
-     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+     workerSecrets.ROOM_DO_SECRET '<new>' --secret
    esc env set sh11235/ramu-shogi-backend-production \
-     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+     workerSecrets.ROOM_DO_SECRET '<new>' --secret
    esc env set sh11235/ramu-shogi-staging \
-     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+     workerSecrets.ROOM_DO_SECRET '<new>' --secret
    esc env set sh11235/ramu-shogi-production \
-     values.workerSecrets.ROOM_DO_SECRET '<new>' --secret
+     workerSecrets.ROOM_DO_SECRET '<new>' --secret
    ```
 3. **secret-sync を即座に連続 dispatch** (backend → frontend、staging → production の順):
    - ramu-shogi-backend `Secret Sync (ESC -> wrangler)` workflow を staging で dispatch


### PR DESCRIPTION
closes #52

## Summary

- frontend Worker の `ROOM_DO_SECRET` を Pulumi ESC (`sh11235/ramu-shogi-{staging,production}`) で一元管理し、`.github/workflows/secret-sync.yml` (`workflow_dispatch`) で `wrangler secret bulk` 経由で Worker secret に反映する仕組みを追加。
- 兄弟 repo (rshogi #690 / nnue-lab #7 / ramu-shogi-backend #7) で確立した Phase 2-D pattern を **frontend Worker にも展開** (Phase 2-D の初版漏れを補完)。
- `docs/iac.md` に §8 (Pulumi ESC + secret-sync workflow) を新設、§4.3 を更新。

## 経緯 (Phase 2-D 補完の理由)

Phase 2-D 初版は ramu-shogi-backend / nnue-lab / rshogi の 3 リポのみを対象とし、ramu-shogi (frontend Worker) は対象外としていた。Playwright での対局完走検証で backend D1 に game record が永続化されない事象が判明し、原因は **frontend Worker の `RoomDO.persistGameRecord` が `ROOM_DO_SECRET=undefined` のまま `x-room-do-secret` ヘッダを生成 → backend `/internal/game-records` 401 silent fail** だった。

frontend / backend は別リポだが `ROOM_DO_SECRET` は **同じ値を共有** (Service Binding 越し HMAC 認証) のため、両側を ESC で一元管理する判断とした。

## Test plan

PR 後、user 側で以下を実施 (詳細は docs/iac.md §8 / §8.1 参照):

- [ ] **(user manual) repo secret 登録**: `CLOUDFLARE_API_TOKEN` (Workers Scripts: Edit + Account Settings: Read) と `CLOUDFLARE_ACCOUNT_ID` (`d5d9818649d8722f73cd798c3b1ffb70`) を ramu-shogi リポの Settings → Secrets and variables → Actions に登録
- [ ] **(user manual) ESC env 確認**: `esc env open sh11235/ramu-shogi-staging` / `sh11235/ramu-shogi-production` で `workerSecrets.ROOM_DO_SECRET` が見えること
- [ ] **(staging dispatch)** `gh workflow run secret-sync.yml -R SH11235/ramu-shogi -f environment=staging` (本 PR merge 後)
- [ ] **(staging 検証)** `pnpm exec wrangler secret list --env stg --cwd apps/web` で `ROOM_DO_SECRET` が表示されること
- [ ] **(production dispatch)** staging 成功後、`gh workflow run secret-sync.yml -R SH11235/ramu-shogi -f environment=production`
- [ ] **(production 検証)** `pnpm exec wrangler secret list --cwd apps/web` で `ROOM_DO_SECRET` が表示されること
- [ ] **(対局検証)** ramu-shogi (production) で対局を 1 局完走 → backend D1 (`ramu_shogi_app`) の `game_records` テーブルに新 row が作られることを確認 (= 401 silent fail なし)

## レビュー

事前 Codex CLI review 2 ラウンド経て Approve 済 (Major 3 件 + Minor 2 件をすべて反映、§8.1 rotation 手順は「どちらの順でも 401 window が出る」事実を正しく記述、`/tmp/esc.json` も chmod 600、cross-ref §10.x → §8.x 修正済)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)