### PR TITLE
fix(web): wasm-stale 自動 reload を browser 非依存にする (Firefox/Safari 対応)

### DIFF
--- a/apps/web/src/platform/stale-deploy-reload.test.ts
+++ b/apps/web/src/platform/stale-deploy-reload.test.ts
@@ -187,4 +187,9 @@ describe("assetReturnsNotOk", () => {
         );
         await expect(assetReturnsNotOk("/assets/x.wasm")).resolves.toBe(false);
     });
+
+    it("fetch 不在の環境では stale 断定せず false", async () => {
+        vi.stubGlobal("fetch", undefined);
+        await expect(assetReturnsNotOk("/assets/x.wasm")).resolves.toBe(false);
+    });
 });

--- a/apps/web/src/platform/stale-deploy-reload.test.ts
+++ b/apps/web/src/platform/stale-deploy-reload.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    assetReturnsNotOk,
     installStaleDeployReloadHandlers,
     isStaleAssetError,
     reloadForStaleDeploy,
@@ -152,5 +153,38 @@ describe("installStaleDeployReloadHandlers", () => {
         window.dispatchEvent(event);
         expect(reloadSpy).not.toHaveBeenCalled();
         expect(event.defaultPrevented).toBe(false);
+    });
+});
+
+describe("assetReturnsNotOk", () => {
+    afterEach(() => {
+        // restoreAllMocks は stubGlobal を巻き戻さないため fetch stub をリークさせる
+        vi.unstubAllGlobals();
+    });
+
+    it("non-ok (404) を返すアセットは true", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: false, status: 404 }) as Response),
+        );
+        await expect(assetReturnsNotOk("/assets/x.wasm")).resolves.toBe(true);
+    });
+
+    it("ok (200) のアセットは false", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => ({ ok: true, status: 200 }) as Response),
+        );
+        await expect(assetReturnsNotOk("/assets/x.wasm")).resolves.toBe(false);
+    });
+
+    it("fetch 自体が失敗 (オフライン等) したら stale 断定せず false", async () => {
+        vi.stubGlobal(
+            "fetch",
+            vi.fn(async () => {
+                throw new TypeError("Failed to fetch");
+            }),
+        );
+        await expect(assetReturnsNotOk("/assets/x.wasm")).resolves.toBe(false);
     });
 });

--- a/apps/web/src/platform/stale-deploy-reload.ts
+++ b/apps/web/src/platform/stale-deploy-reload.ts
@@ -83,10 +83,9 @@ export const reloadOnStaleAsset = (error: unknown): boolean => {
  * 消えているかを直接確認する browser 非依存の stale 判定に使う。
  * HEAD なのは存在時 (200) に本体 (wasm 1.5MB) を無駄に取得しないため。worker は
  * 欠損 /assets/* を 404 に変換するので HEAD でも 404 が返る。
- * fetch 自体が失敗 (オフライン等) したときは stale と断定せず false を返す。
+ * fetch 自体が失敗 (オフライン / fetch 不在) したときは stale と断定せず false を返す。
  */
 export const assetReturnsNotOk = async (url: string | URL): Promise<boolean> => {
-    if (typeof fetch === "undefined") return false;
     try {
         const response = await fetch(url, { method: "HEAD", cache: "no-store" });
         return !response.ok;

--- a/apps/web/src/platform/stale-deploy-reload.ts
+++ b/apps/web/src/platform/stale-deploy-reload.ts
@@ -75,6 +75,26 @@ export const reloadOnStaleAsset = (error: unknown): boolean => {
     return reloadForStaleDeploy();
 };
 
+/**
+ * `url` が non-ok (404 等) を返すなら true。
+ *
+ * wasm compile 失敗時のエラー文言はブラウザ依存 (V8 は "HTTP status code is not ok"、
+ * Firefox / Safari は別表現) で署名一致が不安定なため、文言に頼らずアセット自体が
+ * 消えているかを直接確認する browser 非依存の stale 判定に使う。
+ * HEAD なのは存在時 (200) に本体 (wasm 1.5MB) を無駄に取得しないため。worker は
+ * 欠損 /assets/* を 404 に変換するので HEAD でも 404 が返る。
+ * fetch 自体が失敗 (オフライン等) したときは stale と断定せず false を返す。
+ */
+export const assetReturnsNotOk = async (url: string | URL): Promise<boolean> => {
+    if (typeof fetch === "undefined") return false;
+    try {
+        const response = await fetch(url, { method: "HEAD", cache: "no-store" });
+        return !response.ok;
+    } catch {
+        return false;
+    }
+};
+
 let handlersInstalled = false;
 
 /**

--- a/apps/web/src/platform/wasm-position-service.ts
+++ b/apps/web/src/platform/wasm-position-service.ts
@@ -8,6 +8,7 @@ import {
     type ReplayResultJson,
 } from "@shogi/app-core";
 import {
+    defaultWasmModuleUrl,
     ensureWasmModule,
     wasm_board_to_sfen,
     wasm_get_initial_board,
@@ -15,18 +16,22 @@ import {
     wasm_parse_sfen_to_board,
     wasm_replay_moves_strict,
 } from "@shogi/engine-wasm";
-import { reloadOnStaleAsset } from "./stale-deploy-reload";
+import { assetReturnsNotOk, isStaleAssetError, reloadForStaleDeploy } from "./stale-deploy-reload";
 
 export const createWasmPositionService = (): PositionService => {
     let ready: Promise<void> | null = null;
     const ensureReady = () => {
         if (!ready) {
-            ready = ensureWasmModule().catch((error: unknown) => {
+            ready = ensureWasmModule().catch(async (error: unknown) => {
                 // 旧 hash の wasm が消えて 404 → compile 失敗のときは新バンドルを取りに reload する。
+                // 署名一致は V8 ("HTTP status code is not ok") の fast-path。Firefox / Safari は
+                // 文言が異なるため、署名不一致でも wasm アセット自体が 404 かを確認して stale 判定する。
                 // reload しない (stale でない / クールダウン中) ときは呼び出し元のエラー表示へ流す。
                 // 失敗 Promise はそのままキャッシュされ retry されない。wasm ロード失敗は実質
                 // terminal で、回復手段は reload (自動 or ユーザ手動) のみのため意図どおり。
-                reloadOnStaleAsset(error);
+                if (isStaleAssetError(error) || (await assetReturnsNotOk(defaultWasmModuleUrl))) {
+                    reloadForStaleDeploy();
+                }
                 throw error;
             });
         }

--- a/packages/engine-wasm/src/index.ts
+++ b/packages/engine-wasm/src/index.ts
@@ -199,9 +199,16 @@ function rememberInitOpts(opts?: WasmEngineInitOptions): WasmEngineInitOptions |
 
 let wasmModuleReady: Promise<void> | null = null;
 
+/**
+ * メインスレッドで `ensureWasmModule` が fetch する wasm アセットの URL。
+ * Vite が content-hash 付きの実 URL に書き換える。stale デプロイ検知で「この
+ * アセットが 404 か」を直接確認するため app 層へ公開する。
+ */
+export const defaultWasmModuleUrl: URL = new URL("../pkg/engine_wasm_bg.wasm", import.meta.url);
+
 export const ensureWasmModule = (wasmModule?: WasmModuleSource): Promise<void> => {
     if (!wasmModuleReady) {
-        const moduleOrPath = wasmModule ?? new URL("../pkg/engine_wasm_bg.wasm", import.meta.url);
+        const moduleOrPath = wasmModule ?? defaultWasmModuleUrl;
         wasmModuleReady = initWasmModule({ module_or_path: moduleOrPath }).then(() => undefined);
     }
     return wasmModuleReady;


### PR DESCRIPTION
## 概要

デプロイ後の stale-asset 自動 reload（PR #55）を **browser 非依存**にして、Firefox / Safari でも wasm 経路の自動回復が効くようにする。

## 背景

PR #55 は wasm compile 失敗を文字列署名 `"http status code is not ok"`（V8 / Chromium の文言）で検知して reload する。engine-wasm の wasm-bindgen glue は 404（non-ok）レスポンス時に streaming エラーを **re-throw** する（arrayBuffer fallback は `ok && Content-Type 不一致` のときだけ）ため、伝播するのは各ブラウザの `instantiateStreaming` エラー文言で、**Firefox / Safari は V8 と表現が異なり署名一致しない** → wasm 経路の auto-reload が Chromium 限定だった。

## 修正

文言に頼らず、**wasm アセット URL 自体が 404 か**を直接確認する：

- `engine-wasm`: `ensureWasmModule` が fetch する wasm の URL を `defaultWasmModuleUrl` として export（Vite が content-hash 付き実 URL に書き換える。ビルドで `/assets/engine_wasm_bg-<hash>.wasm` に解決されることを確認）。
- `stale-deploy-reload.ts`: `assetReturnsNotOk(url)` を追加。`HEAD`（存在時に 1.5MB を取得しないため）+ `cache: "no-store"` で fetch し `!response.ok` を返す。fetch 自体が失敗（オフライン等）したら `false`。
- `wasm-position-service.ts`: wasm ロード catch を `if (isStaleAssetError(error) || await assetReturnsNotOk(defaultWasmModuleUrl)) reloadForStaleDeploy()` に。Chromium は文字列署名の fast-path で probe を回避、Firefox / Safari は probe で stale を拾う。

挙動: stale(404)→reload / genuine wasm エラー(asset 200)→reload しない / offline(fetch throw)→reload しない。`reloadForStaleDeploy` の sessionStorage 60s ガードで多重 reload しない。

## 検証

- vitest 41 pass（`assetReturnsNotOk` の 404/200/throw 3本を追加）、typecheck pass、biome clean、`vite build` 成功（`defaultWasmModuleUrl` が hash 付き wasm に解決・probe がバンドル済み）。
- prod で HEAD の挙動を実測（存在 wasm→200 / 欠損 wasm→404）。
- レビュー: local claude / codex 両エージェント APPROVE（HEAD 化・テストの `unstubAllGlobals` 化を反映）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
