### PR TITLE
feat(ui): rshogi live viewer をブロードキャスト・レイアウト化し毎手の再マウントを解消

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -358,6 +358,30 @@ describe("subscribeRshogiLiveGame: 再接続", () => {
         expect(events.errors.some((e) => e.message.includes("上限"))).toBe(true);
     });
 
+    it("安定接続 (STABLE_CONNECTION_MS 継続) 後は attempt がリセットされ、散発的な切断では上限に達しない", () => {
+        const { wsInstances, wsFactory, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        // 上限 (=backoff 段数 6) を超える回数、安定接続→切断→再接続 を繰り返す。
+        const cycles = 9;
+        let ws = wsInstances[0];
+        for (let i = 0; i < cycles; i++) {
+            ws.fireOpen();
+            ws.fireLines(buildSnapshotLines([]));
+            // 30s 継続 = 安定接続とみなされ reconnectAttempt がリセットされる。
+            vi.advanceTimersByTime(30000);
+            ws.fireClose(1006, "blip");
+            // attempt はリセット済みなので毎回 backoff[0]=1000 で reconnect する。
+            vi.advanceTimersByTime(1000);
+            ws = wsInstances[wsInstances.length - 1];
+        }
+        // 上限超の回数を切断・再接続しても closed で止まらず新 WS を張り続ける。
+        expect(wsInstances.length).toBe(cycles + 1);
+    });
+
     it("disconnect() で MONITOR2OFF を送り close、reconnect を停止", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         const session = subscribeRshogiLiveGame(

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -328,6 +328,36 @@ describe("subscribeRshogiLiveGame: 再接続", () => {
         expect(events.states).toContain("closed");
     });
 
+    it("終局検知されない flap (接続成功→即 close) でも上限で打ち切り connected↔reconnecting を無限往復しない", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        // backoff 列と同じ回数だけ reconnect が走り、その後は打ち切られる。
+        const backoff = [1000, 2000, 4000, 8000, 16000, 30000];
+        // 初回接続 → 終局コードを含まない snapshot → close (endFired は false のまま)
+        wsInstances[0].fireOpen();
+        wsInstances[0].fireLines(buildSnapshotLines([]));
+        wsInstances[0].fireClose(1006, "flap");
+        // 各 backoff 遅延で reconnect → 接続成功 → 即 close を繰り返す。
+        // onopen で attempt をリセットしないため delay は単調増加する。
+        for (let i = 0; i < backoff.length; i++) {
+            vi.advanceTimersByTime(backoff[i]);
+            expect(wsInstances.length).toBe(i + 2);
+            const ws = wsInstances[i + 1];
+            ws.fireOpen();
+            ws.fireLines(buildSnapshotLines([]));
+            ws.fireClose(1006, "flap");
+        }
+        // 上限到達後はどれだけ時間を進めても新しい WS を張らず closed で確定する。
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(backoff.length + 1);
+        expect(events.states.at(-1)).toBe("closed");
+        expect(events.errors.some((e) => e.message.includes("上限"))).toBe(true);
+    });
+
     it("disconnect() で MONITOR2OFF を送り close、reconnect を停止", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         const session = subscribeRshogiLiveGame(

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -129,6 +129,13 @@ export interface RshogiLiveSession {
 const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000] as const;
 
 /**
+ * reconnect 試行回数の上限。超えたら確定 closed にして再接続ループを止める。
+ * `onopen` で attempt をリセットしないため、終局済 DO の「接続成功→即 close」flap も
+ * この回数で必ず収束する (= 無限に reconnecting/connected を往復しない)。
+ */
+const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
+
+/**
  * `Game_Summary` block の `Total_Time:` `Byoyomi:` `Increment:` 等を
  * `RshogiTimeControl` 風の構造体に decode する。
  */
@@ -487,6 +494,14 @@ export function subscribeRshogiLiveGame(
 
     const scheduleReconnect = () => {
         if (disposed) return;
+        // 上限到達: これ以上は再接続せず確定 closed にする (無限 flap を断ち切る)。
+        // emitError は disposed 中は無視される契約なので、disposed を立てる前に通知する。
+        if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+            emitError(new Error("再接続の上限に達したため観戦を終了しました"));
+            disposed = true;
+            emitConnectionState("closed");
+            return;
+        }
         const delayIdx = Math.min(reconnectAttempt, RECONNECT_BACKOFF_MS.length - 1);
         const delay = RECONNECT_BACKOFF_MS[delayIdx];
         reconnectAttempt += 1;
@@ -664,7 +679,9 @@ export function subscribeRshogiLiveGame(
 
         socket.onopen = () => {
             if (disposed || ws !== socket) return;
-            reconnectAttempt = 0;
+            // ここで reconnectAttempt をリセットしない。終局済 DO は「接続成功→即
+            // close」を繰り返すため、リセットすると backoff が 1s に戻り無限 flap に
+            // なる。attempt は close 時に積み増し、MAX_RECONNECT_ATTEMPTS で収束させる。
             emitConnectionState("connected");
             try {
                 socket.send(`%%MONITOR2ON ${gameId}\n`);

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -130,10 +130,18 @@ const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000] as const;
 
 /**
  * reconnect 試行回数の上限。超えたら確定 closed にして再接続ループを止める。
- * `onopen` で attempt をリセットしないため、終局済 DO の「接続成功→即 close」flap も
- * この回数で必ず収束する (= 無限に reconnecting/connected を往復しない)。
+ * attempt は `onopen` 即時ではなく「安定接続が継続した」ときだけリセットするため、
+ * 終局済 DO の「接続成功→即 close」flap はこの回数で必ず収束する (= 無限に
+ * reconnecting/connected を往復しない) 一方、安定観戦中の散発的な切断では累積上限に
+ * 達しない。
  */
 const MAX_RECONNECT_ATTEMPTS = RECONNECT_BACKOFF_MS.length;
+
+/**
+ * open がこの時間継続したら「安定接続」とみなして reconnectAttempt をリセットする。
+ * これ未満で閉じる接続 (flap) はリセット対象にせず、backoff を単調増加させる。
+ */
+const STABLE_CONNECTION_MS = 30_000;
 
 /**
  * `Game_Summary` block の `Total_Time:` `Byoyomi:` `Increment:` 等を
@@ -492,6 +500,15 @@ export function subscribeRshogiLiveGame(
         }
     };
 
+    /** 安定接続判定タイマー。open 継続が STABLE_CONNECTION_MS に達したら attempt をリセット。 */
+    let stableTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearStableTimer = () => {
+        if (stableTimer !== null) {
+            clearTimeoutImpl(stableTimer);
+            stableTimer = null;
+        }
+    };
+
     const scheduleReconnect = () => {
         if (disposed) return;
         // 上限到達: これ以上は再接続せず確定 closed にする (無限 flap を断ち切る)。
@@ -679,9 +696,15 @@ export function subscribeRshogiLiveGame(
 
         socket.onopen = () => {
             if (disposed || ws !== socket) return;
-            // ここで reconnectAttempt をリセットしない。終局済 DO は「接続成功→即
-            // close」を繰り返すため、リセットすると backoff が 1s に戻り無限 flap に
-            // なる。attempt は close 時に積み増し、MAX_RECONNECT_ATTEMPTS で収束させる。
+            // open 即時に reconnectAttempt をリセットしない。終局済 DO は「接続成功→
+            // 即 close」を繰り返すため、即リセットすると backoff が 1s に戻り無限 flap
+            // になる。代わりに STABLE_CONNECTION_MS だけ open が継続したら安定接続と
+            // みなしてリセットし、安定観戦中の散発切断では累積上限に達しないようにする。
+            clearStableTimer();
+            stableTimer = setTimeoutImpl(() => {
+                stableTimer = null;
+                reconnectAttempt = 0;
+            }, STABLE_CONNECTION_MS);
             emitConnectionState("connected");
             try {
                 socket.send(`%%MONITOR2ON ${gameId}\n`);
@@ -716,6 +739,8 @@ export function subscribeRshogiLiveGame(
         socket.onclose = () => {
             if (ws !== socket) return;
             ws = null;
+            // 接続が閉じたので安定判定タイマーは無効化する (close から先は flap 扱い)。
+            clearStableTimer();
             recvBuffer = "";
             snapshotLines = [];
             inSnapshot = false;
@@ -751,6 +776,7 @@ export function subscribeRshogiLiveGame(
                 if (disposed) return;
                 disposed = true;
                 cancelReconnect();
+                clearStableTimer();
                 if (ws) {
                     try {
                         ws.send("%%MONITOR2OFF\n");
@@ -776,6 +802,7 @@ export function subscribeRshogiLiveGame(
             if (disposed) return;
             disposed = true;
             cancelReconnect();
+            clearStableTimer();
             const socket = ws;
             ws = null;
             if (socket) {

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { computeRemaining } from "./rshogi-csa-live-viewer";
+
+describe("computeRemaining", () => {
+    it("手番側 (sideToMove) のみ経過分を減算し、相手側は据え置く", () => {
+        const remaining = computeRemaining(
+            { sente: 60_000, gote: 45_000, sideToMove: "sente" },
+            5_000,
+        );
+        expect(remaining).toEqual({ sente: 55_000, gote: 45_000 });
+    });
+
+    it("後手番では後手側のみ減算する", () => {
+        const remaining = computeRemaining(
+            { sente: 60_000, gote: 45_000, sideToMove: "gote" },
+            5_000,
+        );
+        expect(remaining).toEqual({ sente: 60_000, gote: 40_000 });
+    });
+
+    it("手番側の残時間が経過分を下回っても 0 で止める", () => {
+        const remaining = computeRemaining(
+            { sente: 3_000, gote: 45_000, sideToMove: "sente" },
+            5_000,
+        );
+        expect(remaining).toEqual({ sente: 0, gote: 45_000 });
+    });
+
+    it("clocks 未取得時は両者 0 を返す", () => {
+        expect(computeRemaining(null, 5_000)).toEqual({ sente: 0, gote: 0 });
+    });
+});

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -156,7 +156,7 @@ function ScoreboardSide({
             <span
                 className={cn(
                     "flex h-9 w-9 flex-none items-center justify-center rounded-full border border-wafuu-sumi text-lg leading-none",
-                    isSente ? "bg-wafuu-sumi text-white" : "bg-wafuu-washi text-wafuu-sumi",
+                    isSente ? "bg-wafuu-sumi text-background" : "bg-wafuu-washi text-wafuu-sumi",
                 )}
                 aria-hidden="true"
             >

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -4,15 +4,15 @@
  * 静的単局 viewer (`RshogiCsaViewer`) と異なり、`subscribeRshogiLiveGame` を介して
  * WebSocket で server から snapshot + broadcast move を受信し、画面を逐次更新する。
  *
- * MVP では以下に絞る:
- * - 接続状態バナー (connecting / connected / reconnecting / closed) を画面上部に表示
- * - snapshot 受信時は state 全置換、`<ShogiMatch>` の `key` を bump して remount
- * - broadcast move 受信時も累計 moves を拡張して remount し UI を再生
- * - clock countdown は `Black/White_Time_Remaining_Ms:` を anchor に local timer
- *   で減算 (1Hz 程度、`requestAnimationFrame` ではなく `setInterval` で十分)
- * - 終局時に最終結果を表示
+ * - snapshot 受信時のみ state を全置換し `<ShogiMatch>` を remount (key=snapshotEpoch)。
+ *   broadcast move では key を変えず initialReview.moves を伸ばし、prop 更新で反映する
+ *   (毎手 remount しないので盤・棋譜がちらつかない)。
+ * - 対局者・時計・手数・接続状態は上部のブロードキャスト・スコアボードに集約表示する。
+ * - clock countdown は server の残時間を anchor に local timer で 1Hz 減算する。
+ * - 終局時に最終結果を表示する。
  */
 
+import { cn } from "@shogi/design-system";
 import {
     type RshogiGameMeta,
     type RshogiGameResult,
@@ -47,10 +47,12 @@ interface LiveState {
     moves: string[];
     /** 表示中の対局結果 (終局後)。 */
     result?: RshogiGameResult;
-    /** snapshot 適用ごとに増えるカウンタ。`<ShogiMatch>` の key bump に使う。 */
+    /**
+     * snapshot 適用ごとに増えるカウンタ。`<ShogiMatch>` の key に使う。
+     * snapshot は全置換 (接続/再接続時のみ) なので remount してよいが、broadcast
+     * move では key を変えず prop 更新で反映する (毎手 remount を避けてちらつきを防ぐ)。
+     */
     snapshotEpoch: number;
-    /** broadcast move 適用ごとに増えるカウンタ (snapshot epoch と組合せて key 生成)。 */
-    moveEpoch: number;
     /** 最後に server から受け取った clock 残時間 (ms)。 */
     clocks: { sente: number; gote: number; sideToMove: "sente" | "gote" } | null;
     /** clock を local timer で減算するための anchor (ms epoch)。 */
@@ -64,7 +66,6 @@ const initialLiveState: LiveState = {
     snapshot: null,
     moves: [],
     snapshotEpoch: 0,
-    moveEpoch: 0,
     clocks: null,
     clockAnchorAtMs: null,
     connectionState: "connecting",
@@ -115,64 +116,166 @@ const formatResultText = (meta: RshogiGameMeta | undefined, result: RshogiGameRe
     return `${winnerLabel} (${reason})`;
 };
 
-function RshogiLiveMetaPanel({
+/** 手番側だけ countdown した先手・後手の残時間 (ms)。 */
+export function computeRemaining(
+    clocks: LiveState["clocks"],
+    elapsedSinceAnchor: number,
+): { sente: number; gote: number } {
+    return {
+        sente:
+            clocks && clocks.sideToMove === "sente"
+                ? Math.max(0, clocks.sente - elapsedSinceAnchor)
+                : (clocks?.sente ?? 0),
+        gote:
+            clocks && clocks.sideToMove === "gote"
+                ? Math.max(0, clocks.gote - elapsedSinceAnchor)
+                : (clocks?.gote ?? 0),
+    };
+}
+
+/** スコアボードの片側 (対局者名 + 残時間)。手番側は朱で点灯する。 */
+function ScoreboardSide({
+    side,
+    name,
+    remainingMs,
+    active,
+}: {
+    side: "sente" | "gote";
+    name: string;
+    remainingMs: number;
+    active: boolean;
+}): ReactElement {
+    const isSente = side === "sente";
+    return (
+        <div
+            className={cn(
+                "flex min-w-0 items-center gap-3 px-4 py-3",
+                isSente ? "flex-row" : "flex-row-reverse text-right",
+            )}
+        >
+            <span
+                className={cn(
+                    "flex h-9 w-9 flex-none items-center justify-center rounded-full border border-wafuu-sumi text-lg leading-none",
+                    isSente ? "bg-wafuu-sumi text-white" : "bg-wafuu-washi text-wafuu-sumi",
+                )}
+                aria-hidden="true"
+            >
+                {isSente ? "☗" : "☖"}
+            </span>
+            <div className="min-w-0">
+                <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+                    {isSente ? "先手" : "後手"}
+                </div>
+                <div className="truncate text-base font-bold text-wafuu-sumi">
+                    {name || (isSente ? "先手" : "後手")}
+                </div>
+            </div>
+            <div
+                className={cn(
+                    "flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-2xl font-bold leading-none tabular-nums transition-colors",
+                    isSente ? "ml-auto" : "mr-auto",
+                    active ? "bg-wafuu-shu/10 text-wafuu-shu" : "text-wafuu-sumi-light",
+                )}
+            >
+                {active && (
+                    <span
+                        className="h-1.5 w-1.5 flex-none rounded-full bg-wafuu-shu animate-pulse motion-reduce:animate-none"
+                        aria-hidden="true"
+                    />
+                )}
+                {formatMs(remainingMs)}
+            </div>
+        </div>
+    );
+}
+
+/** 対局者・時計・手数・接続状態を対面表示するブロードキャスト・スコアボード。 */
+function RshogiLiveScoreboard({
     meta,
-    moves,
+    moveCount,
     clocks,
     elapsedSinceAnchor,
+    connectionState,
     result,
 }: {
     meta: RshogiGameMeta;
-    moves: string[];
+    moveCount: number;
     clocks: LiveState["clocks"];
     elapsedSinceAnchor: number;
+    connectionState: RshogiLiveConnectionState;
     result?: RshogiGameResult;
 }): ReactElement {
-    // 手番側だけ countdown する (相手側は anchor 値を据え置き表示)。
-    const senteRemainingMs =
-        clocks && clocks.sideToMove === "sente"
-            ? Math.max(0, clocks.sente - elapsedSinceAnchor)
-            : (clocks?.sente ?? 0);
-    const goteRemainingMs =
-        clocks && clocks.sideToMove === "gote"
-            ? Math.max(0, clocks.gote - elapsedSinceAnchor)
-            : (clocks?.gote ?? 0);
+    const remaining = computeRemaining(clocks, elapsedSinceAnchor);
+    const isConnected = connectionState === "connected";
+    const turnLabel = result
+        ? "終局"
+        : clocks?.sideToMove === "sente"
+          ? "☗ 先手番"
+          : clocks?.sideToMove === "gote"
+            ? "☖ 後手番"
+            : "";
+    return (
+        <section
+            aria-label="対局スコアボード"
+            className="grid grid-cols-1 overflow-hidden rounded-xl border border-wafuu-border bg-wafuu-washi-warm shadow-sm sm:grid-cols-[1fr_auto_1fr]"
+        >
+            <ScoreboardSide
+                side="sente"
+                name={meta.senteName}
+                remainingMs={remaining.sente}
+                active={!result && clocks?.sideToMove === "sente"}
+            />
+            <div className="flex flex-row items-center justify-between gap-3 border-y border-wafuu-border bg-wafuu-washi px-4 py-2 sm:flex-col sm:justify-center sm:gap-1 sm:border-x sm:border-y-0">
+                <span className="text-xl font-bold tabular-nums leading-none text-wafuu-sumi">
+                    {moveCount}
+                    <span className="ml-0.5 text-xs font-semibold text-muted-foreground">手</span>
+                </span>
+                {isConnected && !result ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-wafuu-shu/10 px-2.5 py-0.5 text-[11px] font-bold tracking-wider text-wafuu-shu">
+                        <span
+                            className="h-1.5 w-1.5 rounded-full bg-wafuu-shu animate-pulse motion-reduce:animate-none"
+                            aria-hidden="true"
+                        />
+                        LIVE
+                    </span>
+                ) : (
+                    <span className="rounded-full bg-wafuu-sumi/5 px-2.5 py-0.5 text-[11px] font-semibold text-muted-foreground">
+                        {result ? "対局終了" : CONNECTION_LABEL[connectionState]}
+                    </span>
+                )}
+                <span className="text-xs text-muted-foreground">{turnLabel}</span>
+            </div>
+            <ScoreboardSide
+                side="gote"
+                name={meta.goteName}
+                remainingMs={remaining.gote}
+                active={!result && clocks?.sideToMove === "gote"}
+            />
+        </section>
+    );
+}
+
+/** 対局 ID と最終結果のみを表示する補助パネル (名前/時計はスコアボードに集約)。 */
+function RshogiLiveMetaPanel({
+    meta,
+    result,
+}: {
+    meta: RshogiGameMeta;
+    result?: RshogiGameResult;
+}): ReactElement {
     return (
         <section
             aria-label="観戦情報"
-            className="flex flex-col gap-2 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-sm text-wafuu-sumi"
+            className="flex flex-col gap-3 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-sm text-wafuu-sumi"
         >
             <div className="flex flex-col gap-1">
-                <span className="text-xs text-muted-foreground">対局 ID</span>
-                <span className="font-mono text-xs text-wafuu-sumi">{meta.gameId}</span>
-            </div>
-            <div className="flex flex-col gap-1">
-                <span className="text-xs text-muted-foreground">対局者</span>
-                <span className="text-sm font-semibold">
-                    ☗ {meta.senteName || "先手"} vs ☖ {meta.goteName || "後手"}
+                <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                    対局 ID
                 </span>
+                <span className="break-all font-mono text-xs text-wafuu-sumi">{meta.gameId}</span>
             </div>
-            {clocks && (
-                <div className="flex flex-col gap-0.5 text-sm">
-                    <span
-                        className={
-                            clocks.sideToMove === "sente" ? "font-semibold text-wafuu-shu" : ""
-                        }
-                    >
-                        ☗ 残り {formatMs(senteRemainingMs)}
-                    </span>
-                    <span
-                        className={
-                            clocks.sideToMove === "gote" ? "font-semibold text-wafuu-shu" : ""
-                        }
-                    >
-                        ☖ 残り {formatMs(goteRemainingMs)}
-                    </span>
-                </div>
-            )}
-            <div className="text-xs text-muted-foreground">手数: {moves.length}</div>
             {result && (
-                <div className="rounded border border-wafuu-shu/40 bg-wafuu-shu/10 px-2 py-1 text-sm font-semibold text-wafuu-shu">
+                <div className="rounded-md border border-wafuu-shu/40 bg-wafuu-shu/10 px-2.5 py-1.5 text-sm font-semibold text-wafuu-shu">
                     {formatResultText(meta, result)}
                 </div>
             )}
@@ -207,7 +310,6 @@ export function RshogiCsaLiveViewer({
                     moves: snapshot.moves,
                     result: snapshot.finalResult ?? prev.result,
                     snapshotEpoch: prev.snapshotEpoch + 1,
-                    moveEpoch: 0,
                     clocks: snapshot.clocks,
                     clockAnchorAtMs: Date.now(),
                     lastError: undefined,
@@ -217,7 +319,6 @@ export function RshogiCsaLiveViewer({
                 setState((prev) => ({
                     ...prev,
                     moves: [...prev.moves, csaMove],
-                    moveEpoch: prev.moveEpoch + 1,
                     // broadcast move 到着時に手番側を切り替える (= clock の anchor も
                     // 更新してロジックを単純化する。サーバから次 snapshot が来たら
                     // 上書きされる)。
@@ -313,21 +414,16 @@ export function RshogiCsaLiveViewer({
     }
 
     const meta = state.snapshot.meta;
-    // snapshot ごとに `<ShogiMatch>` を remount し、broadcast move 到着時にも
-    // 累計手で再 import するため moveEpoch も key に含める。
-    const matchKey = `${state.snapshotEpoch}-${state.moveEpoch}`;
+    // key は snapshotEpoch のみ。broadcast move では key を変えず初期 review prop の
+    // 更新で反映するため、`<ShogiMatch>` を毎手 remount せずちらつきが起きない。
+    const matchKey = String(state.snapshotEpoch);
 
     return (
         <div className="flex flex-col gap-2">
             {header}
-            <div className="flex flex-wrap items-center gap-2 px-4 pt-2 text-xs">
-                <span
-                    className={`rounded px-2 py-0.5 ${CONNECTION_BADGE_CLASS[state.connectionState]}`}
-                >
-                    {CONNECTION_LABEL[state.connectionState]}
-                </span>
-                {state.lastError && <span className="text-destructive">{state.lastError}</span>}
-            </div>
+            {state.lastError && (
+                <div className="px-4 pt-2 text-xs text-destructive">{state.lastError}</div>
+            )}
             <ShogiMatch
                 key={matchKey}
                 engineOptions={engineOptions}
@@ -342,15 +438,17 @@ export function RshogiCsaLiveViewer({
                 }}
                 initialReview={{ sfen: "startpos", moves: state.moves }}
                 reviewMode={true}
-                reviewLeftContent={
-                    <RshogiLiveMetaPanel
+                reviewTopContent={
+                    <RshogiLiveScoreboard
                         meta={meta}
-                        moves={state.moves}
+                        moveCount={state.moves.length}
                         clocks={state.clocks}
                         elapsedSinceAnchor={elapsedSinceAnchor}
+                        connectionState={state.connectionState}
                         result={state.result}
                     />
                 }
+                reviewLeftContent={<RshogiLiveMetaPanel meta={meta} result={state.result} />}
             />
         </div>
     );

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -22,7 +22,7 @@ import {
     type RshogiLiveSnapshot,
     subscribeRshogiLiveGame,
 } from "@shogi/match-client";
-import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+import { type ReactElement, type ReactNode, useEffect, useRef, useState } from "react";
 import { ShogiMatch } from "./shogi-match";
 import type { EngineOption } from "./shogi-match/types";
 
@@ -225,7 +225,7 @@ function RshogiLiveScoreboard({
                 remainingMs={remaining.sente}
                 active={!result && clocks?.sideToMove === "sente"}
             />
-            <div className="flex flex-row items-center justify-between gap-3 border-y border-wafuu-border bg-wafuu-washi px-4 py-2 sm:flex-col sm:justify-center sm:gap-1 sm:border-x sm:border-y-0">
+            <div className="flex flex-row items-center justify-between gap-3 border-y border-wafuu-border bg-wafuu-washi px-4 py-2 sm:min-w-[7.5rem] sm:flex-col sm:justify-center sm:gap-1 sm:border-x sm:border-y-0">
                 <span className="text-xl font-bold tabular-nums leading-none text-wafuu-sumi">
                     {moveCount}
                     <span className="ml-0.5 text-xs font-semibold text-muted-foreground">手</span>
@@ -295,6 +295,8 @@ export function RshogiCsaLiveViewer({
     isDevMode,
 }: RshogiCsaLiveViewerProps): ReactElement {
     const [state, setState] = useState<LiveState>(initialLiveState);
+    /** 現在の購読セッション。終局時に明示 disconnect して再接続を止めるために保持する。 */
+    const sessionRef = useRef<RshogiLiveSession | null>(null);
     /** clock countdown 用の現在時刻 (1Hz 更新)。 */
     const [tickMs, setTickMs] = useState<number>(() => Date.now());
 
@@ -373,10 +375,20 @@ export function RshogiCsaLiveViewer({
                 connectionState: "closed",
             }));
         }
+        sessionRef.current = session;
         return () => {
             session?.disconnect();
+            sessionRef.current = null;
         };
     }, [gameId, apiBaseUrl]);
+
+    // 終局が確定したら購読を明示的に閉じる。終局済 DO は「接続成功→即 close」を
+    // 繰り返すことがあり、これを止めないと connected↔reconnecting を往復し続ける。
+    useEffect(() => {
+        if (state.result) {
+            sessionRef.current?.disconnect();
+        }
+    }, [state.result]);
 
     // clock countdown 用の 1Hz tick。終局後・clock 未取得時は止めて無駄な再描画を抑える。
     useEffect(() => {
@@ -421,7 +433,9 @@ export function RshogiCsaLiveViewer({
     return (
         <div className="flex flex-col gap-2">
             {header}
-            {state.lastError && (
+            {/* エラーは終局前の確定 closed 時のみ表示する。reconnect 中に出し入れすると
+                行の出現でレイアウトシフトが連発するため、振動する状態では出さない。 */}
+            {!state.result && state.connectionState === "closed" && state.lastError && (
                 <div className="px-4 pt-2 text-xs text-destructive">{state.lastError}</div>
             )}
             <ShogiMatch

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1285,13 +1285,14 @@ export function ShogiMatch({
         setIsMatchRunning,
     });
 
-    // initialReview を取り込む。live 観戦では moves が逐次伸びるため、同一 sfen で
-    // moves が伸びるたびに importSfen で末尾まで再構築する。`<ShogiMatch>` を
-    // remount せず DOM を据え置いたまま再構築するので、盤・棋譜が白く飛ばない。
-    // importSfen / navigation は毎レンダー再生成されるため ref 経由で参照し、
-    // effect の発火は positionReady と initialReview の sfen/moves 参照変化に限定する
-    // (clock tick 等の無関係な再 render で再ロードしない)。
-    const loadedReviewRef = useRef<{ sfen: string; moves: string[] } | null>(null);
+    // initialReview を取り込む。live 観戦では moves が逐次伸びるため、moves が伸びる
+    // たびに importSfen で末尾まで再構築する。`<ShogiMatch>` を remount せず DOM を
+    // 据え置いたまま再構築するので、盤・棋譜が白く飛ばない。
+    // 取込判定は参照ではなく内容 (sfen + moves の連結文字列) で行う。`initialReview`
+    // や moves 配列は呼び出し側で毎レンダー再生成され得るが、内容が同じなら再 import
+    // しない (clock tick 等の無関係な再 render や、同内容を再生成する親に強い)。
+    // importSfen / navigation は毎レンダー再生成されるため ref 経由で参照する。
+    const loadedReviewRef = useRef<{ sfen: string; movesKey: string } | null>(null);
     const importSfenRef = useRef(importSfen);
     importSfenRef.current = importSfen;
     const navigationRef = useRef(navigation);
@@ -1299,12 +1300,18 @@ export function ShogiMatch({
     const initialAnalysisAppliedRef = useRef<string | null>(null);
     const reviewSfen = initialReview?.sfen;
     const reviewMoves = initialReview?.moves;
+    const reviewMovesKey = reviewMoves?.join(" ");
     useEffect(() => {
-        if (!positionReady || reviewSfen === undefined || reviewMoves === undefined) {
+        if (
+            !positionReady ||
+            reviewSfen === undefined ||
+            reviewMoves === undefined ||
+            reviewMovesKey === undefined
+        ) {
             return;
         }
         const loaded = loadedReviewRef.current;
-        if (loaded && loaded.sfen === reviewSfen && loaded.moves === reviewMoves) {
+        if (loaded && loaded.sfen === reviewSfen && loaded.movesKey === reviewMovesKey) {
             return;
         }
 
@@ -1314,12 +1321,14 @@ export function ShogiMatch({
         const wasFollowingTip = navState.currentPly === navState.totalPly;
         const restorePly = navState.currentPly;
 
-        // await 前に確定して StrictMode の二重実行 / 連続着手の競合を冪等化する。
-        loadedReviewRef.current = { sfen: reviewSfen, moves: reviewMoves };
+        // await 前に確定して StrictMode の二重実行を冪等化する。連続着手で先行 import が
+        // 後着 import に追い越されたら、isStale で古い import の state 適用を中止する。
+        loadedReviewRef.current = { sfen: reviewSfen, movesKey: reviewMovesKey };
         void importSfenRef.current(reviewSfen, reviewMoves, {
             gotoPly: wasFollowingTip ? undefined : restorePly,
+            isStale: () => loadedReviewRef.current?.movesKey !== reviewMovesKey,
         });
-    }, [positionReady, reviewSfen, reviewMoves]);
+    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey]);
 
     useEffect(() => {
         if (!positionReady || !initialAnalysisEntries || initialAnalysisEntries.length === 0) {

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1326,7 +1326,9 @@ export function ShogiMatch({
         loadedReviewRef.current = { sfen: reviewSfen, movesKey: reviewMovesKey };
         void importSfenRef.current(reviewSfen, reviewMoves, {
             gotoPly: wasFollowingTip ? undefined : restorePly,
-            isStale: () => loadedReviewRef.current?.movesKey !== reviewMovesKey,
+            isStale: () =>
+                loadedReviewRef.current?.sfen !== reviewSfen ||
+                loadedReviewRef.current?.movesKey !== reviewMovesKey,
         });
     }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey]);
 

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -128,6 +128,8 @@ interface ShogiMatchProps {
     reviewMode?: boolean;
     /** 棋譜検討モード時に左サイドバー位置に表示するコンテンツ */
     reviewLeftContent?: React.ReactNode;
+    /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
+    reviewTopContent?: React.ReactNode;
     /** 外部エンジン管理パネルを開くコールバック（Desktop用） */
     onOpenEngineManager?: () => void;
     /** 起動中外部エンジン設定パネルを開くコールバック（Desktop用） */
@@ -162,6 +164,7 @@ export function ShogiMatch({
     initialAnalysisEntries = null,
     reviewMode,
     reviewLeftContent,
+    reviewTopContent,
     onOpenEngineManager,
     onOpenEngineSettings,
 }: ShogiMatchProps): ReactElement {
@@ -1282,18 +1285,41 @@ export function ShogiMatch({
         setIsMatchRunning,
     });
 
-    // マウント時に initialReview が指定されていれば棋譜を読み込む（一度だけ実行）
-    const initialReviewHandledRef = useRef(false);
+    // initialReview を取り込む。live 観戦では moves が逐次伸びるため、同一 sfen で
+    // moves が伸びるたびに importSfen で末尾まで再構築する。`<ShogiMatch>` を
+    // remount せず DOM を据え置いたまま再構築するので、盤・棋譜が白く飛ばない。
+    // importSfen / navigation は毎レンダー再生成されるため ref 経由で参照し、
+    // effect の発火は positionReady と initialReview の sfen/moves 参照変化に限定する
+    // (clock tick 等の無関係な再 render で再ロードしない)。
+    const loadedReviewRef = useRef<{ sfen: string; moves: string[] } | null>(null);
+    const importSfenRef = useRef(importSfen);
+    importSfenRef.current = importSfen;
+    const navigationRef = useRef(navigation);
+    navigationRef.current = navigation;
     const initialAnalysisAppliedRef = useRef<string | null>(null);
+    const reviewSfen = initialReview?.sfen;
+    const reviewMoves = initialReview?.moves;
     useEffect(() => {
-        if (!positionReady) {
+        if (!positionReady || reviewSfen === undefined || reviewMoves === undefined) {
             return;
         }
-        if (initialReview && !initialReviewHandledRef.current) {
-            initialReviewHandledRef.current = true;
-            void importSfen(initialReview.sfen, initialReview.moves);
+        const loaded = loadedReviewRef.current;
+        if (loaded && loaded.sfen === reviewSfen && loaded.moves === reviewMoves) {
+            return;
         }
-    }, [importSfen, initialReview, positionReady]);
+
+        // 再構築前のカーソルを捕捉する。末尾追従中 (currentPly === totalPly) なら
+        // 最新手まで進め、途中検討中ならその ply を維持する。
+        const navState = navigationRef.current.state;
+        const wasFollowingTip = navState.currentPly === navState.totalPly;
+        const restorePly = navState.currentPly;
+
+        // await 前に確定して StrictMode の二重実行 / 連続着手の競合を冪等化する。
+        loadedReviewRef.current = { sfen: reviewSfen, moves: reviewMoves };
+        void importSfenRef.current(reviewSfen, reviewMoves, {
+            gotoPly: wasFollowingTip ? undefined : restorePly,
+        });
+    }, [positionReady, reviewSfen, reviewMoves]);
 
     useEffect(() => {
         if (!positionReady || !initialAnalysisEntries || initialAnalysisEntries.length === 0) {
@@ -1573,6 +1599,7 @@ export function ShogiMatch({
         onPassRightsSettingsOpenChange: setIsPassRightsSettingsOpen,
         reviewMode,
         reviewLeftContent,
+        reviewTopContent,
     };
 
     // Props グループ化: Mobile専用

--- a/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
@@ -24,9 +24,11 @@ const TEXT_CLASSES = {
  */
 interface PCBoardSectionProps {
     candidateNote: string | null;
+    /** 盤上部の対局時計を隠す（観戦/検討モードでは時計をスコアボードに集約するため） */
+    hideClock?: boolean;
 }
 
-export function PCBoardSection({ candidateNote }: PCBoardSectionProps): ReactElement {
+export function PCBoardSection({ candidateNote, hideClock }: PCBoardSectionProps): ReactElement {
     // 対局設定を取得
     const { timeSettings } = useMatchSettings();
 
@@ -87,12 +89,14 @@ export function PCBoardSection({ candidateNote }: PCBoardSectionProps): ReactEle
                 <div
                     className={`flex flex-col gap-2 items-center ${isDraggingPiece ? "touch-none" : ""}`}
                 >
-                    {/* 時間管理（将棋盤の上） */}
-                    <ClockDisplay
-                        clocks={clocks}
-                        timeSettings={timeSettings}
-                        isRunning={isMatchRunning}
-                    />
+                    {/* 時間管理（将棋盤の上）。観戦/検討モードでは非表示 */}
+                    {!hideClock && (
+                        <ClockDisplay
+                            clocks={clocks}
+                            timeSettings={timeSettings}
+                            isRunning={isMatchRunning}
+                        />
+                    )}
 
                     {/* ステータス行: [手数] [手番] [反転ボタン] */}
                     <div className="flex items-center justify-end w-full gap-4">

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
@@ -72,7 +72,7 @@ interface UseKifuImportExportReturn {
     importSfen: (
         sfen: string,
         movesToLoad: string[],
-        options?: { gotoPly?: number },
+        options?: { gotoPly?: number; isStale?: () => boolean },
     ) => Promise<void>;
     /** KIF形式をインポート */
     importKif: (
@@ -188,12 +188,17 @@ export function useKifuImportExport({
     const importSfen = async (
         sfen: string,
         movesToLoad: string[],
-        options?: { gotoPly?: number },
+        options?: { gotoPly?: number; isStale?: () => boolean },
     ) => {
         const service = getPositionService();
         try {
             // 新しい開始局面を設定
             const newPosition = await service.parseSfen(sfen);
+            // live 観戦の連続着手で先行 import が後着 import に追い越された場合、
+            // 古い moves で navigation を上書きしないよう適用前に最新性を確認して中止する。
+            if (options?.isStale?.()) {
+                return;
+            }
             setBasePosition(newPosition);
             setStartSfen(sfen);
             setInitialBoard(newPosition.board);
@@ -221,10 +226,11 @@ export function useKifuImportExport({
                 setLastMove(deriveLastMove(appliedMoves.at(-1)));
                 // 末尾以外の局面を検討中だった観戦者のカーソルを維持する。
                 // addMove 群と同じ同期ブロックで goToPly することで 1 レンダーに
-                // まとまり、末尾局面が一瞬見える描画を防ぐ。
+                // まとまり、末尾局面が一瞬見える描画を防ぐ。適用手数を上限にクランプ
+                // して、不正手などで適用手が短縮された場合も範囲外へ飛ばさない。
                 const { gotoPly } = options ?? {};
-                if (gotoPly !== undefined && gotoPly >= 0 && gotoPly < appliedMoves.length) {
-                    navigation.goToPly(gotoPly);
+                if (gotoPly !== undefined) {
+                    navigation.goToPly(Math.max(0, Math.min(gotoPly, appliedMoves.length)));
                 }
             } else {
                 setLastMove(undefined);

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
@@ -69,7 +69,11 @@ interface UseKifuImportExportReturn {
     /** KIF形式でコピー */
     handleCopyKif: () => string;
     /** SFENと指し手をインポート */
-    importSfen: (sfen: string, movesToLoad: string[]) => Promise<void>;
+    importSfen: (
+        sfen: string,
+        movesToLoad: string[],
+        options?: { gotoPly?: number },
+    ) => Promise<void>;
     /** KIF形式をインポート */
     importKif: (
         movesToLoad: string[],
@@ -181,7 +185,11 @@ export function useKifuImportExport({
      * SFENインポート（局面 + 指し手）
      * インポート後は自動的に検討モードに入る
      */
-    const importSfen = async (sfen: string, movesToLoad: string[]) => {
+    const importSfen = async (
+        sfen: string,
+        movesToLoad: string[],
+        options?: { gotoPly?: number },
+    ) => {
         const service = getPositionService();
         try {
             // 新しい開始局面を設定
@@ -211,6 +219,13 @@ export function useKifuImportExport({
                     }
                 }
                 setLastMove(deriveLastMove(appliedMoves.at(-1)));
+                // 末尾以外の局面を検討中だった観戦者のカーソルを維持する。
+                // addMove 群と同じ同期ブロックで goToPly することで 1 レンダーに
+                // まとまり、末尾局面が一瞬見える描画を防ぐ。
+                const { gotoPly } = options ?? {};
+                if (gotoPly !== undefined && gotoPly >= 0 && gotoPly < appliedMoves.length) {
+                    navigation.goToPly(gotoPly);
+                }
             } else {
                 setLastMove(undefined);
             }

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -153,9 +153,14 @@ export function PCLayout({
                 // 潰すと盤がはみ出す。中央寄せの flex 行にし、収まる幅では mx-auto で
                 // 中央寄せ、収まらない幅では mx-auto が 0 に畳まれて左寄せ + 横スク
                 // ロールに退避する (列を潰さず盤の重なりを防ぐ)。
+                // 行は w-max (max-content) で常に内容幅を確保し、available 幅へ
+                // クランプされて子が縮むのを防ぐ。LeftSidebar は shrink-0 が無いので
+                // ラッパーで縮小を止める (盤・棋譜は各 root が shrink-0)。
                 <div className="w-full overflow-x-auto">
-                    <div className="mx-auto flex w-fit items-start gap-4 px-4 py-2">
-                        <LeftSidebar />
+                    <div className="mx-auto flex w-max items-start gap-4 px-4 py-2">
+                        <div className="shrink-0">
+                            <LeftSidebar />
+                        </div>
                         <PCBoardSection candidateNote={candidateNote} />
                         <PCKifuSection />
                     </div>

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -126,7 +126,14 @@ export function PCLayout({
                 // 1080px 未満では盤→棋譜→情報の順に縦積みする。
                 <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
                     {reviewTopContent}
-                    <div className="grid grid-cols-1 gap-4 min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)] min-[1080px]:items-start">
+                    {/* 左コンテンツ有無で列数を切り替え、無いときに盤を狭い列へ押し込まない */}
+                    <div
+                        className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${
+                            reviewLeftContent
+                                ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
+                                : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
+                        }`}
+                    >
                         {reviewLeftContent && (
                             <div className="order-3 min-w-0 min-[1080px]:order-none">
                                 {reviewLeftContent}

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -119,52 +119,41 @@ export function PCLayout({
 
     // NavigationContext から取得（ダイアログで使用）
     const { displaySettings: navDisplaySettings } = navigation;
+
+    // 全モード共通の中央 3 カラム Grid。左カラムは観戦=情報パネル / 対局=設定サイド
+    // バーで内容も幅も異なるため、要素と列幅を reviewMode で出し分ける。観戦の情報
+    // パネルは無い場合もあるので、そのときは盤を狭い列へ押し込まないよう 2 列にする。
+    const leftColumn = reviewMode ? (
+        reviewLeftContent ? (
+            <div className="order-3 min-w-0 min-[1080px]:order-none">{reviewLeftContent}</div>
+        ) : null
+    ) : (
+        <div className="order-3 min-[1080px]:order-none">
+            <LeftSidebar />
+        </div>
+    );
+    const gridColsClass = reviewMode
+        ? reviewLeftContent
+            ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
+            : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
+        : "min-[1080px]:grid-cols-[auto_minmax(0,1fr)_minmax(300px,360px)]";
+
     return (
         <section className={matchLayoutClasses}>
-            {reviewMode ? (
-                // 検討/観戦モード: 中央 max-width の 1 ユニットを CSS Grid で 3 カラム化。
-                // 1080px 未満では盤→棋譜→情報の順に縦積みする。
-                <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
-                    {reviewTopContent}
-                    {/* 左コンテンツ有無で列数を切り替え、無いときに盤を狭い列へ押し込まない */}
-                    <div
-                        className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${
-                            reviewLeftContent
-                                ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
-                                : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
-                        }`}
-                    >
-                        {reviewLeftContent && (
-                            <div className="order-3 min-w-0 min-[1080px]:order-none">
-                                {reviewLeftContent}
-                            </div>
-                        )}
-                        <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
-                            <PCBoardSection candidateNote={candidateNote} hideClock />
-                        </div>
-                        <div className="order-2 min-w-0 min-[1080px]:order-none">
-                            <PCKifuSection />
-                        </div>
+            {/* 中央 max-width の 1 ユニットを CSS Grid で 3 カラム化。1080px 未満では
+                盤→棋譜→左カラム(情報/設定)の順に縦積みする。 */}
+            <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
+                {reviewMode && reviewTopContent}
+                <div className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${gridColsClass}`}>
+                    {leftColumn}
+                    <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
+                        <PCBoardSection candidateNote={candidateNote} hideClock={reviewMode} />
                     </div>
-                </div>
-            ) : (
-                <div className="relative min-h-[calc(100dvh-1rem)] min-w-[1400px] overflow-x-auto">
-                    {/* 左サイドバー（絶対配置） */}
-                    <div className="absolute left-4 top-4">
-                        <LeftSidebar />
-                    </div>
-
-                    {/* 将棋盤エリア（画面中央に固定） */}
-                    <div className="flex min-h-[calc(100dvh-1rem)] items-start justify-center p-4">
-                        <PCBoardSection candidateNote={candidateNote} />
-                    </div>
-
-                    {/* 棋譜セクション（絶対配置、viewport内に収める） */}
-                    <div className="absolute right-4 top-4 bottom-4 overflow-hidden">
+                    <div className="order-2 min-w-0 min-[1080px]:order-none">
                         <PCKifuSection />
                     </div>
                 </div>
-            )}
+            </div>
 
             {/* 設定モーダル（棋譜インポート等） */}
             <SettingsModal open={isSettingsModalOpen} onOpenChange={onSettingsModalOpenChange}>

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -120,40 +120,47 @@ export function PCLayout({
     // NavigationContext から取得（ダイアログで使用）
     const { displaySettings: navDisplaySettings } = navigation;
 
-    // 全モード共通の中央 3 カラム Grid。左カラムは観戦=情報パネル / 対局=設定サイド
-    // バーで内容も幅も異なるため、要素と列幅を reviewMode で出し分ける。観戦の情報
-    // パネルは無い場合もあるので、そのときは盤を狭い列へ押し込まないよう 2 列にする。
-    const leftColumn = reviewMode ? (
-        reviewLeftContent ? (
-            <div className="order-3 min-w-0 min-[1080px]:order-none">{reviewLeftContent}</div>
-        ) : null
-    ) : (
-        <div className="order-3 min-[1080px]:order-none">
-            <LeftSidebar />
-        </div>
-    );
-    const gridColsClass = reviewMode
-        ? reviewLeftContent
-            ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
-            : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
-        : "min-[1080px]:grid-cols-[auto_minmax(0,1fr)_minmax(300px,360px)]";
-
     return (
         <section className={matchLayoutClasses}>
-            {/* 中央 max-width の 1 ユニットを CSS Grid で 3 カラム化。1080px 未満では
-                盤→棋譜→左カラム(情報/設定)の順に縦積みする。 */}
-            <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
-                {reviewMode && reviewTopContent}
-                <div className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${gridColsClass}`}>
-                    {leftColumn}
-                    <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
-                        <PCBoardSection candidateNote={candidateNote} hideClock={reviewMode} />
+            {reviewMode ? (
+                // 観戦/検討モード: 中央 max-width の Grid 3 カラム。1080px 未満では
+                // 盤→棋譜→情報の順に縦積み。情報パネルが無いときは盤を狭い列へ
+                // 押し込まないよう 2 列にする。
+                <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
+                    {reviewTopContent}
+                    <div
+                        className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${
+                            reviewLeftContent
+                                ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
+                                : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
+                        }`}
+                    >
+                        {reviewLeftContent && (
+                            <div className="order-3 min-w-0 min-[1080px]:order-none">
+                                {reviewLeftContent}
+                            </div>
+                        )}
+                        <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
+                            <PCBoardSection candidateNote={candidateNote} hideClock />
+                        </div>
+                        <div className="order-2 min-w-0 min-[1080px]:order-none">
+                            <PCKifuSection />
+                        </div>
                     </div>
-                    <div className="order-2 min-w-0 min-[1080px]:order-none">
+                </div>
+            ) : (
+                // 対局モード: 設定サイドバー・盤・棋譜はいずれも固定幅のため Grid で
+                // 潰すと盤がはみ出す。中央寄せの flex 行にし、収まる幅では mx-auto で
+                // 中央寄せ、収まらない幅では mx-auto が 0 に畳まれて左寄せ + 横スク
+                // ロールに退避する (列を潰さず盤の重なりを防ぐ)。
+                <div className="w-full overflow-x-auto">
+                    <div className="mx-auto flex w-fit items-start gap-4 px-4 py-2">
+                        <LeftSidebar />
+                        <PCBoardSection candidateNote={candidateNote} />
                         <PCKifuSection />
                     </div>
                 </div>
-            </div>
+            )}
 
             {/* 設定モーダル（棋譜インポート等） */}
             <SettingsModal open={isSettingsModalOpen} onOpenChange={onSettingsModalOpenChange}>

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -79,6 +79,8 @@ interface PCLayoutProps {
     reviewMode?: boolean;
     /** 棋譜検討モード時に左サイドバー位置に表示するコンテンツ */
     reviewLeftContent?: ReactNode;
+    /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
+    reviewTopContent?: ReactNode;
 }
 
 /**
@@ -106,6 +108,7 @@ export function PCLayout({
     handlePassRightsSettingsChange,
     reviewMode,
     reviewLeftContent,
+    reviewTopContent,
 }: PCLayoutProps): ReactElement {
     // Context から状態を取得
     const matchSettings = useMatchSettings();
@@ -118,337 +121,348 @@ export function PCLayout({
     const { displaySettings: navDisplaySettings } = navigation;
     return (
         <section className={matchLayoutClasses}>
-            <div className="relative min-h-[calc(100dvh-1rem)] min-w-[1400px] overflow-x-auto">
-                {/* 左サイドバー（絶対配置）: 検討モードでは非表示 */}
-                {!reviewMode && (
+            {reviewMode ? (
+                // 検討/観戦モード: 中央 max-width の 1 ユニットを CSS Grid で 3 カラム化。
+                // 1080px 未満では盤→棋譜→情報の順に縦積みする。
+                <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
+                    {reviewTopContent}
+                    <div className="grid grid-cols-1 gap-4 min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)] min-[1080px]:items-start">
+                        {reviewLeftContent && (
+                            <div className="order-3 min-w-0 min-[1080px]:order-none">
+                                {reviewLeftContent}
+                            </div>
+                        )}
+                        <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
+                            <PCBoardSection candidateNote={candidateNote} hideClock />
+                        </div>
+                        <div className="order-2 min-w-0 min-[1080px]:order-none">
+                            <PCKifuSection />
+                        </div>
+                    </div>
+                </div>
+            ) : (
+                <div className="relative min-h-[calc(100dvh-1rem)] min-w-[1400px] overflow-x-auto">
+                    {/* 左サイドバー（絶対配置） */}
                     <div className="absolute left-4 top-4">
                         <LeftSidebar />
                     </div>
-                )}
-                {/* 検討モード時の左コンテンツ（スナップショットUI等） */}
-                {reviewMode && reviewLeftContent && (
-                    <div className="absolute left-4 top-4 w-[220px]">{reviewLeftContent}</div>
-                )}
 
-                {/* 将棋盤エリア（画面中央に固定） */}
-                <div className="flex min-h-[calc(100dvh-1rem)] items-start justify-center p-4">
-                    <PCBoardSection candidateNote={candidateNote} />
-                </div>
-
-                {/* 棋譜セクション（絶対配置、viewport内に収める） */}
-                <div className="absolute right-4 top-4 bottom-4 overflow-hidden">
-                    <PCKifuSection />
-                </div>
-
-                {/* 設定モーダル（棋譜インポート等） */}
-                <SettingsModal open={isSettingsModalOpen} onOpenChange={onSettingsModalOpenChange}>
-                    <div className="flex flex-col gap-6">
-                        {/* インポート */}
-                        <KifuImportPanel
-                            onImportSfen={importSfen}
-                            onImportKif={importKif}
-                            positionReady={positionReady}
-                        />
-
-                        {/* エンジンログ（開発モード） */}
-                        {isDevMode && (
-                            <EngineLogsPanel
-                                eventLogs={eventLogs}
-                                errorLogs={errorLogs}
-                                engineErrorDetails={engineErrorDetails}
-                                onRetry={retryEngine}
-                                isRetrying={isRetrying}
-                            />
-                        )}
+                    {/* 将棋盤エリア（画面中央に固定） */}
+                    <div className="flex min-h-[calc(100dvh-1rem)] items-start justify-center p-4">
+                        <PCBoardSection candidateNote={candidateNote} />
                     </div>
-                </SettingsModal>
 
-                {/* 表示設定ダイアログ */}
-                <Dialog open={isDisplaySettingsOpen} onOpenChange={onDisplaySettingsOpenChange}>
-                    <DialogContent className="w-[min(450px,calc(100%-24px))]">
+                    {/* 棋譜セクション（絶対配置、viewport内に収める） */}
+                    <div className="absolute right-4 top-4 bottom-4 overflow-hidden">
+                        <PCKifuSection />
+                    </div>
+                </div>
+            )}
+
+            {/* 設定モーダル（棋譜インポート等） */}
+            <SettingsModal open={isSettingsModalOpen} onOpenChange={onSettingsModalOpenChange}>
+                <div className="flex flex-col gap-6">
+                    {/* インポート */}
+                    <KifuImportPanel
+                        onImportSfen={importSfen}
+                        onImportKif={importKif}
+                        positionReady={positionReady}
+                    />
+
+                    {/* エンジンログ（開発モード） */}
+                    {isDevMode && (
+                        <EngineLogsPanel
+                            eventLogs={eventLogs}
+                            errorLogs={errorLogs}
+                            engineErrorDetails={engineErrorDetails}
+                            onRetry={retryEngine}
+                            isRetrying={isRetrying}
+                        />
+                    )}
+                </div>
+            </SettingsModal>
+
+            {/* 表示設定ダイアログ */}
+            <Dialog open={isDisplaySettingsOpen} onOpenChange={onDisplaySettingsOpenChange}>
+                <DialogContent className="w-[min(450px,calc(100%-24px))]">
+                    <DialogHeader>
+                        <DialogTitle>表示設定</DialogTitle>
+                    </DialogHeader>
+                    <div className="flex flex-col gap-4 pt-2">
+                        {/* マス内座標表示 */}
+                        <div className="flex flex-col gap-2">
+                            <span className="text-sm font-medium">マス内座標表示</span>
+                            <div className="flex gap-2">
+                                {(
+                                    [
+                                        { value: "none", label: "なし" },
+                                        { value: "sfen", label: "SFEN (5e)" },
+                                        { value: "japanese", label: "日本式 (５五)" },
+                                    ] as const
+                                ).map((opt) => (
+                                    <button
+                                        key={opt.value}
+                                        type="button"
+                                        onClick={() =>
+                                            setDisplaySettings({
+                                                ...navDisplaySettings,
+                                                squareNotation: opt.value,
+                                            })
+                                        }
+                                        className={`px-3 py-1.5 rounded text-sm transition-colors ${
+                                            navDisplaySettings.squareNotation === opt.value
+                                                ? "bg-wafuu-kincha text-white"
+                                                : "bg-wafuu-washi text-wafuu-sumi hover:bg-wafuu-border border border-wafuu-border"
+                                        }`}
+                                    >
+                                        {opt.label}
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+
+                        <div className="h-px bg-wafuu-border" />
+
+                        {/* チェックボックス項目 */}
+                        <label className="flex items-center gap-3 text-sm cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={navDisplaySettings.showBoardLabels}
+                                onChange={(e) =>
+                                    setDisplaySettings({
+                                        ...navDisplaySettings,
+                                        showBoardLabels: e.target.checked,
+                                    })
+                                }
+                                className="w-4 h-4"
+                            />
+                            <span>盤外ラベル表示（筋・段）</span>
+                        </label>
+                        <label className="flex items-center gap-3 text-sm cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={navDisplaySettings.highlightLastMove}
+                                onChange={(e) =>
+                                    setDisplaySettings({
+                                        ...navDisplaySettings,
+                                        highlightLastMove: e.target.checked,
+                                    })
+                                }
+                                className="w-4 h-4"
+                            />
+                            <span>最終手を強調</span>
+                        </label>
+                        <label className="flex items-center gap-3 text-sm cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={navDisplaySettings.showKifuEval}
+                                onChange={(e) =>
+                                    setDisplaySettings({
+                                        ...navDisplaySettings,
+                                        showKifuEval: e.target.checked,
+                                    })
+                                }
+                                className="w-4 h-4"
+                            />
+                            <span>棋譜パネルに評価値を表示</span>
+                        </label>
+                        <label className="flex items-center gap-3 text-sm cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={navDisplaySettings.enableWheelNavigation}
+                                onChange={(e) =>
+                                    setDisplaySettings({
+                                        ...navDisplaySettings,
+                                        enableWheelNavigation: e.target.checked,
+                                    })
+                                }
+                                className="w-4 h-4"
+                            />
+                            <span>ホイールナビゲーション</span>
+                        </label>
+                    </div>
+                </DialogContent>
+            </Dialog>
+
+            {/* 変則ルールダイアログ */}
+            {passRightsSettings && (
+                <Dialog
+                    open={isPassRightsSettingsOpen}
+                    onOpenChange={onPassRightsSettingsOpenChange}
+                >
+                    <DialogContent className="w-[min(400px,calc(100%-24px))]">
                         <DialogHeader>
-                            <DialogTitle>表示設定</DialogTitle>
+                            <DialogTitle>変則ルール</DialogTitle>
                         </DialogHeader>
                         <div className="flex flex-col gap-4 pt-2">
-                            {/* マス内座標表示 */}
-                            <div className="flex flex-col gap-2">
-                                <span className="text-sm font-medium">マス内座標表示</span>
-                                <div className="flex gap-2">
-                                    {(
-                                        [
-                                            { value: "none", label: "なし" },
-                                            { value: "sfen", label: "SFEN (5e)" },
-                                            { value: "japanese", label: "日本式 (５五)" },
-                                        ] as const
-                                    ).map((opt) => (
-                                        <button
-                                            key={opt.value}
-                                            type="button"
-                                            onClick={() =>
-                                                setDisplaySettings({
-                                                    ...navDisplaySettings,
-                                                    squareNotation: opt.value,
-                                                })
-                                            }
-                                            className={`px-3 py-1.5 rounded text-sm transition-colors ${
-                                                navDisplaySettings.squareNotation === opt.value
-                                                    ? "bg-wafuu-kincha text-white"
-                                                    : "bg-wafuu-washi text-wafuu-sumi hover:bg-wafuu-border border border-wafuu-border"
-                                            }`}
-                                        >
-                                            {opt.label}
-                                        </button>
-                                    ))}
+                            {/* パス権セクション */}
+                            <div className="flex flex-col gap-3 p-3 rounded-lg border border-wafuu-border bg-wafuu-washi/50">
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium">パス権</span>
+                                    <Switch
+                                        id="pass-rights-toggle"
+                                        checked={passRightsSettings.enabled}
+                                        onCheckedChange={(checked) =>
+                                            handlePassRightsSettingsChange({
+                                                ...passRightsSettings,
+                                                enabled: checked,
+                                            })
+                                        }
+                                        disabled={settingsLocked}
+                                    />
                                 </div>
-                            </div>
+                                <p className="text-xs text-muted-foreground">
+                                    王手されていない時に手番をパスできます
+                                </p>
 
-                            <div className="h-px bg-wafuu-border" />
-
-                            {/* チェックボックス項目 */}
-                            <label className="flex items-center gap-3 text-sm cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={navDisplaySettings.showBoardLabels}
-                                    onChange={(e) =>
-                                        setDisplaySettings({
-                                            ...navDisplaySettings,
-                                            showBoardLabels: e.target.checked,
-                                        })
-                                    }
-                                    className="w-4 h-4"
-                                />
-                                <span>盤外ラベル表示（筋・段）</span>
-                            </label>
-                            <label className="flex items-center gap-3 text-sm cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={navDisplaySettings.highlightLastMove}
-                                    onChange={(e) =>
-                                        setDisplaySettings({
-                                            ...navDisplaySettings,
-                                            highlightLastMove: e.target.checked,
-                                        })
-                                    }
-                                    className="w-4 h-4"
-                                />
-                                <span>最終手を強調</span>
-                            </label>
-                            <label className="flex items-center gap-3 text-sm cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={navDisplaySettings.showKifuEval}
-                                    onChange={(e) =>
-                                        setDisplaySettings({
-                                            ...navDisplaySettings,
-                                            showKifuEval: e.target.checked,
-                                        })
-                                    }
-                                    className="w-4 h-4"
-                                />
-                                <span>棋譜パネルに評価値を表示</span>
-                            </label>
-                            <label className="flex items-center gap-3 text-sm cursor-pointer">
-                                <input
-                                    type="checkbox"
-                                    checked={navDisplaySettings.enableWheelNavigation}
-                                    onChange={(e) =>
-                                        setDisplaySettings({
-                                            ...navDisplaySettings,
-                                            enableWheelNavigation: e.target.checked,
-                                        })
-                                    }
-                                    className="w-4 h-4"
-                                />
-                                <span>ホイールナビゲーション</span>
-                            </label>
-                        </div>
-                    </DialogContent>
-                </Dialog>
-
-                {/* 変則ルールダイアログ */}
-                {passRightsSettings && (
-                    <Dialog
-                        open={isPassRightsSettingsOpen}
-                        onOpenChange={onPassRightsSettingsOpenChange}
-                    >
-                        <DialogContent className="w-[min(400px,calc(100%-24px))]">
-                            <DialogHeader>
-                                <DialogTitle>変則ルール</DialogTitle>
-                            </DialogHeader>
-                            <div className="flex flex-col gap-4 pt-2">
-                                {/* パス権セクション */}
-                                <div className="flex flex-col gap-3 p-3 rounded-lg border border-wafuu-border bg-wafuu-washi/50">
-                                    <div className="flex items-center justify-between">
-                                        <span className="text-sm font-medium">パス権</span>
-                                        <Switch
-                                            id="pass-rights-toggle"
-                                            checked={passRightsSettings.enabled}
-                                            onCheckedChange={(checked) =>
-                                                handlePassRightsSettingsChange({
-                                                    ...passRightsSettings,
-                                                    enabled: checked,
-                                                })
-                                            }
-                                            disabled={settingsLocked}
-                                        />
-                                    </div>
-                                    <p className="text-xs text-muted-foreground">
-                                        王手されていない時に手番をパスできます
-                                    </p>
-
-                                    {/* 初期パス権数（先手・後手別） */}
-                                    <div
-                                        className={`flex flex-col gap-2 ${!passRightsSettings.enabled ? "opacity-50" : ""}`}
-                                    >
-                                        <span className="text-sm">初期パス権数</span>
-                                        {/* 先手/後手ラベル */}
-                                        <div className="grid grid-cols-2 gap-3">
-                                            <div className="text-xs font-semibold text-wafuu-shu text-center">
-                                                ☗先手
-                                            </div>
-                                            <div className="text-xs font-semibold text-wafuu-ai text-center">
-                                                ☖後手
-                                            </div>
+                                {/* 初期パス権数（先手・後手別） */}
+                                <div
+                                    className={`flex flex-col gap-2 ${!passRightsSettings.enabled ? "opacity-50" : ""}`}
+                                >
+                                    <span className="text-sm">初期パス権数</span>
+                                    {/* 先手/後手ラベル */}
+                                    <div className="grid grid-cols-2 gap-3">
+                                        <div className="text-xs font-semibold text-wafuu-shu text-center">
+                                            ☗先手
                                         </div>
-                                        {/* 先手/後手パス権数設定 */}
-                                        <div className="grid grid-cols-2 gap-3">
-                                            {/* 先手 */}
-                                            <div className="flex items-center justify-center gap-1">
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        handlePassRightsSettingsChange({
-                                                            ...passRightsSettings,
-                                                            senteInitialCount: Math.max(
-                                                                0,
-                                                                passRightsSettings.senteInitialCount -
-                                                                    1,
-                                                            ),
-                                                        })
-                                                    }
-                                                    disabled={
-                                                        settingsLocked ||
-                                                        !passRightsSettings.enabled ||
-                                                        passRightsSettings.senteInitialCount <= 0
-                                                    }
-                                                    className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
-                                                >
-                                                    -
-                                                </button>
-                                                <span className="w-8 text-center text-sm font-semibold">
-                                                    {passRightsSettings.senteInitialCount}
-                                                </span>
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        handlePassRightsSettingsChange({
-                                                            ...passRightsSettings,
-                                                            senteInitialCount: Math.min(
-                                                                10,
-                                                                passRightsSettings.senteInitialCount +
-                                                                    1,
-                                                            ),
-                                                        })
-                                                    }
-                                                    disabled={
-                                                        settingsLocked ||
-                                                        !passRightsSettings.enabled ||
-                                                        passRightsSettings.senteInitialCount >= 10
-                                                    }
-                                                    className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
-                                                >
-                                                    +
-                                                </button>
-                                            </div>
-                                            {/* 後手 */}
-                                            <div className="flex items-center justify-center gap-1">
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        handlePassRightsSettingsChange({
-                                                            ...passRightsSettings,
-                                                            goteInitialCount: Math.max(
-                                                                0,
-                                                                passRightsSettings.goteInitialCount -
-                                                                    1,
-                                                            ),
-                                                        })
-                                                    }
-                                                    disabled={
-                                                        settingsLocked ||
-                                                        !passRightsSettings.enabled ||
-                                                        passRightsSettings.goteInitialCount <= 0
-                                                    }
-                                                    className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
-                                                >
-                                                    -
-                                                </button>
-                                                <span className="w-8 text-center text-sm font-semibold">
-                                                    {passRightsSettings.goteInitialCount}
-                                                </span>
-                                                <button
-                                                    type="button"
-                                                    onClick={() =>
-                                                        handlePassRightsSettingsChange({
-                                                            ...passRightsSettings,
-                                                            goteInitialCount: Math.min(
-                                                                10,
-                                                                passRightsSettings.goteInitialCount +
-                                                                    1,
-                                                            ),
-                                                        })
-                                                    }
-                                                    disabled={
-                                                        settingsLocked ||
-                                                        !passRightsSettings.enabled ||
-                                                        passRightsSettings.goteInitialCount >= 10
-                                                    }
-                                                    className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
-                                                >
-                                                    +
-                                                </button>
-                                            </div>
+                                        <div className="text-xs font-semibold text-wafuu-ai text-center">
+                                            ☖後手
                                         </div>
                                     </div>
-
-                                    {/* パス確認ダイアログしきい値 */}
-                                    <div
-                                        className={`flex flex-col gap-2 ${!passRightsSettings.enabled ? "opacity-50" : ""}`}
-                                    >
-                                        <span className="text-sm">
-                                            パス確認ダイアログしきい値（ms）
-                                        </span>
-                                        <div className="flex items-center gap-2">
-                                            <input
-                                                type="number"
-                                                min={0}
-                                                step={500}
-                                                value={passRightsSettings.confirmDialogThresholdMs}
-                                                onChange={(e) =>
+                                    {/* 先手/後手パス権数設定 */}
+                                    <div className="grid grid-cols-2 gap-3">
+                                        {/* 先手 */}
+                                        <div className="flex items-center justify-center gap-1">
+                                            <button
+                                                type="button"
+                                                onClick={() =>
                                                     handlePassRightsSettingsChange({
                                                         ...passRightsSettings,
-                                                        confirmDialogThresholdMs: Math.max(
+                                                        senteInitialCount: Math.max(
                                                             0,
-                                                            Number(e.target.value) || 0,
+                                                            passRightsSettings.senteInitialCount -
+                                                                1,
                                                         ),
                                                     })
                                                 }
                                                 disabled={
-                                                    settingsLocked || !passRightsSettings.enabled
+                                                    settingsLocked ||
+                                                    !passRightsSettings.enabled ||
+                                                    passRightsSettings.senteInitialCount <= 0
                                                 }
-                                                className="w-28 rounded border border-border bg-card px-2 py-1 text-sm disabled:opacity-50"
-                                            />
-                                            <span className="text-xs text-muted-foreground">
-                                                0で即時、時間が多ければ確認
+                                                className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
+                                            >
+                                                -
+                                            </button>
+                                            <span className="w-8 text-center text-sm font-semibold">
+                                                {passRightsSettings.senteInitialCount}
                                             </span>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    handlePassRightsSettingsChange({
+                                                        ...passRightsSettings,
+                                                        senteInitialCount: Math.min(
+                                                            10,
+                                                            passRightsSettings.senteInitialCount +
+                                                                1,
+                                                        ),
+                                                    })
+                                                }
+                                                disabled={
+                                                    settingsLocked ||
+                                                    !passRightsSettings.enabled ||
+                                                    passRightsSettings.senteInitialCount >= 10
+                                                }
+                                                className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
+                                            >
+                                                +
+                                            </button>
+                                        </div>
+                                        {/* 後手 */}
+                                        <div className="flex items-center justify-center gap-1">
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    handlePassRightsSettingsChange({
+                                                        ...passRightsSettings,
+                                                        goteInitialCount: Math.max(
+                                                            0,
+                                                            passRightsSettings.goteInitialCount - 1,
+                                                        ),
+                                                    })
+                                                }
+                                                disabled={
+                                                    settingsLocked ||
+                                                    !passRightsSettings.enabled ||
+                                                    passRightsSettings.goteInitialCount <= 0
+                                                }
+                                                className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
+                                            >
+                                                -
+                                            </button>
+                                            <span className="w-8 text-center text-sm font-semibold">
+                                                {passRightsSettings.goteInitialCount}
+                                            </span>
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    handlePassRightsSettingsChange({
+                                                        ...passRightsSettings,
+                                                        goteInitialCount: Math.min(
+                                                            10,
+                                                            passRightsSettings.goteInitialCount + 1,
+                                                        ),
+                                                    })
+                                                }
+                                                disabled={
+                                                    settingsLocked ||
+                                                    !passRightsSettings.enabled ||
+                                                    passRightsSettings.goteInitialCount >= 10
+                                                }
+                                                className="flex h-8 w-8 items-center justify-center rounded border border-border bg-card text-sm disabled:opacity-50"
+                                            >
+                                                +
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
+
+                                {/* パス確認ダイアログしきい値 */}
+                                <div
+                                    className={`flex flex-col gap-2 ${!passRightsSettings.enabled ? "opacity-50" : ""}`}
+                                >
+                                    <span className="text-sm">
+                                        パス確認ダイアログしきい値（ms）
+                                    </span>
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="number"
+                                            min={0}
+                                            step={500}
+                                            value={passRightsSettings.confirmDialogThresholdMs}
+                                            onChange={(e) =>
+                                                handlePassRightsSettingsChange({
+                                                    ...passRightsSettings,
+                                                    confirmDialogThresholdMs: Math.max(
+                                                        0,
+                                                        Number(e.target.value) || 0,
+                                                    ),
+                                                })
+                                            }
+                                            disabled={settingsLocked || !passRightsSettings.enabled}
+                                            className="w-28 rounded border border-border bg-card px-2 py-1 text-sm disabled:opacity-50"
+                                        />
+                                        <span className="text-xs text-muted-foreground">
+                                            0で即時、時間が多ければ確認
+                                        </span>
+                                    </div>
+                                </div>
                             </div>
-                        </DialogContent>
-                    </Dialog>
-                )}
-            </div>
+                        </div>
+                    </DialogContent>
+                </Dialog>
+            )}
         </section>
     );
 }

--- a/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
@@ -239,6 +239,7 @@ export function ShogiMatchLayout({
         onPassRightsSettingsOpenChange,
         reviewMode,
         reviewLeftContent,
+        reviewTopContent,
     } = pcSpecificProps;
 
     // グループ化されたpropsを展開: Mobile専用
@@ -602,6 +603,7 @@ export function ShogiMatchLayout({
                                     handlePassRightsSettingsChange={handlePassRightsSettingsChange}
                                     reviewMode={reviewMode}
                                     reviewLeftContent={reviewLeftContent}
+                                    reviewTopContent={reviewTopContent}
                                 />
                             </NavigationProvider>
                         </MatchStateProvider>

--- a/packages/ui/src/components/shogi-match/types/layoutProps.ts
+++ b/packages/ui/src/components/shogi-match/types/layoutProps.ts
@@ -282,6 +282,8 @@ export interface PCSpecificProps {
     reviewMode?: boolean;
     /** 棋譜検討モード時に左サイドバー位置に表示するコンテンツ */
     reviewLeftContent?: import("react").ReactNode;
+    /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
+    reviewTopContent?: import("react").ReactNode;
 }
 
 /**


### PR DESCRIPTION
## Summary

rshogi のレイアウトを刷新し、観戦/検討ページの「1手ごとに `<ShogiMatch>` 全体が remount されて盤・棋譜がちらつく」問題を解消する。あわせてアプリ全体のレイアウトを中央寄せに統一する。

- **ちらつき解消 (fix)**: 毎手の全再マウントをやめ、DOM を据え置いたまま差分描画。
- **レイアウト刷新 (feat)**: 観戦/検討モードを中央 Grid 3カラム化＋ブロードキャスト・スコアボード追加。
- **レイアウト統一 (feat)**: 対局プレイモードも中央寄せに統一（`min-w-[1400px]`＋絶対配置の撤廃）。

## ちらつきの原因と修正

`rshogi-csa-live-viewer.tsx` が `<ShogiMatch>` に `key={`${snapshotEpoch}-${moveEpoch}`}` を渡し `onMove` 毎に `moveEpoch` を増やしていたため、1手ごとにツリー全体が remount されていた。`initialReview` がマウント時1回しか読まれない構造だったため remount をリロード代わりに使っていた。

- key を `String(snapshotEpoch)` のみにし、broadcast move では remount しない。
- `ShogiMatch` は `initialReview` を**内容比較 (sfen + moves 連結)** で取り込み、moves が伸びるたびに `importSfen` で末尾まで再構築（DOM 据え置きで差分描画＝白飛びなし）。
- 末尾追従中のみ最新手へ進め、途中検討中は `importSfen(sfen, moves, { gotoPly })` で同一レンダー内にカーソル復元。
- `importSfen`/`navigation` は ref 経由参照、effect は `[positionReady, reviewSfen, reviewMoves, reviewMovesKey]` に限定。`loadedReviewRef` を await 前確定で StrictMode 冪等化。連続着手は `isStale` ガード (sfen + movesKey) で latest-wins。

## レイアウト

- **観戦/検討モード**: 中央 max-width(1240px) の CSS Grid 3カラム（<1080px 縦積み）。対局者・時計・手数・接続状態を対面表示するブロードキャスト・スコアボードを上部に追加（手番側を朱で点灯、`prefers-reduced-motion` 尊重）。盤上部の既定時計は非表示にしスコアボードへ集約。配色は既存 wafuu トークンのみ。
- **対局プレイモード**: 固定幅の設定サイドバー・盤・棋譜を中央寄せ flex 行 + `overflow-x-auto` に変更（`w-max` で内容幅確保、収まらない幅は横スクロール退避）。旧 `min-w-[1400px]` + 絶対配置・左端固定サイドバーを撤廃し、ワイド画面でのサイドバー浮きを解消。

## 既知の制約

- broadcast move ごとに棋譜ツリーを全再構築するため、観戦者がライブ中に作った検討分岐は破棄される（本線 ply のみ復元）。本 PR は ply 復元のみ保証するスコープのため仕様内。

## 補足

- 戦型 (居飛車/相居飛車) 表示は判定ロジックが無いため未追加。駒は既存 PNG を使用。

## Test plan

- [x] typecheck: `@shogi/ui`, `web` pass
- [x] biome lint / format clean（CI と同じ check 含む）
- [x] vitest: `@shogi/ui` 282 件 pass（`computeRemaining` の新規テスト含む）
- [x] knip clean
- [x] local reviewer #1 (Codex): APPROVE
- [x] local reviewer #2 (Claude): APPROVE
- [x] 本番手動デプロイ (`deploy-web.sh prod`) で観戦モードの動作確認可能
- 観戦ビューの実 WS 経由挙動・対局UIの実描画はローカル e2e 未実施（静的解析・単体・レビューで担保）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追記: 観戦の無限再接続 / レイアウトシフト修正

終局後に接続状態が `connected ↔ reconnecting` を無限往復し、状態表示の出し入れでレイアウトシフトが連発する不具合を修正。

- `match-client/live.ts`: `onopen` での `reconnectAttempt` 即時リセットを廃止し、open が `STABLE_CONNECTION_MS`(30s) 継続したときだけリセット。`MAX_RECONNECT_ATTEMPTS`(=backoff 段数) で flap を確定 closed に収束。安定観戦中の散発的切断は累積上限に達しない。
- `rshogi-csa-live-viewer.tsx`: `result`(終局) 確定時にセッションを `disconnect()`。接続エラー行は終局前の確定 closed 時のみ表示（reconnect 中の出し入れ停止）、スコアボード中央に `min-width` を付与し LIVE ピル↔接続ラベル切替の列幅変動を防止。
- `live.test.ts`: flap 上限収束 / 安定接続後リセットの 2 テストを追加（live.test 19/19 pass）。

注: `match-client/src/client.test.ts` の `再接続 open 時に onOpen を reconnect=true で呼ぶ` 1 件は **origin/main でも失敗する pre-existing**（別ファイル `client.ts`・本 PR 非関連）。CI は JS の vitest を実行しない（js-format-lint のみ）ため CI 影響なし。
