### PR TITLE
feat: live viewer に評価値・読み筋・消費時間を表示

### DIFF
--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -73,7 +73,10 @@ export {
 export type {
     RshogiLiveCallbacks,
     RshogiLiveClockEvent,
+    RshogiLiveComment,
     RshogiLiveConnectionState,
+    RshogiLiveMove,
+    RshogiLiveMoveCommentEvent,
     RshogiLiveMoveEvent,
     RshogiLiveSession,
     RshogiLiveSnapshot,

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -104,8 +104,23 @@ const makeMocks = () => {
         return ws as unknown as WebSocket;
     };
     const events = {
-        snapshot: [] as Array<unknown>,
-        moves: [] as Array<{ csaMove: string; elapsedSec: number }>,
+        snapshot: [] as Array<{
+            moves: string[];
+            moveDetails: Array<{
+                csaMove: string;
+                elapsedSec: number;
+                comment?: { raw: string; evalCp?: number; pv?: string[] };
+            }>;
+        }>,
+        moves: [] as Array<{
+            csaMove: string;
+            elapsedSec: number;
+            comment?: { raw: string; evalCp?: number; pv?: string[] };
+        }>,
+        moveComments: [] as Array<{
+            ply: number;
+            comment: { raw: string; evalCp?: number; pv?: string[] };
+        }>,
         clocks: [] as Array<{ remainingMs: { sente: number; gote: number }; sideToMove: string }>,
         ends: [] as Array<unknown>,
         states: [] as RshogiLiveConnectionState[],
@@ -117,6 +132,9 @@ const makeMocks = () => {
         },
         onMove: (e) => {
             events.moves.push(e);
+        },
+        onMoveComment: (e) => {
+            events.moveComments.push(e);
         },
         onClock: (e) => {
             events.clocks.push(e);
@@ -235,6 +253,141 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         ws.fireLines(buildSnapshotLines(["+7776FU,T8", "-3334FU,T7"], "#RESIGN"));
         expect(events.snapshot.length).toBe(1);
         expect(events.ends.length).toBe(1);
+    });
+});
+
+describe("subscribeRshogiLiveGame: Floodgate コメント (eval / PV)", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    const openWithSnapshot = () => {
+        const mocks = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: mocks.wsFactory },
+            mocks.callbacks,
+        );
+        const ws = mocks.wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+        return { ...mocks, ws };
+    };
+
+    it("live: move 行の直後の `'` コメント行を直前 ply に紐付けて onMoveComment を呼ぶ", () => {
+        const { ws, events } = openWithSnapshot();
+        // 1 手目 (先手, ply=1) とそのコメント
+        ws.fireLines(["+7776FU,T8", "'* 123 +7776FU -3334FU"]);
+        expect(events.moves).toEqual([{ csaMove: "7g7f", elapsedSec: 8 }]);
+        expect(events.moveComments).toEqual([
+            {
+                ply: 1,
+                comment: { raw: "* 123 +7776FU -3334FU", evalCp: 123, pv: ["+7776FU", "-3334FU"] },
+            },
+        ]);
+        // 2 手目 (後手, ply=2) とそのコメント。eval は先手視点固定なので負値も来うる。
+        ws.fireLines(["-3334FU,T7", "'* -45 -3334FU"]);
+        expect(events.moveComments[1]).toEqual({
+            ply: 2,
+            comment: { raw: "* -45 -3334FU", evalCp: -45, pv: ["-3334FU"] },
+        });
+    });
+
+    it("live: onMove は即時発火し、RshogiLiveMoveEvent.comment は付かない (コメントは後追い)", () => {
+        const { ws, events } = openWithSnapshot();
+        ws.fireLines(["+7776FU,T8", "'* 100"]);
+        expect(events.moves[0].comment).toBeUndefined();
+        expect(events.moveComments[0]).toEqual({ ply: 1, comment: { raw: "* 100", evalCp: 100 } });
+    });
+
+    it("live: 解析不能なコメントは raw のみ保持し evalCp/pv は undefined", () => {
+        const { ws, events } = openWithSnapshot();
+        ws.fireLines(["+7776FU,T8", "'なにか自由なコメント"]);
+        expect(events.moveComments[0]).toEqual({
+            ply: 1,
+            comment: { raw: "なにか自由なコメント" },
+        });
+        expect(events.moveComments[0].comment.evalCp).toBeUndefined();
+        expect(events.moveComments[0].comment.pv).toBeUndefined();
+    });
+
+    it("live: `'` 行は move としても終局としても扱われない (誤検知しない)", () => {
+        const { ws, events } = openWithSnapshot();
+        // move の前に届いた `'`, `%TORYO` に見えかねない `'` を送っても move/onEnd に流れない
+        ws.fireLines(["'* 999 先頭コメントは紐付け先なし"]);
+        ws.fireLines(["+7776FU,T8"]);
+        ws.fireLines(["'%TORYO っぽいがコメント"]);
+        expect(events.moves).toEqual([{ csaMove: "7g7f", elapsedSec: 8 }]);
+        expect(events.ends.length).toBe(0);
+        // 先頭 (move 未適用時) の `'` は握り潰され、move 後の 1 件だけ ply=1 に付く
+        expect(events.moveComments).toEqual([
+            { ply: 1, comment: { raw: "%TORYO っぽいがコメント" } },
+        ]);
+    });
+
+    it("snapshot: move 行の直後の `'` を moveDetails に inline で載せる", () => {
+        const { events } = (() => {
+            const mocks = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: mocks.wsFactory },
+                mocks.callbacks,
+            );
+            const ws = mocks.wsInstances[0];
+            ws.fireOpen();
+            ws.fireLines(
+                buildSnapshotLines(["+7776FU,T8", "'* 30 -3334FU", "-3334FU,T7", "'* -20 +2726FU"]),
+            );
+            return mocks;
+        })();
+        const snap = events.snapshot[0];
+        expect(snap.moves).toEqual(["7g7f", "3c3d"]);
+        expect(snap.moveDetails).toEqual([
+            {
+                csaMove: "7g7f",
+                elapsedSec: 8,
+                comment: { raw: "* 30 -3334FU", evalCp: 30, pv: ["-3334FU"] },
+            },
+            {
+                csaMove: "3c3d",
+                elapsedSec: 7,
+                comment: { raw: "* -20 +2726FU", evalCp: -20, pv: ["+2726FU"] },
+            },
+        ]);
+    });
+
+    it("snapshot: コメントも T も無い旧サーバ形式は moveDetails が elapsedSec=0/comment 無しで揃う", () => {
+        const { events } = (() => {
+            const mocks = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: mocks.wsFactory },
+                mocks.callbacks,
+            );
+            const ws = mocks.wsInstances[0];
+            ws.fireOpen();
+            // T サフィックスもコメント行も無い (production 旧サーバ)
+            ws.fireLines(buildSnapshotLines(["+7776FU", "-3334FU"]));
+            return mocks;
+        })();
+        const snap = events.snapshot[0];
+        expect(snap.moveDetails).toEqual([
+            { csaMove: "7g7f", elapsedSec: 0, comment: undefined },
+            { csaMove: "3c3d", elapsedSec: 0, comment: undefined },
+        ]);
+    });
+
+    it("no-comment な live stream は従来と同一 (onMoveComment は呼ばれない)", () => {
+        const { ws, events } = openWithSnapshot();
+        ws.fireLines(["+7776FU,T8", "-3334FU,T7"]);
+        expect(events.moves).toEqual([
+            { csaMove: "7g7f", elapsedSec: 8 },
+            { csaMove: "3c3d", elapsedSec: 7 },
+        ]);
+        expect(events.moveComments.length).toBe(0);
     });
 });
 
@@ -449,6 +602,31 @@ describe("__test_internals", () => {
     it("extractElapsedSec: ,T<n> を抽出。無ければ 0", () => {
         expect(__test_internals.extractElapsedSec("+7776FU,T8")).toBe(8);
         expect(__test_internals.extractElapsedSec("+7776FU")).toBe(0);
+    });
+    it("parseLiveComment: Floodgate 形 `'* <eval> <pv...>` を eval/pv に分解 (eval は先手視点)", () => {
+        expect(__test_internals.parseLiveComment("'* 123 +7776FU -3334FU")).toEqual({
+            raw: "* 123 +7776FU -3334FU",
+            evalCp: 123,
+            pv: ["+7776FU", "-3334FU"],
+        });
+        // 負値 (後手有利) も先手視点固定でそのまま
+        expect(__test_internals.parseLiveComment("'* -250")).toEqual({
+            raw: "* -250",
+            evalCp: -250,
+        });
+    });
+    it("parseLiveComment: eval のみ (PV 無し) は pv undefined", () => {
+        const c = __test_internals.parseLiveComment("'* 0");
+        expect(c.evalCp).toBe(0);
+        expect(c.pv).toBeUndefined();
+    });
+    it("parseLiveComment: Floodgate 形でない/整数でないコメントは raw のみ", () => {
+        expect(__test_internals.parseLiveComment("'ただのコメント")).toEqual({
+            raw: "ただのコメント",
+        });
+        expect(__test_internals.parseLiveComment("'* abc +7776FU")).toEqual({
+            raw: "* abc +7776FU",
+        });
     });
     it("parseGameSummaryLines: 必要 field を decode", () => {
         const r = __test_internals.parseGameSummaryLines([

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -44,6 +44,48 @@ import {
 import type { RshogiGameMeta, RshogiGameResult, RshogiGameResultKind } from "./client";
 
 /**
+ * Floodgate コメント (`'* <eval> <pv...>`) を解析した結果。
+ *
+ * spectator へは move 行 (`<token>,T<sec>`) の直後に、指した側のエンジンが付けた
+ * コメントが独立した 1 行 (`'` で始まる) として届く。
+ *
+ * ## eval 符号規約 (rshogi `build_floodgate_comment` で確認済み)
+ * サーバ (`crates/rshogi-csa-client/src/session.rs` `build_floodgate_comment`) は
+ * エンジン自身の探索スコア `score_cp` (手番側視点 = 指した側から見て正が有利) を
+ * `Black => cp, White => -cp` で **常に先手 (Black) 視点** に正規化してから
+ * `* {score}` を書き出す。したがって wire 上の `evalCp` は「指した側がどちらでも」
+ * 先手視点に固定された値であり、`+` が先手有利・`-` が後手有利を意味する。
+ * (詰みは `±100000` のセンチネルとして符号化される。)
+ */
+export interface RshogiLiveComment {
+    /** `'` を剥がしたコメント本文 (例: `* 123 +7776FU -3334FU`)。常に保持する。 */
+    raw: string;
+    /**
+     * Floodgate 形 `* <整数>` から抽出した評価値 (先手視点、センチポーン)。
+     * `+` = 先手有利、`-` = 後手有利。Floodgate 形でない/整数でないコメントは undefined。
+     */
+    evalCp?: number;
+    /**
+     * 読み筋 (PV) の CSA トークン列 (例: `["+7776FU", "-3334FU"]`)。
+     * eval のみで PV が無いコメントや解析不能コメントでは undefined。
+     */
+    pv?: string[];
+}
+
+/**
+ * snapshot 内の 1 手のメタ情報付きエントリ。
+ * `moves` (USI 文字列配列) と同じ順序・同じ長さで並ぶ。
+ */
+export interface RshogiLiveMove {
+    /** 手の USI 文字列 (`7g7f` / `P*5e` 等)。 */
+    csaMove: string;
+    /** 消費秒数 (`,T<sec>` 由来)。旧サーバは snapshot に T を載せないため 0。 */
+    elapsedSec: number;
+    /** 指した側のエンジンが付けた Floodgate コメント (無ければ undefined)。 */
+    comment?: RshogiLiveComment;
+}
+
+/**
  * 観戦 snapshot (= snapshot block 完了時に client が保持する初期状態)。
  *
  * `RshogiGame` (静的 viewer の単局取得結果) と異なり、`csa` 全文ではなく
@@ -55,6 +97,12 @@ export interface RshogiLiveSnapshot {
     meta: RshogiGameMeta;
     /** これまでの手 (USI 文字列、`parseCsaMoves` 由来)。 */
     moves: string[];
+    /**
+     * `moves` と同順・同長の手ごとメタ情報 (消費秒 + コメント)。
+     * 旧サーバでコメント/T が無くても要素は生成され、その場合 elapsedSec=0・
+     * comment=undefined になる (= graceful degrade)。
+     */
+    moveDetails: RshogiLiveMove[];
     /** snapshot 末尾時点の `PositionState` (board + hands + turn + ply)。 */
     state: PositionState;
     /** snapshot 取得時点の残時間と手番。 */
@@ -76,6 +124,29 @@ export interface RshogiLiveMoveEvent {
     csaMove: string;
     /** 消費秒数 (`,T<elapsed_sec>` の値)。秒数行が無ければ 0。 */
     elapsedSec: number;
+    /**
+     * 指した側のコメント (eval / PV)。
+     *
+     * live stream ではコメントは move 行の *後* に別行で届くため、`onMove` 発火時点
+     * では確定しておらず本フィールドは常に undefined になる (コメントは後続の
+     * `onMoveComment` で ply 紐付きで届く)。型の対称性と将来利用のための予約。
+     * snapshot 由来の手のコメントは {@link RshogiLiveSnapshot.moveDetails} で届く。
+     */
+    comment?: RshogiLiveComment;
+}
+
+/**
+ * move コメント (`'* <eval> <pv...>`) の到着イベント。
+ *
+ * live stream ではコメント行が対応する move 行の直後に別行で届くため、`onMove` を
+ * 即時発火する既存タイミングを崩さず、コメントは本コールバックで ply 紐付きで
+ * 後追い配信する (設計案 (b))。`ply` は 1 始まりで、奇数=先手手番・偶数=後手手番。
+ */
+export interface RshogiLiveMoveCommentEvent {
+    /** コメントが属する手の ply (1 始まり)。奇数=先手・偶数=後手の指し手。 */
+    ply: number;
+    /** 解析済みコメント (raw + eval + pv)。 */
+    comment: RshogiLiveComment;
 }
 
 /** snapshot 受信時の clock 同期イベント。 */
@@ -91,6 +162,11 @@ export interface RshogiLiveCallbacks {
     onSnapshot(snapshot: RshogiLiveSnapshot): void;
     /** 1 手 broadcast の到着。残り時間は本 callback には載せない (client 側 timer で計算)。 */
     onMove(event: RshogiLiveMoveEvent): void;
+    /**
+     * move コメント (eval / PV) の到着。live stream では move 行の直後に別行で届く。
+     * 任意 callback (旧 consumer との後方互換のため optional)。
+     */
+    onMoveComment?(event: RshogiLiveMoveCommentEvent): void;
     /** clock countdown を再同期する任意 callback。snapshot 受信時のみ呼ばれる。 */
     onClock(event: RshogiLiveClockEvent): void;
     /** 終局検知。`onEnd` 発火後は reconnect 経路を停止する。 */
@@ -232,7 +308,8 @@ const decodeSnapshotBlock = (
     snapshotLines: string[],
 ): { snapshot: RshogiLiveSnapshot; finalResultLine?: string } => {
     const summaryLines: string[] = [];
-    const moveLines: string[] = [];
+    /** move 行を順に蓄積する (token + 消費秒 + 直後に来たコメント)。 */
+    const moveEntries: { token: string; elapsedSec: number; comment?: RshogiLiveComment }[] = [];
     let resultCodeLine: string | undefined;
     let inSummary = false;
     for (const raw of snapshotLines) {
@@ -251,7 +328,14 @@ const decodeSnapshotBlock = (
             continue;
         }
         if (line.startsWith("+") || line.startsWith("-")) {
-            moveLines.push(line);
+            // moves 行は `<token>,T<elapsed_sec>` 形式。USI 変換は `<token>` のみで行う。
+            moveEntries.push({ token: line.split(",")[0], elapsedSec: extractElapsedSec(line) });
+            continue;
+        }
+        if (line.startsWith("'")) {
+            // `'` コメント行は直前の move 行に属する。move が未出現なら握り潰す。
+            const last = moveEntries[moveEntries.length - 1];
+            if (last) last.comment = parseLiveComment(line);
             continue;
         }
         if (line.startsWith("#")) {
@@ -263,10 +347,16 @@ const decodeSnapshotBlock = (
 
     const summary = parseGameSummaryLines(summaryLines);
 
-    // moves 行は `<token>,T<elapsed_sec>` 形式。USI 変換は `<token>` のみで行う。
-    const movesText = moveLines.map((l) => l.split(",")[0]).join("\n");
+    const movesText = moveEntries.map((e) => e.token).join("\n");
     const initial = createInitialPositionState();
     const { moves, state } = parseCsaMovesWithState(movesText, initial);
+    // `moves` (USI) と同順・同長でメタ情報を並べる。parse で token が脱落しても
+    // index 対応が崩れないよう moves 側を基準に index する。
+    const moveDetails: RshogiLiveMove[] = moves.map((usi, i) => ({
+        csaMove: usi,
+        elapsedSec: moveEntries[i]?.elapsedSec ?? 0,
+        comment: moveEntries[i]?.comment,
+    }));
 
     const meta: RshogiGameMeta = {
         gameId: summary.gameId ?? gameId,
@@ -295,6 +385,7 @@ const decodeSnapshotBlock = (
     const snapshot: RshogiLiveSnapshot = {
         meta,
         moves,
+        moveDetails,
         state,
         clocks: {
             sente: summary.blackRemainingMs ?? 0,
@@ -433,6 +524,33 @@ const extractElapsedSec = (line: string): number => {
 };
 
 /**
+ * spectator へ配信される Floodgate コメント行 (`'* <eval> <pv...>`) を解析する。
+ *
+ * - 先頭の CSA コメントマーカ `'` を剥がした本文を `raw` に保持する。
+ * - Floodgate 標準形 `* <整数 eval> <pv の CSA トークン...>` を eval / pv に分解する。
+ * - Floodgate 形でない・eval が整数でない等、解析不能なコメントは `raw` のみを
+ *   残し `evalCp` / `pv` を undefined にする (任意コメントを握り潰さない)。
+ *
+ * eval の符号規約は {@link RshogiLiveComment} を参照 (常に先手視点、+ が先手有利)。
+ */
+const parseLiveComment = (line: string): RshogiLiveComment => {
+    const withoutQuote = line.startsWith("'") ? line.slice(1) : line;
+    const raw = withoutQuote.trim();
+    if (raw.startsWith("*")) {
+        const rest = raw.slice(1).trim();
+        if (rest.length > 0) {
+            const parts = rest.split(/\s+/);
+            const evalNum = Number(parts[0]);
+            if (Number.isInteger(evalNum)) {
+                const pv = parts.slice(1);
+                return { raw, evalCp: evalNum, pv: pv.length > 0 ? pv : undefined };
+            }
+        }
+    }
+    return { raw };
+};
+
+/**
  * 進行中対局の WebSocket 観戦を開始する。
  *
  * `apiBaseUrl` 未指定時はサーバ接続を行わず、固定 snapshot を即時配信する MVP
@@ -464,6 +582,12 @@ export function subscribeRshogiLiveGame(
     let liveState: PositionState = createInitialPositionState();
     /** 受信直後に手番側を判定するための補助 (snapshot 完了時に確定)。 */
     let liveTurn: "sente" | "gote" = "sente";
+    /**
+     * これまでに適用済みの手数 (= 直近手の ply、1 始まり)。snapshot で
+     * `snapshot.moves.length` に確定し、broadcast move ごとに +1 する。
+     * `'` コメント行を「直前 move」に紐付けるための ply として使う。
+     */
+    let liveMoveCount = 0;
     /** `onEnd` 発火済みフラグ (= reconnect 抑止)。 */
     let endFired = false;
     /** 指数 backoff の現在 attempt index。 */
@@ -547,6 +671,9 @@ export function subscribeRshogiLiveGame(
             const { snapshot, finalResultLine } = decodeSnapshotBlock(gameId, lines);
             liveState = snapshot.state;
             liveTurn = snapshot.clocks.sideToMove;
+            // ply カウンタを snapshot 手数に同期。以降の broadcast move で +1 され、
+            // その値が後続 `'` コメント行の紐付け先 ply になる。
+            liveMoveCount = snapshot.moves.length;
             try {
                 callbacks.onSnapshot(snapshot);
             } catch (err) {
@@ -580,6 +707,25 @@ export function subscribeRshogiLiveGame(
     const handleLiveLine = (line: string) => {
         const trimmed = line.trim();
         if (trimmed.length === 0) return;
+        // `'` コメント行は直前 move に属する。move / 終局判定より前に処理して、
+        // 絶対に move 行・終局行として扱われないようにする (detectEndLine は `'`
+        // に一致しないが、順序で確実に防御する)。
+        if (trimmed.startsWith("'")) {
+            // まだ 1 手も適用していない場合は紐付け先が無いので握り潰す。
+            if (liveMoveCount >= 1 && callbacks.onMoveComment) {
+                const comment = parseLiveComment(trimmed);
+                try {
+                    callbacks.onMoveComment({ ply: liveMoveCount, comment });
+                } catch (err) {
+                    emitError(
+                        err instanceof Error
+                            ? err
+                            : new Error(`onMoveComment handler threw: ${String(err)}`),
+                    );
+                }
+            }
+            return;
+        }
         // 終局検知 (move 行ではない場合)。
         const endResult = detectEndLine(trimmed, liveTurn);
         if (endResult) {
@@ -601,6 +747,7 @@ export function subscribeRshogiLiveGame(
         }
         liveState = applied.nextState;
         liveTurn = applied.nextState.turn;
+        liveMoveCount += 1;
         try {
             callbacks.onMove({ csaMove: applied.move, elapsedSec });
         } catch (err) {
@@ -831,4 +978,5 @@ export const __test_internals = {
     detectEndLine,
     extractElapsedSec,
     parseGameSummaryLines,
+    parseLiveComment,
 };

--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "bumpalo"

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -1,5 +1,16 @@
+import type { RshogiGameMeta, RshogiLiveMove } from "@shogi/match-client";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { computeRemaining } from "./rshogi-csa-live-viewer";
+import {
+    applyMoveComment,
+    computeRemaining,
+    formatOwnEval,
+    RshogiLiveMetaPanel,
+    RshogiLiveScoreboard,
+    summarizeMoveDetails,
+} from "./rshogi-csa-live-viewer";
+
+const META: RshogiGameMeta = { gameId: "game-1", senteName: "alice", goteName: "bob" };
 
 describe("computeRemaining", () => {
     it("手番側 (sideToMove) のみ経過分を減算し、相手側は据え置く", () => {
@@ -28,5 +39,127 @@ describe("computeRemaining", () => {
 
     it("clocks 未取得時は両者 0 を返す", () => {
         expect(computeRemaining(null, 5_000)).toEqual({ sente: 0, gote: 0 });
+    });
+});
+
+describe("formatOwnEval", () => {
+    it("正/負/ゼロを符号付きで整形する (その手番視点)", () => {
+        expect(formatOwnEval(123)).toBe("+123");
+        expect(formatOwnEval(-45)).toBe("-45");
+        expect(formatOwnEval(0)).toBe("+0");
+    });
+    it("±100000 の詰みセンチネルは詰み表記にする", () => {
+        expect(formatOwnEval(100_000)).toBe("詰み");
+        expect(formatOwnEval(-100_000)).toBe("詰まされ");
+    });
+});
+
+describe("applyMoveComment (onMoveComment reducer)", () => {
+    it("奇数 ply は先手・偶数 ply は後手の eval として保持する (wire=先手視点のまま)", () => {
+        const afterSente = applyMoveComment({}, 1, { evalCp: 120, pv: ["+7776FU"] });
+        expect(afterSente).toEqual({ senteEvalCp: 120, latestPv: ["+7776FU"] });
+        const afterGote = applyMoveComment(afterSente, 2, { evalCp: -80, pv: ["-3334FU"] });
+        expect(afterGote).toEqual({
+            senteEvalCp: 120,
+            goteEvalCp: -80,
+            latestPv: ["-3334FU"],
+        });
+    });
+    it("eval/pv の無いコメントは前の値を据え置く", () => {
+        const prev = { senteEvalCp: 50, goteEvalCp: -10, latestPv: ["+2726FU"] };
+        expect(applyMoveComment(prev, 3, {})).toEqual(prev);
+    });
+});
+
+describe("summarizeMoveDetails", () => {
+    const move = (
+        csaMove: string,
+        elapsedSec: number,
+        comment?: RshogiLiveMove["comment"],
+    ): RshogiLiveMove => ({ csaMove, elapsedSec, comment });
+
+    it("各手番の最新 eval・最新 PV・直近消費秒を導出する", () => {
+        const details = [
+            move("7g7f", 8, { raw: "* 30 -3334FU", evalCp: 30, pv: ["-3334FU"] }),
+            move("3c3d", 7, { raw: "* -20 +2726FU", evalCp: -20, pv: ["+2726FU"] }),
+            move("2g2f", 5, { raw: "* 45", evalCp: 45 }),
+        ];
+        expect(summarizeMoveDetails(details)).toEqual({
+            senteEvalCp: 45, // ply3 (先手) が最新
+            goteEvalCp: -20, // ply2 (後手)
+            latestPv: ["+2726FU"], // 最後に PV を持つコメント
+            lastMoveElapsedSec: 5,
+        });
+    });
+    it("コメントの無い (旧サーバ) moveDetails は eval/PV undefined・消費秒のみ", () => {
+        const details = [move("7g7f", 0), move("3c3d", 0)];
+        expect(summarizeMoveDetails(details)).toEqual({
+            senteEvalCp: undefined,
+            goteEvalCp: undefined,
+            latestPv: undefined,
+            lastMoveElapsedSec: 0,
+        });
+    });
+    it("空配列では全て undefined", () => {
+        expect(summarizeMoveDetails([])).toEqual({
+            senteEvalCp: undefined,
+            goteEvalCp: undefined,
+            latestPv: undefined,
+            lastMoveElapsedSec: undefined,
+        });
+    });
+});
+
+describe("RshogiLiveScoreboard: 評価値 / 消費時間の表示", () => {
+    it("各手番の評価値をその手番視点で表示する (後手は符号反転)", () => {
+        render(
+            <RshogiLiveScoreboard
+                meta={META}
+                moveCount={2}
+                clocks={{ sente: 60_000, gote: 60_000, sideToMove: "sente" }}
+                elapsedSinceAnchor={0}
+                connectionState="connected"
+                senteEvalCp={120}
+                goteEvalCp={-80}
+                lastMoveElapsedSec={12}
+            />,
+        );
+        // 先手: wire 120 (先手視点) → そのまま +120
+        expect(screen.getByText("評価値 +120")).toBeDefined();
+        // 後手: wire -80 (先手視点) → 後手視点 +80
+        expect(screen.getByText("評価値 +80")).toBeDefined();
+        // 直近手の消費秒
+        expect(screen.getByText("直前手 12秒")).toBeDefined();
+    });
+
+    it("評価値・消費秒が無いときは評価値/直前手を表示しない (graceful)", () => {
+        render(
+            <RshogiLiveScoreboard
+                meta={META}
+                moveCount={0}
+                clocks={{ sente: 60_000, gote: 60_000, sideToMove: "sente" }}
+                elapsedSinceAnchor={0}
+                connectionState="connected"
+            />,
+        );
+        expect(screen.queryByText(/評価値/)).toBeNull();
+        expect(screen.queryByText(/直前手/)).toBeNull();
+    });
+});
+
+describe("RshogiLiveMetaPanel: 読み筋の表示", () => {
+    it("最新 PV を CSA トークンで表示する", () => {
+        render(<RshogiLiveMetaPanel meta={META} latestPv={["+7776FU", "-3334FU"]} />);
+        expect(screen.getByText("読み筋")).toBeDefined();
+        expect(screen.getByText("+7776FU -3334FU")).toBeDefined();
+    });
+    it("長い PV は末尾を省略する", () => {
+        const pv = Array.from({ length: 20 }, (_, i) => `+m${i}`);
+        render(<RshogiLiveMetaPanel meta={META} latestPv={pv} />);
+        expect(screen.getByText(/…$/)).toBeDefined();
+    });
+    it("PV が無いときは読み筋を表示しない", () => {
+        render(<RshogiLiveMetaPanel meta={META} />);
+        expect(screen.queryByText("読み筋")).toBeNull();
     });
 });

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -18,6 +18,7 @@ import {
     type RshogiGameResult,
     type RshogiLiveCallbacks,
     type RshogiLiveConnectionState,
+    type RshogiLiveMove,
     type RshogiLiveSession,
     type RshogiLiveSnapshot,
     subscribeRshogiLiveGame,
@@ -60,6 +61,17 @@ interface LiveState {
     connectionState: RshogiLiveConnectionState;
     /** 直近の (致命的でない) エラー文言。 */
     lastError?: string;
+    /**
+     * 各手番エンジンが自コメントで報告した最新評価値 (wire 値 = **先手視点**、
+     * `+` が先手有利)。表示時に後手側のみ符号反転して「その手番自身の視点」に直す。
+     * コメントの無い対局 (旧サーバ) では undefined のまま。
+     */
+    senteEvalCp?: number;
+    goteEvalCp?: number;
+    /** 最新コメントの読み筋 (CSA トークン列)。無ければ undefined。 */
+    latestPv?: string[];
+    /** 直近手の消費秒数 (`,T` 由来)。旧サーバや未着手時は undefined。 */
+    lastMoveElapsedSec?: number;
 }
 
 const initialLiveState: LiveState = {
@@ -70,6 +82,63 @@ const initialLiveState: LiveState = {
     clockAnchorAtMs: null,
     connectionState: "connecting",
 };
+
+/** 詰みを表すセンチネル (サーバ `build_floodgate_comment` は詰みを ±100000 で符号化)。 */
+const MATE_EVAL_SENTINEL = 100_000;
+
+/**
+ * 評価値 (その手番自身の視点に直した値。`+` = その手番が有利) を表示文字列にする。
+ * ±100000 の詰みセンチネルは数値でなく詰み表記にする。
+ */
+export function formatOwnEval(ownCp: number): string {
+    if (ownCp >= MATE_EVAL_SENTINEL) return "詰み";
+    if (ownCp <= -MATE_EVAL_SENTINEL) return "詰まされ";
+    return ownCp >= 0 ? `+${ownCp}` : String(ownCp);
+}
+
+/** 各手番エンジンの最新自己 eval (wire=先手視点) と最新 PV を保持する部分状態。 */
+export interface LiveEvalState {
+    senteEvalCp?: number;
+    goteEvalCp?: number;
+    latestPv?: string[];
+}
+
+/**
+ * 1 件の move コメント (ply + eval/pv) を eval 部分状態に畳み込む。
+ * ply 奇数 = 先手の指し手・偶数 = 後手の指し手。コメントは指した側のエンジンが
+ * 付けるので、その手番側の eval として保持する。eval/pv が無ければ据え置く。
+ */
+export function applyMoveComment(
+    prev: LiveEvalState,
+    ply: number,
+    comment: { evalCp?: number; pv?: string[] },
+): LiveEvalState {
+    const isSenteMove = ply % 2 !== 0;
+    return {
+        senteEvalCp:
+            isSenteMove && comment.evalCp !== undefined ? comment.evalCp : prev.senteEvalCp,
+        goteEvalCp: !isSenteMove && comment.evalCp !== undefined ? comment.evalCp : prev.goteEvalCp,
+        latestPv: comment.pv && comment.pv.length > 0 ? comment.pv : prev.latestPv,
+    };
+}
+
+/**
+ * snapshot の `moveDetails` を畳み込み、各手番の最新 eval・最新 PV・直近消費秒を求める。
+ * eval は wire 値 (先手視点) のまま保持し、表示側で後手のみ符号反転する。
+ */
+export function summarizeMoveDetails(moveDetails: RshogiLiveMove[]): LiveEvalState & {
+    lastMoveElapsedSec?: number;
+} {
+    let evalState: LiveEvalState = {};
+    for (let i = 0; i < moveDetails.length; i++) {
+        const comment = moveDetails[i].comment;
+        if (!comment) continue;
+        // ply = i + 1。奇数 = 先手の指し手、偶数 = 後手の指し手。
+        evalState = applyMoveComment(evalState, i + 1, comment);
+    }
+    const last = moveDetails[moveDetails.length - 1];
+    return { ...evalState, lastMoveElapsedSec: last?.elapsedSec };
+}
 
 const formatMs = (ms: number): string => {
     if (!Number.isFinite(ms) || ms <= 0) return "00:00";
@@ -133,17 +202,20 @@ export function computeRemaining(
     };
 }
 
-/** スコアボードの片側 (対局者名 + 残時間)。手番側は朱で点灯する。 */
+/** スコアボードの片側 (対局者名 + 残時間 + 評価値)。手番側は朱で点灯する。 */
 function ScoreboardSide({
     side,
     name,
     remainingMs,
     active,
+    ownEvalCp,
 }: {
     side: "sente" | "gote";
     name: string;
     remainingMs: number;
     active: boolean;
+    /** その手番自身の視点に直した最新評価値 (`+` = その手番が有利)。無ければ非表示。 */
+    ownEvalCp?: number;
 }): ReactElement {
     const isSente = side === "sente";
     return (
@@ -169,6 +241,11 @@ function ScoreboardSide({
                 <div className="truncate text-base font-bold text-wafuu-sumi">
                     {name || (isSente ? "先手" : "後手")}
                 </div>
+                {ownEvalCp !== undefined && (
+                    <div className="text-[11px] font-semibold tabular-nums text-muted-foreground">
+                        評価値 {formatOwnEval(ownEvalCp)}
+                    </div>
+                )}
             </div>
             <div
                 className={cn(
@@ -189,14 +266,25 @@ function ScoreboardSide({
     );
 }
 
-/** 対局者・時計・手数・接続状態を対面表示するブロードキャスト・スコアボード。 */
-function RshogiLiveScoreboard({
+/** 各手番の wire 評価値 (先手視点) を「その手番自身の視点」に直す。 */
+function toOwnEval(side: "sente" | "gote", wireEvalCp?: number): number | undefined {
+    if (wireEvalCp === undefined) return undefined;
+    // wire は常に先手視点 (+ = 先手有利)。先手側はそのまま、後手側は符号反転して
+    // 「+ = その手番が有利」に揃える。
+    return side === "sente" ? wireEvalCp : -wireEvalCp;
+}
+
+/** 対局者・時計・手数・接続状態・評価値を対面表示するブロードキャスト・スコアボード。 */
+export function RshogiLiveScoreboard({
     meta,
     moveCount,
     clocks,
     elapsedSinceAnchor,
     connectionState,
     result,
+    senteEvalCp,
+    goteEvalCp,
+    lastMoveElapsedSec,
 }: {
     meta: RshogiGameMeta;
     moveCount: number;
@@ -204,6 +292,11 @@ function RshogiLiveScoreboard({
     elapsedSinceAnchor: number;
     connectionState: RshogiLiveConnectionState;
     result?: RshogiGameResult;
+    /** wire 評価値 (先手視点)。各手番エンジンの自己申告。無ければ非表示。 */
+    senteEvalCp?: number;
+    goteEvalCp?: number;
+    /** 直近手の消費秒数。無ければ非表示。 */
+    lastMoveElapsedSec?: number;
 }): ReactElement {
     const remaining = computeRemaining(clocks, elapsedSinceAnchor);
     const isConnected = connectionState === "connected";
@@ -224,6 +317,7 @@ function RshogiLiveScoreboard({
                 name={meta.senteName}
                 remainingMs={remaining.sente}
                 active={!result && clocks?.sideToMove === "sente"}
+                ownEvalCp={toOwnEval("sente", senteEvalCp)}
             />
             <div className="flex flex-row items-center justify-between gap-3 border-y border-wafuu-border bg-wafuu-washi px-4 py-2 sm:min-w-[7.5rem] sm:flex-col sm:justify-center sm:gap-1 sm:border-x sm:border-y-0">
                 <span className="text-xl font-bold tabular-nums leading-none text-wafuu-sumi">
@@ -244,25 +338,42 @@ function RshogiLiveScoreboard({
                     </span>
                 )}
                 <span className="text-xs text-muted-foreground">{turnLabel}</span>
+                {lastMoveElapsedSec !== undefined && (
+                    <span className="text-[11px] tabular-nums text-muted-foreground">
+                        直前手 {lastMoveElapsedSec}秒
+                    </span>
+                )}
             </div>
             <ScoreboardSide
                 side="gote"
                 name={meta.goteName}
                 remainingMs={remaining.gote}
                 active={!result && clocks?.sideToMove === "gote"}
+                ownEvalCp={toOwnEval("gote", goteEvalCp)}
             />
         </section>
     );
 }
 
-/** 対局 ID と最終結果のみを表示する補助パネル (名前/時計はスコアボードに集約)。 */
-function RshogiLiveMetaPanel({
+/** PV 表示の最大トークン数 (これを超えたら末尾を省略する)。 */
+const MAX_PV_TOKENS = 12;
+
+/** 対局 ID・最終結果・最新読み筋を表示する補助パネル (名前/時計はスコアボードに集約)。 */
+export function RshogiLiveMetaPanel({
     meta,
     result,
+    latestPv,
 }: {
     meta: RshogiGameMeta;
     result?: RshogiGameResult;
+    /** 最新コメントの読み筋 (CSA トークン列)。無ければ非表示。 */
+    latestPv?: string[];
 }): ReactElement {
+    const pvText =
+        latestPv && latestPv.length > 0
+            ? latestPv.slice(0, MAX_PV_TOKENS).join(" ") +
+              (latestPv.length > MAX_PV_TOKENS ? " …" : "")
+            : undefined;
     return (
         <section
             aria-label="観戦情報"
@@ -274,6 +385,19 @@ function RshogiLiveMetaPanel({
                 </span>
                 <span className="break-all font-mono text-xs text-wafuu-sumi">{meta.gameId}</span>
             </div>
+            {pvText && (
+                <div className="flex flex-col gap-1">
+                    <span className="text-[11px] uppercase tracking-wider text-muted-foreground">
+                        読み筋
+                    </span>
+                    <span
+                        className="truncate font-mono text-xs text-muted-foreground"
+                        title={pvText}
+                    >
+                        {pvText}
+                    </span>
+                </div>
+            )}
             {result && (
                 <div className="rounded-md border border-wafuu-shu/40 bg-wafuu-shu/10 px-2.5 py-1.5 text-sm font-semibold text-wafuu-shu">
                     {formatResultText(meta, result)}
@@ -306,6 +430,7 @@ export function RshogiCsaLiveViewer({
         setTickMs(Date.now());
         const callbacks: RshogiLiveCallbacks = {
             onSnapshot(snapshot) {
+                const summary = summarizeMoveDetails(snapshot.moveDetails);
                 setState((prev) => ({
                     ...prev,
                     snapshot,
@@ -315,9 +440,14 @@ export function RshogiCsaLiveViewer({
                     clocks: snapshot.clocks,
                     clockAnchorAtMs: Date.now(),
                     lastError: undefined,
+                    // snapshot は全置換なので eval/PV/消費秒も moveDetails から再導出する。
+                    senteEvalCp: summary.senteEvalCp,
+                    goteEvalCp: summary.goteEvalCp,
+                    latestPv: summary.latestPv,
+                    lastMoveElapsedSec: summary.lastMoveElapsedSec,
                 }));
             },
-            onMove({ csaMove }) {
+            onMove({ csaMove, elapsedSec }) {
                 setState((prev) => ({
                     ...prev,
                     moves: [...prev.moves, csaMove],
@@ -346,7 +476,11 @@ export function RshogiCsaLiveViewer({
                           }
                         : prev.clocks,
                     clockAnchorAtMs: Date.now(),
+                    lastMoveElapsedSec: elapsedSec,
                 }));
+            },
+            onMoveComment({ ply, comment }) {
+                setState((prev) => ({ ...prev, ...applyMoveComment(prev, ply, comment) }));
             },
             onClock({ remainingMs, sideToMove }) {
                 setState((prev) => ({
@@ -460,9 +594,18 @@ export function RshogiCsaLiveViewer({
                         elapsedSinceAnchor={elapsedSinceAnchor}
                         connectionState={state.connectionState}
                         result={state.result}
+                        senteEvalCp={state.senteEvalCp}
+                        goteEvalCp={state.goteEvalCp}
+                        lastMoveElapsedSec={state.lastMoveElapsedSec}
                     />
                 }
-                reviewLeftContent={<RshogiLiveMetaPanel meta={meta} result={state.result} />}
+                reviewLeftContent={
+                    <RshogiLiveMetaPanel
+                        meta={meta}
+                        result={state.result}
+                        latestPv={state.latestPv}
+                    />
+                }
             />
         </div>
     );

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -97,7 +97,7 @@ export function formatOwnEval(ownCp: number): string {
 }
 
 /** 各手番エンジンの最新自己 eval (wire=先手視点) と最新 PV を保持する部分状態。 */
-export interface LiveEvalState {
+interface LiveEvalState {
     senteEvalCp?: number;
     goteEvalCp?: number;
     latestPv?: string[];


### PR DESCRIPTION
## 概要

rshogi CSA サーバ（SH11235/rshogi#856 でマージ済み・未デプロイ）が観戦者限定で配信する Floodgate コメント行（`'* <eval> <pv...>`）と snapshot の正規化済み `T` 値を取り込み、live 観戦 viewer に**評価値・読み筋・直前手の消費時間**を表示します。

## 変更内容

### match-client（`live.ts`）
- `'` コメント行のパース（`RshogiLiveComment`: raw + evalCp + pv。Floodgate 形でない任意コメントは raw のみ保持）
- live stream では `onMove` の即時発火タイミングを維持し、コメントは `onMoveComment({ply, comment})` で ply 紐付きの後追い配信（コメント行は move 行の後に届くため）
- snapshot は `moveDetails`（`moves` と同順・同長の elapsedSec + comment）として inline 提供
- `'` 行は move / 終局判定より**前**に処理し誤検知を順序で防御
- **後方互換**: 現行サーバ（コメント/T 無し）では従来と同一挙動に degrade

### ui（`rshogi-csa-live-viewer.tsx`）
- スコアボード両側に各対局者エンジンの最新評価値。wire 値は**常に先手視点**（rshogi `build_floodgate_comment` が `Black => cp, White => -cp` で正規化していることをコード確認済み）なので、表示は各手番自身の視点に変換（+ = その対局者有利）。詰みセンチネル ±100000 は「詰み / 詰まされ」表記
- 中央に「直前手 N秒」
- メタパネルに最新読み筋（CSA トークン、12 個超は省略、title に全文）

### 見送り（理由付き）
ShogiMatch 棋譜パネルへの per-move eval/時間カラム統合は、既存 `recordEvalByPly` 経路が「手番側視点の未正規化 eval」前提で ply パリティ反転しており、先手視点固定の wire 値を流すと二重反転するため今回は見送り（スコアボード表示で代替）。

## テスト / 品質ゲート

- lint / typecheck（match-client, ui）: successful
- test: match-client **72 pass**（+10: コメント紐付け・誤検知防止・旧サーバ互換ほか）/ ui **298 pass**（+12: 符号整形・reducer・表示/非表示）
- 実データでの表示確認はサーバ（rshogi#856）のデプロイ後に可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL