### PR TITLE
fix(web): デプロイ後に消えた旧 hash アセットの 404 を検知して自動 reload する

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,7 +3,11 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { initializePositionService } from "./platform/position-service-bootstrap";
+import { installStaleDeployReloadHandlers } from "./platform/stale-deploy-reload";
 import { router } from "./router";
+
+// デプロイ更新後に旧バンドルが消えた chunk/wasm を要求して 404 になる場合の自動回復を仕込む
+installStaleDeployReloadHandlers();
 
 // PositionService を初期化（React レンダリング前に実行）
 initializePositionService();

--- a/apps/web/src/platform/stale-deploy-reload.test.ts
+++ b/apps/web/src/platform/stale-deploy-reload.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    installStaleDeployReloadHandlers,
+    isStaleAssetError,
+    reloadForStaleDeploy,
+    reloadOnStaleAsset,
+} from "./stale-deploy-reload";
+
+describe("isStaleAssetError", () => {
+    it("wasm streaming compile の 404 メッセージを stale と判定する", () => {
+        expect(
+            isStaleAssetError(
+                new Error(
+                    "Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok",
+                ),
+            ),
+        ).toBe(true);
+    });
+
+    it("dynamic import chunk 消失のメッセージを stale と判定する", () => {
+        expect(
+            isStaleAssetError(
+                new Error("Failed to fetch dynamically imported module: /assets/x-abcd.js"),
+            ),
+        ).toBe(true);
+        expect(isStaleAssetError("error loading dynamically imported module")).toBe(true);
+        expect(isStaleAssetError(new Error("Importing a module script failed."))).toBe(true);
+    });
+
+    it("一般的なネットワークエラーやその他は stale 扱いしない (誤 reload 防止)", () => {
+        expect(isStaleAssetError(new Error("Failed to fetch"))).toBe(false);
+        expect(
+            isStaleAssetError(new Error("NetworkError when attempting to fetch resource.")),
+        ).toBe(false);
+        expect(isStaleAssetError(undefined)).toBe(false);
+        expect(isStaleAssetError(null)).toBe(false);
+    });
+});
+
+describe("reloadForStaleDeploy / reloadOnStaleAsset", () => {
+    let reloadSpy: ReturnType<typeof vi.spyOn>;
+    let nowSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        window.sessionStorage.clear();
+        reloadSpy = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+        nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000_000);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("stale エラーで full reload を1回起動する", () => {
+        expect(reloadOnStaleAsset(new Error("HTTP status code is not ok"))).toBe(true);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("stale でないエラーでは reload しない", () => {
+        expect(reloadOnStaleAsset(new Error("Failed to fetch"))).toBe(false);
+        expect(reloadSpy).not.toHaveBeenCalled();
+    });
+
+    it("クールダウン内の再失敗は reload しない (ループ防止)", () => {
+        expect(reloadForStaleDeploy()).toBe(true);
+        expect(reloadForStaleDeploy()).toBe(false);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("クールダウン経過後は再び reload する", () => {
+        expect(reloadForStaleDeploy()).toBe(true);
+        nowSpy.mockReturnValue(1_000_000 + 61_000);
+        expect(reloadForStaleDeploy()).toBe(true);
+        expect(reloadSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("クールダウン内は reloadOnStaleAsset でも reload しない", () => {
+        expect(reloadOnStaleAsset(new Error("HTTP status code is not ok"))).toBe(true);
+        expect(reloadOnStaleAsset(new Error("HTTP status code is not ok"))).toBe(false);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("sessionStorage の読み取りが不可なら reload しない", () => {
+        // happy-dom の sessionStorage は Proxy で restoreAllMocks が効かないため Once で自己復帰させる
+        vi.spyOn(window.sessionStorage, "getItem").mockImplementationOnce(() => {
+            throw new Error("storage denied");
+        });
+        expect(reloadForStaleDeploy()).toBe(false);
+        expect(reloadSpy).not.toHaveBeenCalled();
+    });
+
+    it("ガード時刻を書き込めないなら reload しない (ループ防止)", () => {
+        vi.spyOn(window.sessionStorage, "setItem").mockImplementationOnce(() => {
+            throw new Error("quota exceeded");
+        });
+        expect(reloadForStaleDeploy()).toBe(false);
+        expect(reloadSpy).not.toHaveBeenCalled();
+    });
+});
+
+describe("installStaleDeployReloadHandlers", () => {
+    let reloadSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeAll(() => {
+        installStaleDeployReloadHandlers();
+    });
+
+    beforeEach(() => {
+        window.sessionStorage.clear();
+        reloadSpy = vi.spyOn(window.location, "reload").mockImplementation(() => undefined);
+        vi.spyOn(Date, "now").mockReturnValue(2_000_000);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("vite:preloadError で reload し、preventDefault する", () => {
+        const event = new Event("vite:preloadError", { cancelable: true });
+        window.dispatchEvent(event);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("stale な unhandledrejection で reload し、preventDefault する", () => {
+        const event = new Event("unhandledrejection", { cancelable: true });
+        Object.assign(event, { reason: new Error("error loading dynamically imported module") });
+        window.dispatchEvent(event);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("stale な error イベントで reload し、preventDefault する", () => {
+        const event = new Event("error", { cancelable: true });
+        Object.assign(event, { error: new Error("HTTP status code is not ok") });
+        window.dispatchEvent(event);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("stale でない unhandledrejection では reload せず preventDefault もしない", () => {
+        const event = new Event("unhandledrejection", { cancelable: true });
+        Object.assign(event, { reason: new Error("Failed to fetch") });
+        window.dispatchEvent(event);
+        expect(reloadSpy).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("stale でない error イベントでは reload せず preventDefault もしない", () => {
+        const event = new Event("error", { cancelable: true });
+        Object.assign(event, { error: new Error("ResizeObserver loop limit exceeded") });
+        window.dispatchEvent(event);
+        expect(reloadSpy).not.toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(false);
+    });
+});

--- a/apps/web/src/platform/stale-deploy-reload.ts
+++ b/apps/web/src/platform/stale-deploy-reload.ts
@@ -1,0 +1,97 @@
+/**
+ * デプロイで content-hash 付きアセット (wasm / dynamic import chunk) が差し替わると、
+ * 旧 index.html / 旧バンドルを掴んだままのクライアントは消えた旧 hash を要求して 404 になる。
+ * worker (apps/web/worker/index.ts) は欠損 /assets/* を SPA fallback させず 404 にするため、
+ * wasm streaming compile は "HTTP status code is not ok" で失敗する。
+ *
+ * stale 署名のときだけ新しい index.html を取りに full reload して回復する。
+ * 真に壊れたデプロイ (全員が同じ 404) では reload ループになり得るので、
+ * クールダウン内の再失敗では reload せず通常のエラー表示へ委ねる。
+ */
+
+const RELOAD_GUARD_KEY = "ramu-shogi:stale-asset-reloaded-at";
+// reload 直後に再び失敗する場合は新 hash でも直っていない (= stale ではなく恒久障害) とみなし、
+// この窓内では再 reload しない。
+const RELOAD_COOLDOWN_MS = 60_000;
+
+const STALE_ERROR_SIGNATURES = [
+    // wasm streaming compile が 404 Response を受けたときの V8 メッセージ
+    "http status code is not ok",
+    // Vite dynamic import chunk が消えたときの表現 (Chromium / Firefox / Safari)
+    "failed to fetch dynamically imported module",
+    "error loading dynamically imported module",
+    "importing a module script failed",
+];
+
+const toMessage = (error: unknown): string => {
+    if (error instanceof Error) return error.message;
+    if (typeof error === "string") return error;
+    if (error && typeof error === "object" && "message" in error) {
+        return String((error as { message: unknown }).message);
+    }
+    return String(error);
+};
+
+export const isStaleAssetError = (error: unknown): boolean => {
+    const message = toMessage(error).toLowerCase();
+    return STALE_ERROR_SIGNATURES.some((signature) => message.includes(signature));
+};
+
+const canReloadNow = (): boolean => {
+    if (typeof window === "undefined") return false;
+    try {
+        const raw = window.sessionStorage.getItem(RELOAD_GUARD_KEY);
+        const last = raw ? Number.parseInt(raw, 10) : 0;
+        return !Number.isFinite(last) || Date.now() - last > RELOAD_COOLDOWN_MS;
+    } catch {
+        // sessionStorage 不可 (private mode 等) ではループ防止のガードが効かないため reload しない
+        return false;
+    }
+};
+
+// reload 前にガード時刻を永続化する。書けたら true。
+// 書けない環境ではループ防止が成立しないため、呼び出し側は reload を見送る。
+const markReloaded = (): boolean => {
+    try {
+        window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(Date.now()));
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/** ガード付き full reload。実際に reload を開始したら true。 */
+export const reloadForStaleDeploy = (): boolean => {
+    // ガードを読めない / 書けない環境では loop 防止が効かないため reload しない
+    if (!canReloadNow()) return false;
+    if (!markReloaded()) return false;
+    window.location.reload();
+    return true;
+};
+
+/** error が stale 署名のときだけガード付き reload する。reload を開始したら true。 */
+export const reloadOnStaleAsset = (error: unknown): boolean => {
+    if (!isStaleAssetError(error)) return false;
+    return reloadForStaleDeploy();
+};
+
+/**
+ * dynamic import / 未捕捉の stale エラーに対する保険ハンドラを window へ登録する。
+ * 個別 catch で拾えない経路 (route chunk の preload 失敗など) を回復させる。main.tsx から1回だけ呼ぶ。
+ */
+export const installStaleDeployReloadHandlers = (): void => {
+    if (typeof window === "undefined") return;
+
+    // Vite が dispatch する chunk preload 失敗イベント。発火時点で stale 確定なので署名チェック不要。
+    window.addEventListener("vite:preloadError", (event) => {
+        if (reloadForStaleDeploy()) event.preventDefault();
+    });
+
+    window.addEventListener("unhandledrejection", (event) => {
+        if (reloadOnStaleAsset(event.reason)) event.preventDefault();
+    });
+
+    window.addEventListener("error", (event) => {
+        if (reloadOnStaleAsset(event.error ?? event.message)) event.preventDefault();
+    });
+};

--- a/apps/web/src/platform/stale-deploy-reload.ts
+++ b/apps/web/src/platform/stale-deploy-reload.ts
@@ -75,12 +75,16 @@ export const reloadOnStaleAsset = (error: unknown): boolean => {
     return reloadForStaleDeploy();
 };
 
+let handlersInstalled = false;
+
 /**
  * dynamic import / 未捕捉の stale エラーに対する保険ハンドラを window へ登録する。
  * 個別 catch で拾えない経路 (route chunk の preload 失敗など) を回復させる。main.tsx から1回だけ呼ぶ。
+ * 二重呼び出し (StrictMode / HMR / 呼び出しミス) でリスナーが重複登録されないよう冪等にする。
  */
 export const installStaleDeployReloadHandlers = (): void => {
-    if (typeof window === "undefined") return;
+    if (typeof window === "undefined" || handlersInstalled) return;
+    handlersInstalled = true;
 
     // Vite が dispatch する chunk preload 失敗イベント。発火時点で stale 確定なので署名チェック不要。
     window.addEventListener("vite:preloadError", (event) => {
@@ -91,6 +95,7 @@ export const installStaleDeployReloadHandlers = (): void => {
         if (reloadOnStaleAsset(event.reason)) event.preventDefault();
     });
 
+    // ErrorEvent 以外 (リソース読込エラー等) では error/message が無く空文字 → 署名不一致で no-op。
     window.addEventListener("error", (event) => {
         if (reloadOnStaleAsset(event.error ?? event.message)) event.preventDefault();
     });

--- a/apps/web/src/platform/wasm-position-service.ts
+++ b/apps/web/src/platform/wasm-position-service.ts
@@ -15,12 +15,18 @@ import {
     wasm_parse_sfen_to_board,
     wasm_replay_moves_strict,
 } from "@shogi/engine-wasm";
+import { reloadOnStaleAsset } from "./stale-deploy-reload";
 
 export const createWasmPositionService = (): PositionService => {
     let ready: Promise<void> | null = null;
     const ensureReady = () => {
         if (!ready) {
-            ready = ensureWasmModule();
+            ready = ensureWasmModule().catch((error: unknown) => {
+                // 旧 hash の wasm が消えて 404 → compile 失敗のときは新バンドルを取りに reload する。
+                // reload しない (stale でない / クールダウン中) ときは呼び出し元のエラー表示へ流す。
+                reloadOnStaleAsset(error);
+                throw error;
+            });
         }
         return ready;
     };

--- a/apps/web/src/platform/wasm-position-service.ts
+++ b/apps/web/src/platform/wasm-position-service.ts
@@ -24,6 +24,8 @@ export const createWasmPositionService = (): PositionService => {
             ready = ensureWasmModule().catch((error: unknown) => {
                 // 旧 hash の wasm が消えて 404 → compile 失敗のときは新バンドルを取りに reload する。
                 // reload しない (stale でない / クールダウン中) ときは呼び出し元のエラー表示へ流す。
+                // 失敗 Promise はそのままキャッシュされ retry されない。wasm ロード失敗は実質
+                // terminal で、回復手段は reload (自動 or ユーザ手動) のみのため意図どおり。
                 reloadOnStaleAsset(error);
                 throw error;
             });


### PR DESCRIPTION
## 概要

本番 viewer (`/rshogi-viewer/<gameId>`) で発生していた
`初期局面の取得に失敗しました: TypeError: Failed to execute 'compile' on 'WebAssembly': HTTP status code is not ok`
を、デプロイ後の自動回復で解消する。

## 原因

`scripts/deploy-web.sh prod` (Cloudflare Workers Static Assets) は content-hash 付き
アセットを差し替え、旧 hash を削除する。`apps/web/worker/index.ts` は欠損 `/assets/*`
を SPA fallback させず**ハード 404** を返す設計のため、旧 `index.html` / 旧 JS バンドルを
掴んだままの stale クライアント（ブラウザ/エッジキャッシュ、または開きっぱなしの SPA
タブのクライアント遷移）が削除済みの旧 wasm hash を fetch すると、wasm streaming
compile が `HTTP status code is not ok` で失敗する。viewer では `getInitialBoard` →
`ensureWasmModule` 経路で初期局面取得が落ちる。

- 現行デプロイ自体は内部整合（curl で `index.html` の参照アセットは全て 200、存在しない
  `/assets/*.wasm` は 404 を確認）。**キャッシュ無しのフレッシュロードでは再現しない**。

## 修正

stale 署名（`http status code is not ok` / dynamic import chunk 消失メッセージ）の
ロード失敗を検知し、`sessionStorage` の 60s クールダウン付きで**1回だけ full reload**
して新バンドルを取得する。真に壊れたデプロイでの reload ループは、ガードを読めない/
書けない環境では reload しない・クールダウン内の再失敗では reload しないことで防ぐ。

- 新規 `apps/web/src/platform/stale-deploy-reload.ts`
- `main.tsx`: `vite:preloadError` / `error` / `unhandledrejection` 保険ハンドラを登録
- `wasm-position-service.ts`: `ensureWasmModule()` の catch で stale 時 reload、それ以外は
  従来どおりエラー表示へ流す
- ユニットテスト 15 ケース（署名判定、クールダウン、storage 例外、イベント結線）

## scope 外（follow-up 余地）

対局中エンジン用 wasm は `packages/engine-wasm` の Worker 内でロードされ、失敗は
`worker.onerror` → `enterErrorState` に流れる。Worker 内例外は親 window に伝播しない
ため本修正の reload では拾わない。viewer は `getInitialBoard` が最初期に発火するため
最初の reload で全アセットが新 hash 化され実害は小さい。

## 検証

- apps/web vitest 38/38 pass
- typecheck (tsc -b) / biome / 本番 vite build いずれも pass
- レビュー: local claude / codex 両エージェントから APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)
