### PR TITLE
fix(match-client): 観戦 WS URL を origin 直下に張る (/api/v1 混入を除去)

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -168,6 +168,19 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         expect(events.clocks[0].sideToMove).toBe("sente");
     });
 
+    it("apiBaseUrl に path (/api/v1) を含んでも観戦 WS は origin 直下 /ws/<id>/spectate に張る", () => {
+        const { wsInstances, wsFactory, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com/api/v1", webSocketFactory: wsFactory },
+            callbacks,
+        );
+
+        expect(wsInstances.length).toBe(1);
+        // REST 共用ベースの `/api/v1` を引きずらず origin だけ使う (path 混入で 404 になる回帰防止)
+        expect(wsInstances[0].url).toBe("wss://example.com/ws/game-1/spectate");
+    });
+
     it("snapshot 後の broadcast move 行を onMove に流す", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         subscribeRshogiLiveGame(

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -636,11 +636,13 @@ export function subscribeRshogiLiveGame(
             emitConnectionState("closed");
             return;
         }
-        const base = options.apiBaseUrl.replace(/\/+$/, "");
-        // `apiBaseUrl` は HTTPS スキーム (例: `https://csa.example.com`) で渡される
-        // 想定。WebSocket スキームに揃える。
-        const wsBase = base.replace(/^http(s?):\/\//i, (_m, s) => `ws${s ?? ""}://`);
-        const url = `${wsBase}/ws/${encodeURIComponent(gameId)}/spectate`;
+        // `apiBaseUrl` は REST と共用で path (`/api/v1` 等) を含みうるが、観戦 WS は
+        // ルート直下 (`/ws/<id>/spectate`) にあるため origin だけ使い path は捨てる。
+        // scheme は https/wss→wss、http/ws→ws に揃える。
+        const apiUrl = new URL(options.apiBaseUrl);
+        const wsScheme =
+            apiUrl.protocol === "https:" || apiUrl.protocol === "wss:" ? "wss:" : "ws:";
+        const url = `${wsScheme}//${apiUrl.host}/ws/${encodeURIComponent(gameId)}/spectate`;
         emitConnectionState(reconnectAttempt > 0 ? "reconnecting" : "connecting");
 
         let socket: WebSocket;


### PR DESCRIPTION
## 背景 (バグ)

ライブ観戦ビュー (`/rshogi-viewer/live/<gameId>`) が `エラー: WebSocket error` で接続できなかった。

`subscribeRshogiLiveGame` (`packages/match-client/src/rshogi-csa/live.ts`) が観戦 WS URL を **REST 用 `apiBaseUrl`**（`VITE_RSHOGI_API_BASE` = `https://rshogi-csa-server.sh11235.com/api/v1`）からスキームだけ差し替えて生成しており、`wss://host/api/v1/ws/<id>/spectate` と **`/api/v1` が混入**していた。サーバの spectate エンドポイントは root 直下 (`/ws/<id>/spectate`) のため 404 になっていた。

実測 (production):
- 正 `/ws/<id>/spectate` → HTTP **426** (Upgrade 可)
- 誤 `/api/v1/ws/<id>/spectate` → HTTP **404**

## 修正

`new URL(apiBaseUrl)` の **origin (host) だけ**を使い path を捨てて URL を組む。scheme は `https`/`wss`→`wss`、`http`/`ws`→`ws`。port 付き host も維持。回帰テストを追加。

```
https://host/api/v1  → wss://host/ws/<id>/spectate   (path 除去 = 本修正)
https://host         → wss://host/ws/<id>/spectate   (従来どおり)
https://host:8443/.. → wss://host:8443/ws/<id>/...    (port 維持)
http://host          → ws://host/ws/<id>/spectate
```

## 検証

- `live.test.ts` **17/17 pass**（新規回帰テスト含む）。`biome check` クリーン、`tsc --noEmit` クリーン。
- `client.test.ts` の `createRoomClient` 再接続テスト1件 fail は **`main` でも fail する既存問題**で本修正（`live.ts` のみ）とは無関係（stash 検証済み・`client.*` は無変更）。
- local Claude + Codex の独立レビューで **APPROVE** 済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)