### PR TITLE
feat(web): ページ共通レイアウトのプリミティブ抽出とデザイン整合

### DIFF
--- a/apps/web/src/components/PageContainer.tsx
+++ b/apps/web/src/components/PageContainer.tsx
@@ -1,0 +1,38 @@
+import { cn } from "@shogi/design-system";
+import type { ReactElement, ReactNode } from "react";
+
+type PageContainerWidth = "form" | "narrow" | "standard" | "wide";
+
+// 幅はページ種別ごとの意図でまとめる。form=入力フォーム, narrow=長文,
+// standard=一覧/詳細, wide=盤面など横に広い内容。
+const widthClass: Record<PageContainerWidth, string> = {
+    form: "max-w-[480px]",
+    narrow: "max-w-[720px]",
+    standard: "max-w-[960px]",
+    wide: "max-w-[1100px]",
+};
+
+interface PageContainerProps {
+    width?: PageContainerWidth;
+    className?: string;
+    children: ReactNode;
+}
+
+/** ページ本文の中央寄せコンテナ。幅・左右 padding・縦の section 間隔を一元化する。 */
+export function PageContainer({
+    width = "standard",
+    className,
+    children,
+}: PageContainerProps): ReactElement {
+    return (
+        <main
+            className={cn(
+                "mx-auto flex w-full flex-col gap-6 px-4 py-8",
+                widthClass[width],
+                className,
+            )}
+        >
+            {children}
+        </main>
+    );
+}

--- a/apps/web/src/components/PageHeading.tsx
+++ b/apps/web/src/components/PageHeading.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@shogi/design-system";
+import type { ReactElement, ReactNode } from "react";
+
+interface PageHeadingProps {
+    title: ReactNode;
+    description?: ReactNode;
+    /** 説明文の下、同じ見出しブロック内に並べる補足 (件数表示など)。 */
+    children?: ReactNode;
+    className?: string;
+}
+
+/** ページ見出し (h1) と任意の説明文。全ページで h1 の見た目を揃える。 */
+export function PageHeading({
+    title,
+    description,
+    children,
+    className,
+}: PageHeadingProps): ReactElement {
+    return (
+        <div className={cn("flex flex-col gap-2", className)}>
+            <h1 className="text-2xl font-bold text-foreground">{title}</h1>
+            {description && <p className="text-sm text-muted-foreground">{description}</p>}
+            {children}
+        </div>
+    );
+}

--- a/apps/web/src/components/Section.tsx
+++ b/apps/web/src/components/Section.tsx
@@ -1,0 +1,23 @@
+import { cn } from "@shogi/design-system";
+import type { ReactElement, ReactNode } from "react";
+
+interface SectionProps {
+    title?: ReactNode;
+    className?: string;
+    children: ReactNode;
+}
+
+/** カード型セクション。角丸・border・bg・影・見出しスタイルをページ間で揃える。 */
+export function Section({ title, className, children }: SectionProps): ReactElement {
+    return (
+        <section
+            className={cn(
+                "flex flex-col gap-3 rounded-xl border border-border bg-card p-5 shadow-sm",
+                className,
+            )}
+        >
+            {title && <h2 className="text-lg font-semibold text-foreground">{title}</h2>}
+            {children}
+        </section>
+    );
+}

--- a/apps/web/src/components/StatusBanner.tsx
+++ b/apps/web/src/components/StatusBanner.tsx
@@ -1,0 +1,27 @@
+import { cn } from "@shogi/design-system";
+import type { ReactElement, ReactNode } from "react";
+
+type StatusBannerVariant = "error" | "success";
+
+const variantClass: Record<StatusBannerVariant, string> = {
+    success: "border-status-success-border bg-status-success-bg text-status-success",
+    error: "border-destructive/30 bg-destructive/10 text-destructive",
+};
+
+interface StatusBannerProps {
+    variant: StatusBannerVariant;
+    className?: string;
+    children: ReactNode;
+}
+
+/** 成功 / エラーの帯。色は design system の status-success / destructive トークンで揃える。 */
+export function StatusBanner({ variant, className, children }: StatusBannerProps): ReactElement {
+    return (
+        <div
+            role={variant === "error" ? "alert" : "status"}
+            className={cn("rounded-xl border px-4 py-3 text-sm", variantClass[variant], className)}
+        >
+            {children}
+        </div>
+    );
+}

--- a/apps/web/src/pages/auth/AuthPage.tsx
+++ b/apps/web/src/pages/auth/AuthPage.tsx
@@ -2,7 +2,11 @@ import { Link, useRouter } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { Section } from "../../components/Section";
+import { StatusBanner } from "../../components/StatusBanner";
 import {
     dispatchAuthSessionSyncEvent,
     parseApiError,
@@ -28,8 +32,8 @@ function AuthenticatedProfileSection({
     const [profileDisplayName, setProfileDisplayName] = useState(sessionUser.displayName);
 
     return (
-        <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-            <div className="mb-3 flex items-center justify-between gap-3">
+        <Section>
+            <div className="flex items-center justify-between gap-3">
                 <div>
                     <h2 className="text-lg font-semibold text-foreground">ユーザー名設定</h2>
                     <p className="text-sm text-muted-foreground">
@@ -83,7 +87,7 @@ function AuthenticatedProfileSection({
                     </button>
                 </div>
             </form>
-        </section>
+        </Section>
     );
 }
 
@@ -193,73 +197,63 @@ export default function AuthPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "認証" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[960px] flex-col gap-6 px-4 py-8">
-                <div className="flex flex-col gap-2">
-                    <h1 className="text-2xl font-bold text-foreground">
-                        {session?.authenticated
+            <PageContainer>
+                <PageHeading
+                    title={
+                        session?.authenticated
                             ? requiresUsernameSetup && !session.user.displayName.trim()
                                 ? "ユーザー名設定"
                                 : "アカウント設定"
-                            : "ログイン"}
-                    </h1>
-                    <p className="text-sm text-muted-foreground">
-                        {session?.authenticated
+                            : "ログイン"
+                    }
+                    description={
+                        session?.authenticated
                             ? requiresUsernameSetup && !session.user.displayName.trim()
                                 ? "オンライン対局で使うユーザー名を設定してください。"
                                 : "オンライン対局で使うユーザー名を設定できます。"
-                            : "Google アカウントで認証できます。"}
-                    </p>
-                </div>
+                            : "Google アカウントで認証できます。"
+                    }
+                />
 
-                {status && (
-                    <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
-                        {status}
-                    </div>
-                )}
-                {displayedError && (
-                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                        {displayedError}
-                    </div>
-                )}
+                {status && <StatusBanner variant="success">{status}</StatusBanner>}
+                {displayedError && <StatusBanner variant="error">{displayedError}</StatusBanner>}
 
                 {!session?.authenticated && (
-                    <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                        <div className="flex flex-col gap-4">
-                            <div className="space-y-1">
-                                <h2 className="text-lg font-semibold text-foreground">
-                                    Google でログイン
-                                </h2>
-                                <p className="text-sm text-muted-foreground">
-                                    {resolvedNextPath === "/auth"
-                                        ? "Google アカウントでログインすると、このページに戻ります。"
-                                        : "Google アカウントでログインすると、元のページに戻ります。"}
-                                </p>
-                            </div>
-                            <button
-                                type="button"
-                                onClick={handleGoogleLogin}
-                                className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/50"
-                            >
-                                Google アカウントでログイン
-                            </button>
-                            <p className="text-xs text-muted-foreground">
-                                ログインすることで{" "}
-                                <Link
-                                    to="/privacy"
-                                    className="underline underline-offset-2 hover:text-foreground"
-                                >
-                                    プライバシーポリシー
-                                </Link>
-                                に同意したものとみなします。
+                    <Section className="gap-4">
+                        <div className="space-y-1">
+                            <h2 className="text-lg font-semibold text-foreground">
+                                Google でログイン
+                            </h2>
+                            <p className="text-sm text-muted-foreground">
+                                {resolvedNextPath === "/auth"
+                                    ? "Google アカウントでログインすると、このページに戻ります。"
+                                    : "Google アカウントでログインすると、元のページに戻ります。"}
                             </p>
                         </div>
-                    </section>
+                        <button
+                            type="button"
+                            onClick={handleGoogleLogin}
+                            className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-muted/50"
+                        >
+                            Google アカウントでログイン
+                        </button>
+                        <p className="text-xs text-muted-foreground">
+                            ログインすることで{" "}
+                            <Link
+                                to="/privacy"
+                                className="underline underline-offset-2 hover:text-foreground"
+                            >
+                                プライバシーポリシー
+                            </Link>
+                            に同意したものとみなします。
+                        </p>
+                    </Section>
                 )}
 
                 {isLoadingSession ? (
-                    <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                    <Section>
                         <p className="text-sm text-muted-foreground">読み込み中...</p>
-                    </section>
+                    </Section>
                 ) : session?.authenticated ? (
                     <AuthenticatedProfileSection
                         key={`${session.user.id}:${session.user.displayName}`}
@@ -271,11 +265,11 @@ export default function AuthPage(): ReactElement {
                         onLogout={handleLogout}
                     />
                 ) : (
-                    <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                    <Section>
                         <p className="text-sm text-muted-foreground">未ログインです。</p>
-                    </section>
+                    </Section>
                 )}
-            </main>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/games/GameDetailPage.tsx
+++ b/apps/web/src/pages/games/GameDetailPage.tsx
@@ -7,7 +7,10 @@ import { getRouteApi, Link, useParams } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { Section } from "../../components/Section";
+import { StatusBanner } from "../../components/StatusBanner";
 import { parseApiError } from "../../hooks/useAuthSession";
 import { formatGameResult } from "./gameResultUtils";
 
@@ -66,20 +69,12 @@ export default function GameDetailPage(): ReactElement {
                 ]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[960px] flex-col gap-6 px-4 py-8">
-                {status && (
-                    <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
-                        {status}
-                    </div>
-                )}
+            <PageContainer>
+                {status && <StatusBanner variant="success">{status}</StatusBanner>}
 
-                {error && (
-                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                        {error}
-                    </div>
-                )}
+                {error && <StatusBanner variant="error">{error}</StatusBanner>}
 
-                <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                <Section>
                     <div className="flex flex-col gap-3">
                         <div className="flex flex-wrap items-center gap-2 text-xs">
                             <span className="rounded-full bg-muted px-2 py-1 text-muted-foreground">
@@ -116,10 +111,10 @@ export default function GameDetailPage(): ReactElement {
                             </span>
                         </div>
                     </div>
-                </section>
+                </Section>
 
-                <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                    <div className="mb-4">
+                <Section>
+                    <div>
                         <h2 className="text-lg font-semibold text-foreground">公開設定</h2>
                         <p className="text-sm text-muted-foreground">
                             限定公開・公開への変更はメール確認済みアカウントのみできます。
@@ -160,11 +155,11 @@ export default function GameDetailPage(): ReactElement {
                             </button>
                         ))}
                     </div>
-                </section>
+                </Section>
 
                 {publicUrl && game.publicId && (
-                    <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                        <div className="mb-3">
+                    <Section>
+                        <div>
                             <h2 className="text-lg font-semibold text-foreground">共有リンク</h2>
                             <p className="text-sm text-muted-foreground">
                                 このリンクを知っている人は棋譜を閲覧できます。
@@ -200,10 +195,10 @@ export default function GameDetailPage(): ReactElement {
                                 開く
                             </Link>
                         </div>
-                    </section>
+                    </Section>
                 )}
 
-                <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                <Section>
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                         <div>
                             <h2 className="text-lg font-semibold text-foreground">検討</h2>
@@ -219,10 +214,10 @@ export default function GameDetailPage(): ReactElement {
                             棋譜を検討する
                         </Link>
                     </div>
-                </section>
+                </Section>
 
-                <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                    <h2 className="mb-3 text-lg font-semibold text-foreground">指し手</h2>
+                <Section>
+                    <h2 className="text-lg font-semibold text-foreground">指し手</h2>
                     <ol className="grid gap-2 text-sm text-foreground">
                         {game.moves.map((move, index) => {
                             const ply = index + 1;
@@ -236,10 +231,10 @@ export default function GameDetailPage(): ReactElement {
                             );
                         })}
                     </ol>
-                </section>
+                </Section>
 
-                <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                    <div className="mb-3 flex items-center justify-between gap-3">
+                <Section>
+                    <div className="flex items-center justify-between gap-3">
                         <h2 className="text-lg font-semibold text-foreground">KIF テキスト</h2>
                         <button
                             type="button"
@@ -261,8 +256,8 @@ export default function GameDetailPage(): ReactElement {
                     <pre className="overflow-x-auto rounded-md bg-muted/40 p-4 text-xs text-foreground">
                         {game.kifuText}
                     </pre>
-                </section>
-            </main>
+                </Section>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/games/GameReviewPage.tsx
+++ b/apps/web/src/pages/games/GameReviewPage.tsx
@@ -184,7 +184,7 @@ export default function GameReviewPage(): ReactElement {
                 {game.participants.map((p) => p.displayNameSnapshot).join(" vs ")}
             </div>
             {status && (
-                <div className="rounded-md border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-700">
+                <div className="rounded-md border border-status-success-border bg-status-success-bg px-3 py-2 text-xs text-status-success">
                     {status}
                 </div>
             )}

--- a/apps/web/src/pages/games/GamesPage.tsx
+++ b/apps/web/src/pages/games/GamesPage.tsx
@@ -3,7 +3,10 @@ import { getRouteApi, Link } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { AuthRequiredCard } from "../../components/AuthRequiredCard";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { Section } from "../../components/Section";
 import { formatGameResult } from "./gameResultUtils";
 
 const routeApi = getRouteApi("/games");
@@ -26,12 +29,11 @@ export default function GamesPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "棋譜一覧" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[960px] flex-col gap-6 px-4 py-8">
-                <div className="flex flex-col gap-2">
-                    <h1 className="text-2xl font-bold text-foreground">棋譜一覧</h1>
-                    <p className="text-sm text-muted-foreground">
-                        保存済みのオンライン対局を確認できます。
-                    </p>
+            <PageContainer>
+                <PageHeading
+                    title="棋譜一覧"
+                    description="保存済みのオンライン対局を確認できます。"
+                >
                     {!needsAuth && (
                         <p className="text-xs text-muted-foreground">
                             {games.length} / 50件
@@ -42,7 +44,7 @@ export default function GamesPage(): ReactElement {
                             )}
                         </p>
                     )}
-                </div>
+                </PageHeading>
 
                 {needsAuth && (
                     <AuthRequiredCard
@@ -58,11 +60,11 @@ export default function GamesPage(): ReactElement {
                 )}
 
                 {!needsAuth && games.length === 0 && (
-                    <div className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                    <Section>
                         <p className="text-sm text-muted-foreground">
                             まだ保存済みの棋譜はありません。
                         </p>
-                    </div>
+                    </Section>
                 )}
 
                 {!needsAuth && games.length > 0 && (
@@ -109,7 +111,7 @@ export default function GamesPage(): ReactElement {
                         ))}
                     </div>
                 )}
-            </main>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/games/PublicGamesPage.tsx
+++ b/apps/web/src/pages/games/PublicGamesPage.tsx
@@ -3,7 +3,10 @@ import { getRouteApi, Link } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { Section } from "../../components/Section";
 import { formatGameResult } from "./gameResultUtils";
 
 const routeApi = getRouteApi("/public/games");
@@ -42,20 +45,18 @@ export default function PublicGamesPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "公開棋譜" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[960px] flex-col gap-6 px-4 py-8">
-                <div className="flex flex-col gap-2">
-                    <h1 className="text-2xl font-bold text-foreground">公開棋譜</h1>
-                    <p className="text-sm text-muted-foreground">
-                        ユーザーが公開設定にした棋譜の一覧です。
-                    </p>
-                </div>
+            <PageContainer>
+                <PageHeading
+                    title="公開棋譜"
+                    description="ユーザーが公開設定にした棋譜の一覧です。"
+                />
 
                 {games.length === 0 && (
-                    <div className="rounded-xl border border-border bg-card p-5 shadow-sm">
+                    <Section>
                         <p className="text-sm text-muted-foreground">
                             公開されている棋譜はまだありません。
                         </p>
-                    </div>
+                    </Section>
                 )}
 
                 {games.length > 0 && (
@@ -103,7 +104,7 @@ export default function PublicGamesPage(): ReactElement {
                         </button>
                     </div>
                 )}
-            </main>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/nnue/NnueFilesPage.tsx
+++ b/apps/web/src/pages/nnue/NnueFilesPage.tsx
@@ -8,7 +8,11 @@ import type { ChangeEvent, ReactElement } from "react";
 import { useState } from "react";
 import { AuthRequiredCard } from "../../components/AuthRequiredCard";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { Section } from "../../components/Section";
+import { StatusBanner } from "../../components/StatusBanner";
 import { parseApiError } from "../../hooks/useAuthSession";
 
 const routeApi = getRouteApi("/nnue");
@@ -217,25 +221,15 @@ export default function NnueFilesPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "NNUE ファイル" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[960px] flex-col gap-6 px-4 py-8">
-                <div className="flex flex-col gap-2">
-                    <h1 className="text-2xl font-bold text-foreground">NNUE ファイル</h1>
-                    <p className="text-sm text-muted-foreground">
-                        アカウントに紐づく private NNUE を upload / download / delete できます。
-                    </p>
-                </div>
+            <PageContainer>
+                <PageHeading
+                    title="NNUE ファイル"
+                    description="アカウントに紐づく private NNUE を upload / download / delete できます。"
+                />
 
-                {status && (
-                    <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-700">
-                        {status}
-                    </div>
-                )}
+                {status && <StatusBanner variant="success">{status}</StatusBanner>}
 
-                {error && (
-                    <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-                        {error}
-                    </div>
-                )}
+                {error && <StatusBanner variant="error">{error}</StatusBanner>}
 
                 {loaderData.needsAuth ? (
                     <AuthRequiredCard
@@ -250,45 +244,37 @@ export default function NnueFilesPage(): ReactElement {
                     />
                 ) : (
                     <>
-                        <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                            <div className="flex flex-col gap-3">
-                                <h2 className="text-lg font-semibold text-foreground">
-                                    アップロード
-                                </h2>
-                                <input
-                                    type="file"
-                                    accept=".bin"
-                                    onChange={handleFileChange}
-                                    className="text-sm text-foreground file:mr-3 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium file:text-secondary-foreground"
-                                />
-                                {selectedFile && (
-                                    <div className="text-sm text-muted-foreground">
-                                        {selectedFile.name} / {formatBytes(selectedFile.size)}
-                                    </div>
-                                )}
-                                {isUploading && (
-                                    <div className="text-sm text-muted-foreground">
-                                        アップロード中... {uploadProgress}%
-                                    </div>
-                                )}
-                                <div className="text-xs text-muted-foreground">
-                                    50MB ごとの chunk に分割して upload します。
+                        <Section title="アップロード">
+                            <input
+                                type="file"
+                                accept=".bin"
+                                onChange={handleFileChange}
+                                className="text-sm text-foreground file:mr-3 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:py-2 file:text-sm file:font-medium file:text-secondary-foreground"
+                            />
+                            {selectedFile && (
+                                <div className="text-sm text-muted-foreground">
+                                    {selectedFile.name} / {formatBytes(selectedFile.size)}
                                 </div>
-                                <button
-                                    type="button"
-                                    onClick={() => void handleUpload()}
-                                    disabled={!selectedFile || isUploading}
-                                    className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
-                                >
-                                    {isUploading ? "アップロード中..." : "アップロード"}
-                                </button>
+                            )}
+                            {isUploading && (
+                                <div className="text-sm text-muted-foreground">
+                                    アップロード中... {uploadProgress}%
+                                </div>
+                            )}
+                            <div className="text-xs text-muted-foreground">
+                                50MB ごとの chunk に分割して upload します。
                             </div>
-                        </section>
+                            <button
+                                type="button"
+                                onClick={() => void handleUpload()}
+                                disabled={!selectedFile || isUploading}
+                                className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+                            >
+                                {isUploading ? "アップロード中..." : "アップロード"}
+                            </button>
+                        </Section>
 
-                        <section className="rounded-xl border border-border bg-card p-5 shadow-sm">
-                            <h2 className="mb-3 text-lg font-semibold text-foreground">
-                                アカウント NNUE 一覧
-                            </h2>
+                        <Section title="アカウント NNUE 一覧">
                             {files.length === 0 ? (
                                 <p className="text-sm text-muted-foreground">
                                     保存済みの NNUE はありません。
@@ -331,10 +317,10 @@ export default function NnueFilesPage(): ReactElement {
                                     ))}
                                 </div>
                             )}
-                        </section>
+                        </Section>
                     </>
                 )}
-            </main>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/online/CreateRoomPage.tsx
+++ b/apps/web/src/pages/online/CreateRoomPage.tsx
@@ -4,7 +4,9 @@ import { useNavigate } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useEffect, useRef, useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
 import { syncProfileDisplayNameIfNeeded, useAuthSession } from "../../hooks/useAuthSession";
 import { getLocalPlayerName, saveLocalPlayerName } from "../../hooks/useLocalPlayerName";
 
@@ -174,8 +176,8 @@ export default function CreateRoomPage(): ReactElement {
                 ]}
                 right={<HeaderNav />}
             />
-            <div className="mx-auto flex max-w-[480px] flex-col gap-6 px-4 py-10">
-                <h1 className="text-xl font-bold text-foreground">対局設定</h1>
+            <PageContainer width="form">
+                <PageHeading title="対局設定" />
 
                 {/* 名前入力 */}
                 <div className="flex flex-col gap-2">
@@ -449,7 +451,7 @@ export default function CreateRoomPage(): ReactElement {
                 >
                     {isCreating ? "作成中..." : "部屋を作成する"}
                 </button>
-            </div>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/online/OnlinePage.tsx
+++ b/apps/web/src/pages/online/OnlinePage.tsx
@@ -2,7 +2,9 @@ import { useNavigate } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
 
 export default function OnlinePage(): ReactElement {
     const navigate = useNavigate();
@@ -24,8 +26,8 @@ export default function OnlinePage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "オンライン対局" }]}
                 right={<HeaderNav />}
             />
-            <div className="mx-auto flex max-w-[480px] flex-col gap-6 px-4 py-10">
-                <h1 className="text-2xl font-bold text-foreground">オンライン対局</h1>
+            <PageContainer width="form">
+                <PageHeading title="オンライン対局" />
 
                 <button
                     type="button"
@@ -67,7 +69,7 @@ export default function OnlinePage(): ReactElement {
                         </button>
                     </div>
                 </div>
-            </div>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/privacy/PrivacyPage.tsx
+++ b/apps/web/src/pages/privacy/PrivacyPage.tsx
@@ -1,8 +1,17 @@
 import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { Section } from "../../components/Section";
 
-function Section({ title, children }: { title: string; children: ReactElement | ReactElement[] }) {
+function PolicySection({
+    title,
+    children,
+}: {
+    title: string;
+    children: ReactElement | ReactElement[];
+}) {
     return (
         <section className="flex flex-col gap-2">
             <h2 className="text-base font-semibold text-foreground">{title}</h2>
@@ -18,20 +27,17 @@ export default function PrivacyPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "プライバシーポリシー" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex max-w-[720px] flex-col gap-8 px-4 py-8">
-                <div className="flex flex-col gap-1">
-                    <h1 className="text-2xl font-bold text-foreground">プライバシーポリシー</h1>
-                    <p className="text-sm text-muted-foreground">最終更新日：2026年3月15日</p>
-                </div>
+            <PageContainer width="narrow">
+                <PageHeading title="プライバシーポリシー" description="最終更新日：2026年3月15日" />
 
-                <div className="flex flex-col gap-6 rounded-xl border border-border bg-card p-6 shadow-sm">
-                    <Section title="1. はじめに">
+                <Section className="gap-6 p-6">
+                    <PolicySection title="1. はじめに">
                         <p>
                             ラム将棋（https://ramu-shogi.sh11235.com/、以下「本サービス」）は、将棋の対局・棋譜管理を提供するWebサービスです。本ポリシーは、本サービスが取得する情報とその取り扱いについて説明します。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="2. 取得する情報">
+                    <PolicySection title="2. 取得する情報">
                         <p>Googleアカウントでログインする際に以下の情報を取得します。</p>
                         <ul className="mt-2 list-inside list-disc space-y-1">
                             <li>メールアドレス</li>
@@ -40,9 +46,9 @@ export default function PrivacyPage(): ReactElement {
                         <p className="mt-2">
                             表示名はGoogleアカウントから取得せず、ユーザーご自身に設定していただきます。プロフィール画像は取得・保存しません。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="3. 利用目的">
+                    <PolicySection title="3. 利用目的">
                         <p>取得した情報は以下の目的のみで利用します。</p>
                         <ul className="mt-2 list-inside list-disc space-y-1">
                             <li>ユーザー認証およびアカウント管理</li>
@@ -52,21 +58,21 @@ export default function PrivacyPage(): ReactElement {
                         <p className="mt-2">
                             メールアドレスは本人確認の目的のみで使用し、ユーザーへの連絡・マーケティングには使用しません。対戦相手など他のユーザーには公開されません。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="4. 第三者への提供">
+                    <PolicySection title="4. 第三者への提供">
                         <p>
                             取得した個人情報を第三者に販売・提供・開示することはありません。ただし、法令に基づく開示要求がある場合はこの限りではありません。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="5. 情報の管理">
+                    <PolicySection title="5. 情報の管理">
                         <p>
                             取得した情報はCloudflareのインフラ上で管理します。アカウントの削除をご希望の場合は、お問い合わせ先までご連絡ください。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="6. Googleサービスの利用">
+                    <PolicySection title="6. Googleサービスの利用">
                         <p>
                             本サービスは認証にGoogle
                             OAuthを利用しています。Googleのプライバシーポリシーについては{" "}
@@ -80,15 +86,15 @@ export default function PrivacyPage(): ReactElement {
                             </a>
                             をご参照ください。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="7. Cookieの利用">
+                    <PolicySection title="7. Cookieの利用">
                         <p>
                             認証セッションの維持のためにCookieを使用します。ブラウザの設定によりCookieを無効にすることができますが、ログイン機能が使用できなくなります。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="8. お問い合わせ">
+                    <PolicySection title="8. お問い合わせ">
                         <p>
                             プライバシーポリシーに関するご質問は、X（旧Twitter）アカウント{" "}
                             <a
@@ -101,15 +107,15 @@ export default function PrivacyPage(): ReactElement {
                             </a>
                             までご連絡ください。
                         </p>
-                    </Section>
+                    </PolicySection>
 
-                    <Section title="9. ポリシーの変更">
+                    <PolicySection title="9. ポリシーの変更">
                         <p>
                             必要に応じて本ポリシーを改定することがあります。重要な変更がある場合はサービス上でお知らせします。
                         </p>
-                    </Section>
-                </div>
-            </main>
+                    </PolicySection>
+                </Section>
+            </PageContainer>
         </>
     );
 }

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -4,7 +4,10 @@ import { RshogiCsaGameList } from "@shogi/ui";
 import { useNavigate } from "@tanstack/react-router";
 import { type ReactElement, useEffect, useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { StatusBanner } from "../../components/StatusBanner";
 
 const PAGE_LIMIT = 50;
 
@@ -87,20 +90,13 @@ export default function RshogiViewerListPage(): ReactElement {
                 items={[{ label: "ラム将棋", to: "/" }, { label: "rshogi viewer" }]}
                 right={<HeaderNav />}
             />
-            <main className="mx-auto flex w-full max-w-[960px] flex-col gap-4 px-4 py-6">
-                <div className="flex flex-col gap-1">
-                    <h1 className="text-lg font-semibold text-wafuu-sumi">rshogi 棋譜一覧</h1>
-                    <p className="text-xs text-muted-foreground">
-                        rshogi CSA サーバで終局した棋譜を新着順で表示します。クリックすると個別の
-                        viewer に遷移します。
-                    </p>
-                </div>
+            <PageContainer>
+                <PageHeading
+                    title="rshogi 棋譜一覧"
+                    description="rshogi CSA サーバで終局した棋譜を新着順で表示します。クリックすると個別の viewer に遷移します。"
+                />
 
-                {errorMessage && (
-                    <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
-                        {errorMessage}
-                    </div>
-                )}
+                {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
 
                 <RshogiCsaGameList
                     games={games}
@@ -109,7 +105,7 @@ export default function RshogiViewerListPage(): ReactElement {
                     isLoading={isLoading}
                     hasMore={nextCursor !== undefined}
                 />
-            </main>
+            </PageContainer>
         </>
     );
 }

--- a/packages/design-system/src/theme.css
+++ b/packages/design-system/src/theme.css
@@ -63,6 +63,10 @@
         --status-online-fg: 140 40% 95%; /* オンライン前景 */
         --status-online-bg: 140 45% 93%; /* オンライン背景 */
         --status-online-border: 140 35% 78%; /* オンラインボーダー */
+        --status-success: 140 50% 38%; /* 成功 - 落ち着いた緑 */
+        --status-success-fg: 140 40% 95%; /* 成功前景 */
+        --status-success-bg: 140 45% 93%; /* 成功背景 */
+        --status-success-border: 140 35% 78%; /* 成功ボーダー */
 
         /* レイアウト */
         --panel-width: 400px; /* 右サイドパネルの幅 */
@@ -110,6 +114,10 @@
         --status-online-fg: 140 40% 98%; /* オンライン前景 */
         --status-online-bg: 140 30% 12%; /* オンライン背景 */
         --status-online-border: 140 25% 22%; /* オンラインボーダー */
+        --status-success: 140 45% 45%; /* 成功 */
+        --status-success-fg: 140 40% 98%; /* 成功前景 */
+        --status-success-bg: 140 30% 12%; /* 成功背景 */
+        --status-success-border: 140 25% 22%; /* 成功ボーダー */
     }
 
     *,

--- a/packages/design-system/tailwind.preset.ts
+++ b/packages/design-system/tailwind.preset.ts
@@ -69,6 +69,10 @@ const preset: Omit<Config, "content"> = {
                     "online-fg": "hsl(var(--status-online-fg))",
                     "online-bg": "hsl(var(--status-online-bg))",
                     "online-border": "hsl(var(--status-online-border))",
+                    success: "hsl(var(--status-success))",
+                    "success-fg": "hsl(var(--status-success-fg))",
+                    "success-bg": "hsl(var(--status-success-bg))",
+                    "success-border": "hsl(var(--status-success-border))",
                 },
                 // 将棋盤配色
                 shogi: {


### PR DESCRIPTION
## Summary

各ページで重複していた中央寄せレイアウト・見出し・カード・ステータス帯のインライン class を共通プリミティブに抽出し、ページ間の不整合を解消する (デザイン統一)。構造的な統一 (共通ヘッダー・中央寄せ・トークン色) は既に概ね出来ていたため、本 PR は「重複の集約」と「外れ値の標準化」が主眼。

## 新規プリミティブ (`apps/web/src/components/`)

- **PageContainer**: 中央寄せ本文コンテナ。幅 (`form`=480 / `narrow`=720 / `standard`=960 / `wide`=1100)・左右 padding・縦 gap を一元化 (`<main>` を描画)。
- **PageHeading**: `h1` (text-2xl) + 任意の説明文 + 任意の補足スロット (件数表示など)。
- **StatusBanner**: `success` / `error` の帯。`role=status/alert`。色は design-system トークン。
- **Section**: カード (`rounded-xl border border-border bg-card p-5 shadow-sm` + 任意 `h2` title)。

## design-system

- `--status-success` 系トークンを追加 (既存 `--status-online` と同じ緑値・同じ命名規則、light/dark 両方) + tailwind preset の `status.success` 系。

## 整合 (不整合修正)

- **success の emerald ハードコード除去**: GameDetail / GameReview / Nnue / Auth で使われていた `emerald-500/*` `text-emerald-700` を `status-success` トークンへ置換。
- **外れ値ページの標準化**: 下記は意図的に多数派の標準値へ揃えた (大多数のページが既に標準値を採用済み)。
  - `RshogiViewerListPage`: h1 `text-lg text-wafuu-sumi` → `text-2xl text-foreground`、`gap-4`→`gap-6`、description `text-xs`→`text-sm`、error 帯 `border-destructive/50 rounded-md` → StatusBanner (`/30 rounded-xl`)。
  - `OnlinePage` / `CreateRoomPage` (form 系): `py-10`→`py-8`、CreateRoom の h1 `text-xl`→`text-2xl`。
  - `PrivacyPage`: 見出し〜カード間 `gap-8`→`gap-6` (ローカル `Section` は `PolicySection` に改名し共通 `Section` と分離)。

## スコープ外 (変更なし)

トップ (`App.tsx`=対局アプリ)、`RoomPage` (対局ルーム)、full-width viewer 系 (`RshogiViewerPage` / `RshogiViewerLivePage` / `PublicGamePage`)、primary CTA ボタンの `rounded-lg`、CreateRoom の inline error `<p>`。和風カラーへの全見出し統一 (意匠変更) は別途。

## Test plan

- [x] biome format/check (clean) + turbo typecheck (design-system + web) + knip (clean) + vitest (web 7 ファイル 42 テスト pass)
- [x] production build + vite preview + Playwright 実描画
  - `/privacy` (narrow 720px) / `/online` (form 480px) / `/rshogi-viewer` (standard 960px, h1 24px・gap 24px に是正) / `/auth` (Section カード rounded-xl/bg-card/p-5, StatusBanner error 帯が赤系で描画) を確認
  - `status-success` トークンは緑 (bg `rgb(229,245,234)` / text `rgb(48,145,81)` / border `rgb(179,219,192)`) に解決
  - 全ページ中央寄せ・横スクロール無し
- [x] local reviewer (Codex) APPROVE
- [x] local reviewer (Claude) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)