### PR TITLE
fix(ui): 観戦/検討 viewer の review グリッドのはみ出し・浮き・上端ズレを修正

### DIFF
--- a/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
@@ -20,7 +20,13 @@ import { EvalPanel } from "./EvalPanel";
 import { KifuPanel } from "./KifuPanel";
 import { TabHeader } from "./TabHeader";
 
-export function PCKifuSection(): ReactElement {
+interface PCKifuSectionProps {
+    /** 観戦/検討モード。対局モードは盤上に時計があり pt-16 でその分を空けて
+     *  棋譜パネルの頭を盤面と揃えるが、検討モードは時計が無いので頭詰めにする。 */
+    reviewMode?: boolean;
+}
+
+export function PCKifuSection({ reviewMode }: PCKifuSectionProps): ReactElement {
     const [activeTab, setActiveTab] = useState<"kifu" | "ai">("kifu");
 
     // 分析関連は Context から取得
@@ -70,7 +76,9 @@ export function PCKifuSection(): ReactElement {
     const parallelismConfig = detectParallelism();
 
     return (
-        <div className="flex flex-col shrink-0 pt-16 w-[var(--panel-width)]">
+        <div
+            className={`flex flex-col shrink-0 w-[var(--panel-width)] ${reviewMode ? "" : "pt-16"}`}
+        >
             <TabHeader
                 tabs={[
                     { id: "kifu", label: "棋譜" },

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -123,24 +123,29 @@ export function PCLayout({
     return (
         <section className={matchLayoutClasses}>
             {reviewMode ? (
-                // 観戦/検討モード: 中央 max-width の Grid 3 カラム。1080px 未満では
-                // 盤→棋譜→情報の順に縦積み。情報パネルが無いときは盤を狭い列へ
-                // 押し込まないよう 2 列にする。
+                // 観戦/検討モード: 中央 max-width の Grid 3 カラム。盤(~537px)+棋譜
+                // (var(--panel-width)=400px)+情報(最大240px)+gap が収まる 1280px 以上で
+                // 横並びにし、それ未満は盤→棋譜→情報の順に縦積みする。狭い幅で 3 列を
+                // 維持すると固定幅の棋譜パネルが列をはみ出し横スクロールが出るため。
+                // 盤列は auto で盤幅に密着させ(1fr だと盤が浮く)、棋譜列は panel 幅に
+                // 一致させてはみ出しを防ぐ。情報列の minmax は盤幅の変動を吸収する。
+                // 情報パネルが無いときは盤を狭い列へ押し込まないよう 2 列にし、
+                // justify-center で盤+棋譜の対を中央へ寄せる。
                 <div className="flex w-full max-w-[1240px] flex-col gap-4 px-4 py-2">
                     {reviewTopContent}
                     <div
-                        className={`grid grid-cols-1 gap-4 min-[1080px]:items-start ${
+                        className={`grid grid-cols-1 gap-4 min-[1280px]:items-start min-[1280px]:justify-center ${
                             reviewLeftContent
-                                ? "min-[1080px]:grid-cols-[minmax(210px,240px)_minmax(0,1fr)_minmax(300px,360px)]"
-                                : "min-[1080px]:grid-cols-[minmax(0,1fr)_minmax(300px,360px)]"
+                                ? "min-[1280px]:grid-cols-[minmax(210px,240px)_auto_var(--panel-width)]"
+                                : "min-[1280px]:grid-cols-[auto_var(--panel-width)]"
                         }`}
                     >
                         {reviewLeftContent && (
-                            <div className="order-3 min-w-0 min-[1080px]:order-none">
+                            <div className="order-3 min-w-0 min-[1280px]:order-none">
                                 {reviewLeftContent}
                             </div>
                         )}
-                        <div className="order-1 flex min-w-0 justify-center min-[1080px]:order-none">
+                        <div className="order-1 flex min-w-0 justify-center min-[1280px]:order-none">
                             {/* 盤上の時計はスコアボード(reviewTopContent)が時計を表示する
                                 ときだけ隠す。スコアボードが無い静的 viewer 等では従来どおり
                                 盤上時計を残す。 */}
@@ -149,8 +154,10 @@ export function PCLayout({
                                 hideClock={Boolean(reviewTopContent)}
                             />
                         </div>
-                        <div className="order-2 min-w-0 min-[1080px]:order-none">
-                            <PCKifuSection />
+                        {/* 縦積み時は固定幅の棋譜パネルを中央へ。横並び時は列幅に一致する
+                            ので justify-self は既定へ戻す。 */}
+                        <div className="order-2 min-w-0 justify-self-center min-[1280px]:order-none min-[1280px]:justify-self-auto">
+                            <PCKifuSection reviewMode />
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

live viewer / 静的単局 viewer が共有する `PCLayout` の reviewMode 3 カラム grid (#56 で導入) に入っていた 3 つのレイアウト regression を修正する。

- **棋譜列のはみ出し → 横スクロール**: 棋譜列が `minmax(300px,360px)`=360px だったが、中の `PCKifuSection` は `w-[var(--panel-width)]`=400px (shrink-0) のため列を 40px はみ出し、1180px 幅でページ横スクロールが発生していた。棋譜列を `var(--panel-width)` に一致させて解消。
- **盤の浮き**: 盤列が `minmax(0,1fr)` で盤実体(~537px)より広く、盤が列内で浮いていた。盤列を `auto` にして密着させ、`justify-center` で 3 カラムを中央へ寄せる。
- **棋譜列の上端ズレ**: `PCKifuSection` の `pt-16` (対局モードで盤上 clock の高さ分を空けて頭を揃える指定) が、clock を表示しない検討モードでも効いて棋譜列だけ中身が 64px 下にズレていた。`reviewMode` prop で `pt-16` を条件化。

あわせて 3 カラム発火 breakpoint を `1080px → 1280px` に引き上げ、3 列が収まらない幅では縦積みへ退避させて横スクロールを根絶した (縦積み時の棋譜パネルは `justify-self-center` で中央寄せ)。

## スコープ

- 対象: reviewMode (観戦/検討) の grid レイアウトのみ。
- 非スコープ: 対局モード (playing, flex 分岐) の描画は不変 (`pt-16` 維持、`PCKifuSection` を props 無しで呼ぶため `reviewMode=undefined`)。

## Test plan

- [x] biome format/check (clean) + turbo typecheck (@shogi/ui, web) + vitest @shogi/ui 282 tests pass
- [x] production build + vite preview + Playwright 実描画検証 (静的 viewer / fixture / 実 NNUE manifest)
  - 1440/1920px: 3 カラム中央寄せ、棋譜列 overflow 0、盤密着、棋譜上端=盤上端、横スクロール無し
  - 1280px (境界): 3 カラム発火、overflow 0、横スクロール無し
  - 1180px: 縦積み・棋譜中央寄せ・横スクロール無し (修正前は横スクロール発生)
- [x] local reviewer (Codex) APPROVE
- [x] local reviewer (Claude) APPROVE

> live viewer は WebSocket 必須で fixture 描画ができないが、静的 viewer と同一の `PCLayout` 経路 (reviewMode + reviewLeftContent) に reviewTopContent (スコアボード, 全幅) を足すだけで、grid 変更は同等に適用される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)