### PR TITLE
feat: rshogi 進行中対局一覧ページを追加 (web/desktop)

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { ActiveEngineSettingsPanel } from "./components/ActiveEngineSettingsPanel";
 import { CsaGameView } from "./components/csa/CsaGameView";
 import { EngineManagerPanel } from "./components/EngineManagerPanel";
+import { RshogiLiveGamesView } from "./components/rshogi-viewer/RshogiLiveGamesView";
 import { RshogiViewerListView } from "./components/rshogi-viewer/RshogiViewerListView";
 import { RshogiViewerLiveView } from "./components/rshogi-viewer/RshogiViewerLiveView";
 import { RshogiViewerView } from "./components/rshogi-viewer/RshogiViewerView";
@@ -88,6 +89,7 @@ type AppMode =
     | "local"
     | "csa"
     | "rshogi-viewer-list"
+    | "rshogi-viewer-live-list"
     | "rshogi-viewer-detail"
     | "rshogi-viewer-live";
 
@@ -113,14 +115,31 @@ function App() {
         setAppMode("rshogi-viewer-list");
     };
 
+    const handleSwitchToRshogiLiveList = () => {
+        setRshogiViewerGameId(null);
+        setAppMode("rshogi-viewer-live-list");
+    };
+
     const handleSelectRshogiGame = (gameId: string) => {
         setRshogiViewerGameId(gameId);
         setAppMode("rshogi-viewer-detail");
     };
 
+    // 進行中対局一覧から live 観戦へ。ここで gameId を set することで、これまで
+    // 到達不能だった "rshogi-viewer-live" 分岐 (gameId 必須) が初めて描画される。
+    const handleSelectRshogiLiveGame = (gameId: string) => {
+        setRshogiViewerGameId(gameId);
+        setAppMode("rshogi-viewer-live");
+    };
+
     const handleBackToRshogiList = () => {
         setRshogiViewerGameId(null);
         setAppMode("rshogi-viewer-list");
+    };
+
+    const handleBackToRshogiLiveList = () => {
+        setRshogiViewerGameId(null);
+        setAppMode("rshogi-viewer-live-list");
     };
 
     const [panelPosition, setPanelPosition] = useState<{
@@ -221,6 +240,19 @@ function App() {
         );
     }
 
+    if (appMode === "rshogi-viewer-live-list") {
+        return (
+            <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
+                <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
+                    <RshogiLiveGamesView
+                        onBackToLocal={() => setAppMode("local")}
+                        onSelectGame={handleSelectRshogiLiveGame}
+                    />
+                </main>
+            </NnueProvider>
+        );
+    }
+
     if (appMode === "rshogi-viewer-detail" && rshogiViewerGameId) {
         return (
             <NnueProvider storage={nnueStorage} validateNnueHeader={validateNnueHeader}>
@@ -241,7 +273,7 @@ function App() {
                 <main className="mx-auto flex max-w-[1100px] flex-col gap-3 p-4 md:px-5">
                     <RshogiViewerLiveView
                         gameId={rshogiViewerGameId}
-                        onBackToList={handleBackToRshogiList}
+                        onBackToList={handleBackToRshogiLiveList}
                         onBackToLocal={() => setAppMode("local")}
                     />
                 </main>
@@ -255,6 +287,9 @@ function App() {
                 <div className="flex justify-end gap-2 pt-2 px-1">
                     <Button variant="outline" size="sm" onClick={handleSwitchToRshogiViewer}>
                         rshogi viewer
+                    </Button>
+                    <Button variant="outline" size="sm" onClick={handleSwitchToRshogiLiveList}>
+                        進行中対局
                     </Button>
                     <Button variant="outline" size="sm" onClick={handleSwitchToCsa}>
                         CSA対局

--- a/apps/desktop/src/components/rshogi-viewer/RshogiLiveGamesView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiLiveGamesView.tsx
@@ -1,0 +1,128 @@
+import type { RshogiLiveGameSummary } from "@shogi/match-client";
+import { fetchRshogiLiveGameList } from "@shogi/match-client";
+import { RshogiCsaLiveGameList } from "@shogi/ui";
+import { Button } from "@shogi/ui/components/button";
+import { type ReactElement, useEffect, useState } from "react";
+
+const PAGE_LIMIT = 50;
+// サーバの edge cache TTL (60 秒) に合わせて自動再取得する。
+const AUTO_REFRESH_MS = 60_000;
+
+interface Props {
+    onBackToLocal: () => void;
+    onSelectGame: (gameId: string) => void;
+}
+
+/**
+ * Desktop 用の rshogi 進行中対局一覧ビュー。
+ *
+ * Web 側 `RshogiLiveGamesPage` と同じ挙動 (初回ロード + 60 秒自動更新 + 手動更新 +
+ * ページング) を持つ。行クリックで `onSelectGame` を呼び、呼出側 (`App.tsx`) が
+ * live 観戦ビューへ遷移する。
+ */
+export function RshogiLiveGamesView({ onBackToLocal, onSelectGame }: Props): ReactElement {
+    const apiBaseUrl =
+        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
+
+    const [games, setGames] = useState<RshogiLiveGameSummary[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [refreshNonce, setRefreshNonce] = useState<number>(0);
+
+    // 初回ロード + 60 秒ごとの自動更新。手動更新 (refreshNonce 変化) でも再実行する。
+    // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce は手動更新の再取得トリガー。effect 本体では読まないが、依存に含めることで再実行させる。
+    useEffect(() => {
+        const controller = new AbortController();
+        const loadFirstPage = async (): Promise<void> => {
+            setIsLoading(true);
+            setErrorMessage(null);
+            try {
+                const page = await fetchRshogiLiveGameList({
+                    baseUrl: apiBaseUrl,
+                    limit: PAGE_LIMIT,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                setGames(page.liveGames);
+                setNextCursor(page.nextCursor);
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+                );
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        };
+        void loadFirstPage();
+        const intervalId = setInterval(() => {
+            void loadFirstPage();
+        }, AUTO_REFRESH_MS);
+        return () => {
+            controller.abort();
+            clearInterval(intervalId);
+        };
+    }, [apiBaseUrl, refreshNonce]);
+
+    const handleLoadMore = async (): Promise<void> => {
+        if (!nextCursor || isLoading) return;
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const page = await fetchRshogiLiveGameList({
+                baseUrl: apiBaseUrl,
+                cursor: nextCursor,
+                limit: PAGE_LIMIT,
+            });
+            setGames((prev) => [...prev, ...page.liveGames]);
+            setNextCursor(page.nextCursor);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleRefresh = (): void => {
+        setRefreshNonce((n) => n + 1);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-wrap items-center gap-2">
+                <Button variant="outline" size="sm" onClick={onBackToLocal}>
+                    ← ローカル対局へ戻る
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isLoading}>
+                    {isLoading ? "更新中..." : "更新"}
+                </Button>
+                <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer (live)</span>
+                <span className="text-xs text-muted-foreground">
+                    進行中の対局を開始が新しい順で表示します (反映まで最大 60 秒)。
+                </span>
+            </div>
+
+            {errorMessage && (
+                <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive">
+                    {errorMessage}
+                </div>
+            )}
+
+            <RshogiCsaLiveGameList
+                games={games}
+                onSelectGame={onSelectGame}
+                onLoadMore={() => void handleLoadMore()}
+                isLoading={isLoading}
+                hasMore={nextCursor !== undefined}
+                emptyMessage="現在進行中の対局はありません。"
+            />
+        </div>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
@@ -1,0 +1,149 @@
+import type { RshogiLiveGameSummary } from "@shogi/match-client";
+import { fetchRshogiLiveGameList } from "@shogi/match-client";
+import { RshogiCsaLiveGameList } from "@shogi/ui";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { type ReactElement, useEffect, useState } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+import { PageHeading } from "../../components/PageHeading";
+import { StatusBanner } from "../../components/StatusBanner";
+
+const PAGE_LIMIT = 50;
+// サーバの edge cache TTL (60 秒) に合わせて自動再取得する。それより短くしても
+// stale cache が返るだけで新鮮なデータは得られないため 60 秒固定。
+const AUTO_REFRESH_MS = 60_000;
+
+const resolveApiBaseUrl = (): string | undefined => {
+    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
+    return raw?.trim() || undefined;
+};
+
+export default function RshogiLiveGamesPage(): ReactElement {
+    const navigate = useNavigate();
+    const apiBaseUrl = resolveApiBaseUrl();
+
+    const [games, setGames] = useState<RshogiLiveGameSummary[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    // 手動更新ボタンを押すたびに増やして effect を再実行させる (先頭ページを
+    // 取り直し + 自動更新タイマーをリセットする)。
+    const [refreshNonce, setRefreshNonce] = useState<number>(0);
+
+    // 初回ロード + 60 秒ごとの自動更新。手動更新 (refreshNonce 変化) でも再実行する。
+    // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce は手動更新の再取得トリガー。effect 本体では読まないが、依存に含めることで再実行させる。
+    useEffect(() => {
+        const controller = new AbortController();
+        const loadFirstPage = async (): Promise<void> => {
+            setIsLoading(true);
+            setErrorMessage(null);
+            try {
+                const page = await fetchRshogiLiveGameList({
+                    baseUrl: apiBaseUrl,
+                    limit: PAGE_LIMIT,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                setGames(page.liveGames);
+                setNextCursor(page.nextCursor);
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+                );
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        };
+        void loadFirstPage();
+        const intervalId = setInterval(() => {
+            void loadFirstPage();
+        }, AUTO_REFRESH_MS);
+        return () => {
+            controller.abort();
+            clearInterval(intervalId);
+        };
+    }, [apiBaseUrl, refreshNonce]);
+
+    const handleLoadMore = async (): Promise<void> => {
+        if (!nextCursor || isLoading) return;
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const page = await fetchRshogiLiveGameList({
+                baseUrl: apiBaseUrl,
+                cursor: nextCursor,
+                limit: PAGE_LIMIT,
+            });
+            // append (開始が新しい順で連結)
+            setGames((prev) => [...prev, ...page.liveGames]);
+            setNextCursor(page.nextCursor);
+        } catch (error) {
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleRefresh = (): void => {
+        setRefreshNonce((n) => n + 1);
+    };
+
+    const handleSelect = (gameId: string): void => {
+        void navigate({ to: "/rshogi-viewer/live/$gameId", params: { gameId } });
+    };
+
+    return (
+        <>
+            <PageHeader
+                items={[
+                    { label: "ラム将棋", to: "/" },
+                    { label: "rshogi viewer", to: "/rshogi-viewer" },
+                    { label: "進行中対局" },
+                ]}
+                right={<HeaderNav />}
+            />
+            <PageContainer>
+                <PageHeading
+                    title="rshogi 進行中対局一覧"
+                    description="rshogi CSA サーバで進行中の対局を開始が新しい順で表示します。クリックすると live 観戦ページに遷移します。反映には最大 60 秒ほどの遅延があります。"
+                >
+                    <div className="flex flex-wrap items-center gap-3">
+                        <button
+                            type="button"
+                            onClick={handleRefresh}
+                            disabled={isLoading}
+                            className="rounded-md border border-wafuu-border px-3 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                            {isLoading ? "更新中..." : "更新"}
+                        </button>
+                        <Link
+                            to="/rshogi-viewer"
+                            className="text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                        >
+                            終局済みの棋譜一覧へ →
+                        </Link>
+                    </div>
+                </PageHeading>
+
+                {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
+
+                <RshogiCsaLiveGameList
+                    games={games}
+                    onSelectGame={handleSelect}
+                    onLoadMore={() => void handleLoadMore()}
+                    isLoading={isLoading}
+                    hasMore={nextCursor !== undefined}
+                    emptyMessage="現在進行中の対局はありません。"
+                />
+            </PageContainer>
+        </>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -1,7 +1,7 @@
 import type { RshogiGameSummary } from "@shogi/match-client";
 import { fetchRshogiGameList } from "@shogi/match-client";
 import { RshogiCsaGameList } from "@shogi/ui";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { type ReactElement, useEffect, useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
@@ -94,7 +94,14 @@ export default function RshogiViewerListPage(): ReactElement {
                 <PageHeading
                     title="rshogi 棋譜一覧"
                     description="rshogi CSA サーバで終局した棋譜を新着順で表示します。クリックすると個別の viewer に遷移します。"
-                />
+                >
+                    <Link
+                        to="/rshogi-viewer/live"
+                        className="text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                    >
+                        進行中の対局一覧へ →
+                    </Link>
+                </PageHeading>
 
                 {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -28,6 +28,7 @@ import CreateRoomPage from "./pages/online/CreateRoomPage";
 import OnlinePage from "./pages/online/OnlinePage";
 import RoomPage from "./pages/online/RoomPage";
 import PrivacyPage from "./pages/privacy/PrivacyPage";
+import RshogiLiveGamesPage from "./pages/rshogi-viewer/RshogiLiveGamesPage";
 import RshogiViewerListPage from "./pages/rshogi-viewer/RshogiViewerListPage";
 import RshogiViewerLivePage from "./pages/rshogi-viewer/RshogiViewerLivePage";
 import RshogiViewerPage from "./pages/rshogi-viewer/RshogiViewerPage";
@@ -235,6 +236,15 @@ const rshogiViewerListRoute = createRoute({
     component: RshogiViewerListPage,
 });
 
+// 進行中対局一覧 (静的 path)。単局 `/rshogi-viewer/live/$gameId` とはセグメント数が
+// 異なるため衝突しない。単局 `/rshogi-viewer/$gameId` より前に登録して、`live` を
+// gameId として誤解決しないようにする。
+const rshogiViewerLiveListRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer/live",
+    component: RshogiLiveGamesPage,
+});
+
 // `/rshogi-viewer/live/$gameId` は単局 `/rshogi-viewer/$gameId` よりも前に
 // 登録する必要がある (TanStack Router は登録順で path 解決する)。
 const rshogiViewerLiveRoute = createRoute({
@@ -314,6 +324,7 @@ const routeTree = rootRoute.addChildren([
     createRoomRoute,
     roomRoute,
     rshogiViewerListRoute,
+    rshogiViewerLiveListRoute,
     rshogiViewerLiveRoute,
     rshogiViewerRoute,
 ]);

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -48,6 +48,7 @@ export {
 export type {
     FetchRshogiGameListOptions,
     FetchRshogiGameOptions,
+    FetchRshogiLiveGameListOptions,
     RshogiClockKind,
     RshogiEndReason,
     RshogiGame,
@@ -57,11 +58,14 @@ export type {
     RshogiGameResultKind,
     RshogiGameSource,
     RshogiGameSummary,
+    RshogiLiveGameListPage,
+    RshogiLiveGameSummary,
     RshogiTimeControl,
 } from "./rshogi-csa/client";
 export {
     fetchRshogiGame,
     fetchRshogiGameList,
+    fetchRshogiLiveGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     fetchRshogiGame,
     fetchRshogiGameList,
+    fetchRshogiLiveGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,
@@ -426,6 +427,136 @@ describe("fetchRshogiGameList (real baseUrl)", () => {
         ) as unknown as typeof fetch;
         await expect(
             fetchRshogiGameList({
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+});
+
+describe("fetchRshogiLiveGameList (mock fallback)", () => {
+    it("returns the mock live list when no baseUrl is provided", async () => {
+        const page = await fetchRshogiLiveGameList();
+        expect(page.liveGames.length).toBeGreaterThan(0);
+        expect(page.liveGames[0].gameId).toBeTruthy();
+        for (const game of page.liveGames) {
+            expect(typeof game.senteName).toBe("string");
+            expect(typeof game.goteName).toBe("string");
+            // 進行中対局には result / endedAtMs / movesCount が無い。
+            expect(game).not.toHaveProperty("result");
+            expect(game).not.toHaveProperty("endedAtMs");
+            expect(game).not.toHaveProperty("movesCount");
+        }
+    });
+
+    it("respects limit and exposes nextCursor when more results exist", async () => {
+        const first = await fetchRshogiLiveGameList({ limit: 1 });
+        expect(first.liveGames).toHaveLength(1);
+        expect(first.nextCursor).toBe("1");
+        const second = await fetchRshogiLiveGameList({ limit: 1, cursor: first.nextCursor });
+        expect(second.liveGames.length).toBeGreaterThan(0);
+        expect(second.liveGames[0].gameId).not.toBe(first.liveGames[0].gameId);
+    });
+});
+
+describe("fetchRshogiLiveGameList (real baseUrl)", () => {
+    it("calls baseUrl/games/live with cursor & limit query and decodes wire into RshogiLiveGameListPage", async () => {
+        const wirePayload = {
+            live_games: [
+                {
+                    game_id: "lobby-cross-fischer-1777391025209",
+                    started_at_ms: 1777391025209,
+                    black_handle: "alice",
+                    white_handle: "bob",
+                    clock: {
+                        kind: "fischer",
+                        total_sec: 300,
+                        byoyomi_sec: 10,
+                        byoyomi_ms: null,
+                        increment_sec: 5,
+                    },
+                    source: "kifu",
+                },
+            ],
+            next_cursor: "opaque-cursor",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                }),
+        ) as unknown as typeof fetch;
+
+        const page = await fetchRshogiLiveGameList({
+            baseUrl: "https://rshogi.example.com/api/v1/",
+            cursor: "prev-cursor",
+            limit: 25,
+            fetchImpl,
+        });
+
+        const calledUrl = (fetchImpl as unknown as { mock: { calls: [string][] } }).mock
+            .calls[0][0];
+        expect(calledUrl).toBe(
+            "https://rshogi.example.com/api/v1/games/live?cursor=prev-cursor&limit=25",
+        );
+        expect(page.nextCursor).toBe("opaque-cursor");
+        expect(page.liveGames).toHaveLength(1);
+        expect(page.liveGames[0]).toEqual({
+            gameId: "lobby-cross-fischer-1777391025209",
+            // black=sente, white=gote
+            senteName: "alice",
+            goteName: "bob",
+            startedAtMs: 1777391025209,
+            source: "kifu",
+            timeControl: {
+                kind: "fischer",
+                mainSeconds: 300,
+                byoyomiSeconds: 10,
+                byoyomiMilliseconds: undefined,
+                incrementSeconds: 5,
+            },
+        });
+        // live summary は result 系フィールドを持たない。
+        expect(page.liveGames[0]).not.toHaveProperty("result");
+        expect(page.liveGames[0]).not.toHaveProperty("endedAtMs");
+        expect(page.liveGames[0]).not.toHaveProperty("movesCount");
+    });
+
+    it("omits null next_cursor", async () => {
+        const wirePayload = { live_games: [], next_cursor: null };
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify(wirePayload), { status: 200 }),
+        ) as unknown as typeof fetch;
+        const page = await fetchRshogiLiveGameList({
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(page.liveGames).toEqual([]);
+        expect(page.nextCursor).toBeUndefined();
+    });
+
+    it("throws RshogiGameFetchError on non-2xx", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response("boom", { status: 500, statusText: "Server Error" }),
+        ) as unknown as typeof fetch;
+        await expect(
+            fetchRshogiLiveGameList({
+                baseUrl: "https://rshogi.example.com",
+                fetchImpl,
+            }),
+        ).rejects.toBeInstanceOf(RshogiGameFetchError);
+    });
+
+    it("throws RshogiGameFetchError when payload has no live_games array", async () => {
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify({ games: [] }), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        await expect(
+            fetchRshogiLiveGameList({
                 baseUrl: "https://rshogi.example.com",
                 fetchImpl,
             }),

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -21,7 +21,7 @@ import type {
     RshogiGameSourceWire,
     RshogiResultKindWire,
 } from "./fixtures";
-import { MOCK_RSHOGI_GAME_LIST, MOCK_RSHOGI_GAMES } from "./fixtures";
+import { MOCK_RSHOGI_GAME_LIST, MOCK_RSHOGI_GAMES, MOCK_RSHOGI_LIVE_GAME_LIST } from "./fixtures";
 
 /**
  * 終局理由 (wire の `end_reason` をそのまま保持したいケース向け)。
@@ -124,6 +124,33 @@ export interface RshogiGameListPage {
     nextCursor?: string;
 }
 
+/**
+ * 進行中対局一覧 API (`GET /api/v1/games/live`) の 1 件分。
+ *
+ * 終局済一覧 (`RshogiGameSummary`) と同じ camelCase 規約で揃えるが、進行中対局
+ * には `result` / `endedAtMs` / `movesCount` が存在しない (サーバ側
+ * `LiveGamesIndexEntry` の wire にこれらのフィールドが無い契約)。live entry は
+ * あくまで **発見手段** であり、実状態は行クリック時の WS spectate で確認する。
+ */
+export interface RshogiLiveGameSummary {
+    gameId: string;
+    /** 黒 (= 先手 / sente) のハンドル。 */
+    senteName: string;
+    /** 白 (= 後手 / gote) のハンドル。 */
+    goteName: string;
+    /** 開始時刻 (epoch ms)。Date 化は UI 側で行う (タイムゾーン事故防止)。 */
+    startedAtMs?: number;
+    timeControl?: RshogiTimeControl;
+    /** 対局のソース (`kifu` / `floodgate`)。 */
+    source?: RshogiGameSource;
+}
+
+export interface RshogiLiveGameListPage {
+    liveGames: RshogiLiveGameSummary[];
+    /** 次ページ取得用カーソル。null/undefined の場合は末尾。 */
+    nextCursor?: string;
+}
+
 export interface FetchRshogiGameOptions {
     /**
      * rshogi 配信 API のベース URL。
@@ -137,6 +164,13 @@ export interface FetchRshogiGameOptions {
 }
 
 export interface FetchRshogiGameListOptions extends FetchRshogiGameOptions {
+    /** 次ページ取得用カーソル。サーバが発行した opaque string をそのまま渡す。 */
+    cursor?: string;
+    /** 1 ページあたり件数 (1〜100、サーバ既定 50)。 */
+    limit?: number;
+}
+
+export interface FetchRshogiLiveGameListOptions extends FetchRshogiGameOptions {
     /** 次ページ取得用カーソル。サーバが発行した opaque string をそのまま渡す。 */
     cursor?: string;
     /** 1 ページあたり件数 (1〜100、サーバ既定 50)。 */
@@ -253,6 +287,26 @@ interface GameDetailWire extends GameWireBase {
 
 interface GameListResponseWire {
     games?: GameWireBase[];
+    next_cursor?: string | null;
+}
+
+/**
+ * 進行中対局一覧 (`/api/v1/games/live`) の 1 件分 (wire, snake_case)。
+ *
+ * サーバ側 `LiveGamesIndexEntry` に一致させる。終局済 (`GameWireBase`) と異なり
+ * `ended_at_ms` / `result_kind` / `end_reason` / `moves_count` は存在しない。
+ */
+interface LiveGameWireBase {
+    game_id: string;
+    started_at_ms?: number | null;
+    black_handle: string;
+    white_handle: string;
+    clock?: ClockWire | null;
+    source?: RshogiGameSourceWire | string | null;
+}
+
+interface LiveGameListResponseWire {
+    live_games?: LiveGameWireBase[];
     next_cursor?: string | null;
 }
 
@@ -416,6 +470,26 @@ const decodeGameListResponse = (wire: GameListResponseWire): RshogiGameListPage 
     };
 };
 
+const decodeLiveGameSummary = (wire: LiveGameWireBase): RshogiLiveGameSummary => ({
+    gameId: wire.game_id,
+    // black=sente, white=gote のマッピング (終局済 decode と対称)。
+    senteName: wire.black_handle,
+    goteName: wire.white_handle,
+    startedAtMs: decodeNumberOrUndefined(wire.started_at_ms),
+    timeControl: decodeClock(wire.clock),
+    source: decodeStringOrUndefined(wire.source ?? undefined),
+});
+
+const decodeLiveGameListResponse = (wire: LiveGameListResponseWire): RshogiLiveGameListPage => {
+    const liveGames = Array.isArray(wire.live_games)
+        ? wire.live_games.map(decodeLiveGameSummary)
+        : [];
+    return {
+        liveGames,
+        nextCursor: decodeStringOrUndefined(wire.next_cursor ?? undefined),
+    };
+};
+
 /**
  * rshogi の対局 ID から CSA 棋譜とメタを取得する。
  *
@@ -506,6 +580,52 @@ export async function fetchRshogiGameList(
     return decodeGameListResponse(payload);
 }
 
+/**
+ * rshogi の進行中対局一覧 (`GET /api/v1/games/live`) を取得する。
+ *
+ * 終局済一覧 (`fetchRshogiGameList`) と pagination semantics は同じだが、
+ * レスポンスの配列キーが `live_games`、要素に `result` 系フィールドが無い点が
+ * 異なる。サーバは edge で 60 秒キャッシュしており、best-effort eventual
+ * consistency (既に終局済の対局が一時的に含まれることがある) を前提とする。
+ *
+ * @param options ページング・baseUrl の指定。`baseUrl` 未指定時はモック fixture を返す。
+ */
+export async function fetchRshogiLiveGameList(
+    options: FetchRshogiLiveGameListOptions = {},
+): Promise<RshogiLiveGameListPage> {
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) {
+        // モック動作: cursor/limit に応じてスライス (MVP 用)。
+        return mockLiveGameListPage(options.cursor, options.limit);
+    }
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError("", "fetch is not available in this environment");
+    }
+
+    const params = new URLSearchParams();
+    if (options.cursor) params.set("cursor", options.cursor);
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    const query = params.toString();
+    const url = `${trimTrailingSlash(baseUrl)}/games/live${query.length > 0 ? `?${query}` : ""}`;
+
+    const response = await fetchImpl(url, buildRequestInit(options.signal));
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            "",
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+
+    const payload = (await response.json()) as LiveGameListResponseWire | null;
+    if (!payload || !Array.isArray(payload.live_games)) {
+        throw new RshogiGameFetchError("", "rshogi API response missing live_games array");
+    }
+    return decodeLiveGameListResponse(payload);
+}
+
 const DEFAULT_MOCK_LIMIT = 50;
 const MAX_MOCK_LIMIT = 100;
 
@@ -521,6 +641,22 @@ const mockGameListPage = (
     const next = startIndex + clamped;
     return {
         games: slice,
+        nextCursor: next < list.length ? String(next) : undefined,
+    };
+};
+
+const mockLiveGameListPage = (
+    cursor: string | undefined,
+    limit: number | undefined,
+): RshogiLiveGameListPage => {
+    const list = MOCK_RSHOGI_LIVE_GAME_LIST;
+    const startIndex = cursor ? Math.max(0, Number.parseInt(cursor, 10) || 0) : 0;
+    const requested = limit ?? DEFAULT_MOCK_LIMIT;
+    const clamped = Math.min(Math.max(1, requested), MAX_MOCK_LIMIT);
+    const slice = list.slice(startIndex, startIndex + clamped);
+    const next = startIndex + clamped;
+    return {
+        liveGames: slice,
         nextCursor: next < list.length ? String(next) : undefined,
     };
 };

--- a/packages/match-client/src/rshogi-csa/fixtures.ts
+++ b/packages/match-client/src/rshogi-csa/fixtures.ts
@@ -5,7 +5,7 @@
  * decode 層が呼ばれないため、ここでは「decode 後」の TS 型 (camelCase + epoch_ms) で直接定義する。
  */
 
-import type { RshogiGame, RshogiGameSummary } from "./client";
+import type { RshogiGame, RshogiGameSummary, RshogiLiveGameSummary } from "./client";
 
 /** 一覧 API の `result_kind` (wire) リテラル。 */
 export type RshogiResultKindWire = "WIN_BLACK" | "WIN_WHITE" | "DRAW" | "ABORT";
@@ -181,5 +181,58 @@ export const MOCK_RSHOGI_GAME_LIST: RshogiGameSummary[] = [
         result: { kind: "draw", endReason: "SENNICHITE" },
         movesCount: 124,
         source: "kifu",
+    },
+];
+
+const LIVE_1_STARTED_AT_MS = Date.UTC(2026, 3, 30, 13, 0, 0);
+const LIVE_2_STARTED_AT_MS = Date.UTC(2026, 3, 30, 12, 45, 0);
+const LIVE_3_STARTED_AT_MS = Date.UTC(2026, 3, 30, 12, 30, 0);
+
+/**
+ * モック進行中対局一覧 (`GET /api/v1/games/live`) の応答セット。開始が新しい順。
+ *
+ * 終局済一覧 (`MOCK_RSHOGI_GAME_LIST`) と異なり、進行中対局には `result` /
+ * `endedAtMs` / `movesCount` が存在しない (サーバ側 `LiveGamesIndexEntry` の
+ * wire に無いフィールドは decode 後も持たない)。baseUrl 未指定時の MVP 動作 /
+ * テストの既定値として使う。
+ */
+export const MOCK_RSHOGI_LIVE_GAME_LIST: RshogiLiveGameSummary[] = [
+    {
+        gameId: "live-lobby-cross-fischer-1777400000000",
+        senteName: "RAMU_TP",
+        goteName: "Challenger-A",
+        startedAtMs: LIVE_1_STARTED_AT_MS,
+        timeControl: {
+            kind: "fischer",
+            mainSeconds: 600,
+            byoyomiSeconds: 0,
+            incrementSeconds: 10,
+        },
+        source: "kifu",
+    },
+    {
+        gameId: "live-lobby-countdown-1777399100000",
+        senteName: "PC1_save012",
+        goteName: "RAMU_TP",
+        startedAtMs: LIVE_2_STARTED_AT_MS,
+        timeControl: {
+            kind: "countdown",
+            mainSeconds: 300,
+            byoyomiSeconds: 30,
+        },
+        source: "kifu",
+    },
+    {
+        gameId: "live-floodgate-1777398200000",
+        senteName: "GreatBlue",
+        goteName: "FFF-70k",
+        startedAtMs: LIVE_3_STARTED_AT_MS,
+        timeControl: {
+            kind: "fischer",
+            mainSeconds: 900,
+            byoyomiSeconds: 0,
+            incrementSeconds: 5,
+        },
+        source: "floodgate",
     },
 ];

--- a/packages/ui/src/components/rshogi-csa-live-game-list.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-game-list.test.tsx
@@ -1,0 +1,89 @@
+import type { RshogiLiveGameSummary } from "@shogi/match-client";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RshogiCsaLiveGameList } from "./rshogi-csa-live-game-list";
+
+const SAMPLE_LIVE_GAMES: RshogiLiveGameSummary[] = [
+    {
+        gameId: "live-room-1-1234",
+        senteName: "alice",
+        goteName: "bob",
+        startedAtMs: Date.UTC(2026, 3, 28, 12, 34),
+        timeControl: {
+            kind: "fischer",
+            mainSeconds: 300,
+            byoyomiSeconds: 0,
+            incrementSeconds: 10,
+        },
+        source: "kifu",
+    },
+    {
+        gameId: "live-room-2-9999",
+        senteName: "carol",
+        goteName: "dave",
+        startedAtMs: Date.UTC(2026, 3, 28, 13, 0),
+        timeControl: {
+            kind: "countdown",
+            mainSeconds: 600,
+            byoyomiSeconds: 30,
+        },
+        source: "floodgate",
+    },
+];
+
+describe("RshogiCsaLiveGameList", () => {
+    it("renders one row per live game with sente/gote names, clock and source", () => {
+        render(<RshogiCsaLiveGameList games={SAMPLE_LIVE_GAMES} onSelectGame={vi.fn()} />);
+        expect(screen.getByText("☗ alice vs ☖ bob")).toBeDefined();
+        expect(screen.getByText("☗ carol vs ☖ dave")).toBeDefined();
+        // 進行中バッジは 1 行につき 1 つ。
+        expect(screen.getAllByText("対局中")).toHaveLength(2);
+        expect(screen.getByText("source: kifu")).toBeDefined();
+        expect(screen.getByText("source: floodgate")).toBeDefined();
+    });
+
+    it("invokes onSelectGame with the gameId when a row is clicked", () => {
+        const onSelectGame = vi.fn();
+        render(<RshogiCsaLiveGameList games={SAMPLE_LIVE_GAMES} onSelectGame={onSelectGame} />);
+        const button = screen.getByText("☗ alice vs ☖ bob").closest("button");
+        expect(button).toBeDefined();
+        if (button) fireEvent.click(button);
+        expect(onSelectGame).toHaveBeenCalledWith("live-room-1-1234");
+    });
+
+    it("shows empty message when there are no live games and not loading", () => {
+        render(
+            <RshogiCsaLiveGameList
+                games={[]}
+                onSelectGame={vi.fn()}
+                emptyMessage="進行中の対局はありません"
+            />,
+        );
+        expect(screen.getByText("進行中の対局はありません")).toBeDefined();
+    });
+
+    it("shows load-more button only when hasMore=true and onLoadMore is provided", () => {
+        const onLoadMore = vi.fn();
+        const { rerender } = render(
+            <RshogiCsaLiveGameList
+                games={SAMPLE_LIVE_GAMES}
+                onSelectGame={vi.fn()}
+                onLoadMore={onLoadMore}
+                hasMore={true}
+            />,
+        );
+        const button = screen.getByText("もっと読み込む");
+        fireEvent.click(button);
+        expect(onLoadMore).toHaveBeenCalledTimes(1);
+
+        rerender(
+            <RshogiCsaLiveGameList
+                games={SAMPLE_LIVE_GAMES}
+                onSelectGame={vi.fn()}
+                onLoadMore={onLoadMore}
+                hasMore={false}
+            />,
+        );
+        expect(screen.queryByText("もっと読み込む")).toBeNull();
+    });
+});

--- a/packages/ui/src/components/rshogi-csa-live-game-list.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-game-list.tsx
@@ -1,0 +1,136 @@
+/**
+ * rshogi CSA 進行中対局一覧コンポーネント。
+ *
+ * Web/Desktop 両方から共通で使う。表示用のフォーマットだけ担当し、
+ * fetch / state 管理 (cursor, ページング, 再取得) は呼び出し側 (Page/View) で行う。
+ *
+ * 入力データ (`RshogiLiveGameSummary`) は match-client の decode 層通過後の
+ * camelCase + epoch_ms 形式で受け取る前提。終局済一覧 (`RshogiCsaGameList`) と
+ * 異なり、進行中対局には結果・手数が無いため「対局中」バッジを出す。
+ */
+
+import type { RshogiLiveGameSummary, RshogiTimeControl } from "@shogi/match-client";
+import type { ReactElement } from "react";
+
+export interface RshogiCsaLiveGameListProps {
+    games: RshogiLiveGameSummary[];
+    /** 行クリック時に gameId を返す。 */
+    onSelectGame: (gameId: string) => void;
+    /** 「もっと読み込む」押下時に呼ばれる。`hasMore=true` のときのみ表示。 */
+    onLoadMore?: () => void;
+    /** 初回 / ページ追加読み込み中フラグ。 */
+    isLoading?: boolean;
+    /** 次ページが存在するか。 */
+    hasMore?: boolean;
+    /** 一覧が空のときに出すメッセージ (省略時はデフォルト)。 */
+    emptyMessage?: string;
+}
+
+const pad2 = (n: number): string => n.toString().padStart(2, "0");
+
+/** 既存 ramu-shogi の慣習に揃えた `YYYY-MM-DD HH:mm` (ローカル時刻) フォーマット。 */
+const formatStartedAt = (epochMs: number | undefined): string => {
+    if (epochMs === undefined) return "不明";
+    const d = new Date(epochMs);
+    if (Number.isNaN(d.getTime())) return "不明";
+    return `${d.getFullYear()}-${pad2(d.getMonth() + 1)}-${pad2(d.getDate())} ${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+};
+
+const CLOCK_KIND_LABEL: Record<string, string> = {
+    fischer: "Fischer",
+    countdown: "秒読み",
+    countdown_msec: "秒読み(ms)",
+    stopwatch: "ストップウォッチ",
+};
+
+const formatClockSummary = (clock: RshogiTimeControl | undefined): string => {
+    if (!clock) return "持ち時間: 不明";
+    const kindLabel = clock.kind ? (CLOCK_KIND_LABEL[clock.kind] ?? clock.kind) : "持ち時間";
+    const mainMin = Math.round(clock.mainSeconds / 60);
+    const main = mainMin > 0 ? `${mainMin}min` : "";
+    const inc =
+        clock.incrementSeconds && clock.incrementSeconds > 0 ? `+${clock.incrementSeconds}s` : "";
+    // byoyomi は秒値を優先、ms 値はサーバが ms 精度で返した countdown_msec 系のために
+    // <1 秒のときだけ ms 単位で表示する。
+    let byoyomi = "";
+    if (clock.byoyomiSeconds > 0) {
+        byoyomi = `+秒読み${clock.byoyomiSeconds}s`;
+    } else if (clock.byoyomiMilliseconds && clock.byoyomiMilliseconds > 0) {
+        byoyomi = `+秒読み${clock.byoyomiMilliseconds}ms`;
+    }
+    const tail = [main, inc, byoyomi].filter((s) => s.length > 0).join(" ");
+    return tail.length > 0 ? `${kindLabel} ${tail}` : kindLabel;
+};
+
+export function RshogiCsaLiveGameList({
+    games,
+    onSelectGame,
+    onLoadMore,
+    isLoading,
+    hasMore,
+    emptyMessage,
+}: RshogiCsaLiveGameListProps): ReactElement {
+    const empty = games.length === 0;
+
+    return (
+        <div className="flex flex-col gap-3">
+            {empty && !isLoading && (
+                <div className="rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-4 text-sm text-muted-foreground">
+                    {emptyMessage ?? "進行中の対局はありません。"}
+                </div>
+            )}
+
+            {empty && isLoading && (
+                <div className="rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-4 text-sm text-muted-foreground">
+                    読み込み中...
+                </div>
+            )}
+
+            {!empty && (
+                <ul className="flex flex-col gap-2" aria-label="rshogi 進行中対局一覧">
+                    {games.map((game) => (
+                        <li key={game.gameId}>
+                            <button
+                                type="button"
+                                onClick={() => onSelectGame(game.gameId)}
+                                className="flex w-full flex-col gap-1 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-3 text-left transition-colors hover:bg-wafuu-kincha/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-wafuu-shu"
+                            >
+                                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                                    <span className="text-sm font-semibold text-wafuu-sumi">
+                                        ☗ {game.senteName} vs ☖ {game.goteName}
+                                    </span>
+                                    <span className="text-xs text-muted-foreground">
+                                        {formatStartedAt(game.startedAtMs)}
+                                    </span>
+                                </div>
+                                <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                                    <span className="rounded-full bg-wafuu-shu/15 px-2 py-0.5 font-semibold text-wafuu-shu">
+                                        対局中
+                                    </span>
+                                    <span>{formatClockSummary(game.timeControl)}</span>
+                                    {game.source && <span>source: {game.source}</span>}
+                                </div>
+                                <div className="text-[11px] font-mono text-muted-foreground/80">
+                                    {game.gameId}
+                                </div>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {hasMore && onLoadMore && (
+                <div className="flex justify-center">
+                    <button
+                        type="button"
+                        onClick={onLoadMore}
+                        disabled={isLoading}
+                        className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                        {isLoading ? "読み込み中..." : "もっと読み込む"}
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -54,6 +54,9 @@ export { OnlineGameView } from "./components/online-game-view";
 export type { RshogiCsaGameListProps } from "./components/rshogi-csa-game-list";
 // rshogi-csa-game-list
 export { RshogiCsaGameList } from "./components/rshogi-csa-game-list";
+export type { RshogiCsaLiveGameListProps } from "./components/rshogi-csa-live-game-list";
+// rshogi-csa-live-game-list
+export { RshogiCsaLiveGameList } from "./components/rshogi-csa-live-game-list";
 export type { RshogiCsaLiveViewerProps } from "./components/rshogi-csa-live-viewer";
 // rshogi-csa-live-viewer
 export { RshogiCsaLiveViewer } from "./components/rshogi-csa-live-viewer";


### PR DESCRIPTION
## 概要

rshogi CSA サーバの `GET /api/v1/games/live` を利用した**進行中対局一覧**を web / desktop 両対応で追加します。これまで live 観戦ページ (`/rshogi-viewer/live/$gameId`) は URL 直打ちでしか到達できず、進行中対局の発見導線が存在しませんでした（サーバ側 doc `viewer_access_control.md` §7.1 の運用契約に対しクライアント側が未実装だった穴）。

## 変更内容

- **match-client**: `fetchRshogiLiveGameList()` + `RshogiLiveGameSummary` 型を追加。`live_games` wire (snake_case) の decode、`baseUrl` 未指定時は fixture フォールバック。live entry には `result`/`endedAtMs`/`movesCount` が無い契約を型にも反映
- **ui**: `RshogiCsaLiveGameList`（presentational。先手/後手・開始時刻・持ち時間・source・対局中バッジ。色は design-system CSS 変数のみ）
- **web**: `/rshogi-viewer/live` ページ。初回 fetch + 60秒 auto-refresh（サーバ edge cache TTL に一致）+ 手動更新 + cursor ページング。終局済み一覧と相互リンク
- **desktop**: `AppMode` に `rshogi-viewer-live-list` を追加。従来 `setAppMode("rshogi-viewer-live")` を呼ぶ箇所が無く**到達不能だった live 観戦分岐**に、gameId を set して遷移する導線を配線

## テスト

- `turbo lint typecheck --filter=@shogi/match-client --filter=@shogi/ui --filter=web --filter=desktop`: 7/7 successful
- `turbo test`: match-client 62 pass（live 用 8 件追加）/ ui 286 pass（新規コンポーネント 4 件追加）/ desktop 7 pass
- web の一部テスト失敗は既存の環境要因（`engine-wasm/pkg` 未生成）で本変更とは無関係（新規ページは engine-wasm 非依存、web typecheck は clean）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL