### PR TITLE
fix: PR #61 / #62 のレビュー指摘対応 (共有フック化・snapshot index ずれ修正ほか)

### DIFF
--- a/apps/desktop/src/components/rshogi-viewer/RshogiLiveGamesView.tsx
+++ b/apps/desktop/src/components/rshogi-viewer/RshogiLiveGamesView.tsx
@@ -1,12 +1,11 @@
-import type { RshogiLiveGameSummary } from "@shogi/match-client";
-import { fetchRshogiLiveGameList } from "@shogi/match-client";
-import { RshogiCsaLiveGameList } from "@shogi/ui";
+import { RshogiCsaLiveGameList, useRshogiLiveGameList } from "@shogi/ui";
 import { Button } from "@shogi/ui/components/button";
-import { type ReactElement, useEffect, useState } from "react";
+import type { ReactElement } from "react";
 
-const PAGE_LIMIT = 50;
-// サーバの edge cache TTL (60 秒) に合わせて自動再取得する。
-const AUTO_REFRESH_MS = 60_000;
+// web 側 (`RshogiLiveGamesPage`) と同じくモジュールスコープで解決する
+// (import.meta.env はビルド時定数のためコンポーネント外で確定できる)。
+const apiBaseUrl =
+    (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
 
 interface Props {
     onBackToLocal: () => void;
@@ -16,83 +15,13 @@ interface Props {
 /**
  * Desktop 用の rshogi 進行中対局一覧ビュー。
  *
- * Web 側 `RshogiLiveGamesPage` と同じ挙動 (初回ロード + 60 秒自動更新 + 手動更新 +
- * ページング) を持つ。行クリックで `onSelectGame` を呼び、呼出側 (`App.tsx`) が
- * live 観戦ビューへ遷移する。
+ * 取得・60 秒自動更新・手動更新・ページングは web 側 `RshogiLiveGamesPage` と
+ * 共有のフック (`useRshogiLiveGameList`) に委譲する。行クリックで `onSelectGame`
+ * を呼び、呼出側 (`App.tsx`) が live 観戦ビューへ遷移する。
  */
 export function RshogiLiveGamesView({ onBackToLocal, onSelectGame }: Props): ReactElement {
-    const apiBaseUrl =
-        (import.meta.env.VITE_RSHOGI_API_BASE as string | undefined)?.trim() || undefined;
-
-    const [games, setGames] = useState<RshogiLiveGameSummary[]>([]);
-    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    const [refreshNonce, setRefreshNonce] = useState<number>(0);
-
-    // 初回ロード + 60 秒ごとの自動更新。手動更新 (refreshNonce 変化) でも再実行する。
-    // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce は手動更新の再取得トリガー。effect 本体では読まないが、依存に含めることで再実行させる。
-    useEffect(() => {
-        const controller = new AbortController();
-        const loadFirstPage = async (): Promise<void> => {
-            setIsLoading(true);
-            setErrorMessage(null);
-            try {
-                const page = await fetchRshogiLiveGameList({
-                    baseUrl: apiBaseUrl,
-                    limit: PAGE_LIMIT,
-                    signal: controller.signal,
-                });
-                if (controller.signal.aborted) return;
-                setGames(page.liveGames);
-                setNextCursor(page.nextCursor);
-            } catch (error) {
-                if (controller.signal.aborted) return;
-                setErrorMessage(
-                    error instanceof Error
-                        ? error.message
-                        : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
-                );
-            } finally {
-                if (!controller.signal.aborted) setIsLoading(false);
-            }
-        };
-        void loadFirstPage();
-        const intervalId = setInterval(() => {
-            void loadFirstPage();
-        }, AUTO_REFRESH_MS);
-        return () => {
-            controller.abort();
-            clearInterval(intervalId);
-        };
-    }, [apiBaseUrl, refreshNonce]);
-
-    const handleLoadMore = async (): Promise<void> => {
-        if (!nextCursor || isLoading) return;
-        setIsLoading(true);
-        setErrorMessage(null);
-        try {
-            const page = await fetchRshogiLiveGameList({
-                baseUrl: apiBaseUrl,
-                cursor: nextCursor,
-                limit: PAGE_LIMIT,
-            });
-            setGames((prev) => [...prev, ...page.liveGames]);
-            setNextCursor(page.nextCursor);
-        } catch (error) {
-            setErrorMessage(
-                error instanceof Error
-                    ? error.message
-                    : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const handleRefresh = (): void => {
-        setRefreshNonce((n) => n + 1);
-    };
+    const { games, isLoading, errorMessage, hasMore, refresh, loadMore } =
+        useRshogiLiveGameList(apiBaseUrl);
 
     return (
         <div className="flex flex-col gap-3">
@@ -100,7 +29,7 @@ export function RshogiLiveGamesView({ onBackToLocal, onSelectGame }: Props): Rea
                 <Button variant="outline" size="sm" onClick={onBackToLocal}>
                     ← ローカル対局へ戻る
                 </Button>
-                <Button variant="outline" size="sm" onClick={handleRefresh} disabled={isLoading}>
+                <Button variant="outline" size="sm" onClick={refresh} disabled={isLoading}>
                     {isLoading ? "更新中..." : "更新"}
                 </Button>
                 <span className="text-sm font-semibold text-wafuu-sumi">rshogi viewer (live)</span>
@@ -118,9 +47,9 @@ export function RshogiLiveGamesView({ onBackToLocal, onSelectGame }: Props): Rea
             <RshogiCsaLiveGameList
                 games={games}
                 onSelectGame={onSelectGame}
-                onLoadMore={() => void handleLoadMore()}
+                onLoadMore={() => void loadMore()}
                 isLoading={isLoading}
-                hasMore={nextCursor !== undefined}
+                hasMore={hasMore}
                 emptyMessage="現在進行中の対局はありません。"
             />
         </div>

--- a/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
@@ -1,18 +1,11 @@
-import type { RshogiLiveGameSummary } from "@shogi/match-client";
-import { fetchRshogiLiveGameList } from "@shogi/match-client";
-import { RshogiCsaLiveGameList } from "@shogi/ui";
+import { RshogiCsaLiveGameList, useRshogiLiveGameList } from "@shogi/ui";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { type ReactElement, useEffect, useState } from "react";
+import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
 import { PageHeading } from "../../components/PageHeading";
 import { StatusBanner } from "../../components/StatusBanner";
-
-const PAGE_LIMIT = 50;
-// サーバの edge cache TTL (60 秒) に合わせて自動再取得する。それより短くしても
-// stale cache が返るだけで新鮮なデータは得られないため 60 秒固定。
-const AUTO_REFRESH_MS = 60_000;
 
 const resolveApiBaseUrl = (): string | undefined => {
     const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
@@ -23,78 +16,9 @@ export default function RshogiLiveGamesPage(): ReactElement {
     const navigate = useNavigate();
     const apiBaseUrl = resolveApiBaseUrl();
 
-    const [games, setGames] = useState<RshogiLiveGameSummary[]>([]);
-    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [errorMessage, setErrorMessage] = useState<string | null>(null);
-    // 手動更新ボタンを押すたびに増やして effect を再実行させる (先頭ページを
-    // 取り直し + 自動更新タイマーをリセットする)。
-    const [refreshNonce, setRefreshNonce] = useState<number>(0);
-
-    // 初回ロード + 60 秒ごとの自動更新。手動更新 (refreshNonce 変化) でも再実行する。
-    // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce は手動更新の再取得トリガー。effect 本体では読まないが、依存に含めることで再実行させる。
-    useEffect(() => {
-        const controller = new AbortController();
-        const loadFirstPage = async (): Promise<void> => {
-            setIsLoading(true);
-            setErrorMessage(null);
-            try {
-                const page = await fetchRshogiLiveGameList({
-                    baseUrl: apiBaseUrl,
-                    limit: PAGE_LIMIT,
-                    signal: controller.signal,
-                });
-                if (controller.signal.aborted) return;
-                setGames(page.liveGames);
-                setNextCursor(page.nextCursor);
-            } catch (error) {
-                if (controller.signal.aborted) return;
-                setErrorMessage(
-                    error instanceof Error
-                        ? error.message
-                        : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
-                );
-            } finally {
-                if (!controller.signal.aborted) setIsLoading(false);
-            }
-        };
-        void loadFirstPage();
-        const intervalId = setInterval(() => {
-            void loadFirstPage();
-        }, AUTO_REFRESH_MS);
-        return () => {
-            controller.abort();
-            clearInterval(intervalId);
-        };
-    }, [apiBaseUrl, refreshNonce]);
-
-    const handleLoadMore = async (): Promise<void> => {
-        if (!nextCursor || isLoading) return;
-        setIsLoading(true);
-        setErrorMessage(null);
-        try {
-            const page = await fetchRshogiLiveGameList({
-                baseUrl: apiBaseUrl,
-                cursor: nextCursor,
-                limit: PAGE_LIMIT,
-            });
-            // append (開始が新しい順で連結)
-            setGames((prev) => [...prev, ...page.liveGames]);
-            setNextCursor(page.nextCursor);
-        } catch (error) {
-            setErrorMessage(
-                error instanceof Error
-                    ? error.message
-                    : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
-            );
-        } finally {
-            setIsLoading(false);
-        }
-    };
-
-    const handleRefresh = (): void => {
-        setRefreshNonce((n) => n + 1);
-    };
+    // 取得・60 秒自動更新・手動更新・ページングは desktop と共有のフックに委譲する。
+    const { games, isLoading, errorMessage, hasMore, refresh, loadMore } =
+        useRshogiLiveGameList(apiBaseUrl);
 
     const handleSelect = (gameId: string): void => {
         void navigate({ to: "/rshogi-viewer/live/$gameId", params: { gameId } });
@@ -118,7 +42,7 @@ export default function RshogiLiveGamesPage(): ReactElement {
                     <div className="flex flex-wrap items-center gap-3">
                         <button
                             type="button"
-                            onClick={handleRefresh}
+                            onClick={refresh}
                             disabled={isLoading}
                             className="rounded-md border border-wafuu-border px-3 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:cursor-not-allowed disabled:opacity-60"
                         >
@@ -138,9 +62,9 @@ export default function RshogiLiveGamesPage(): ReactElement {
                 <RshogiCsaLiveGameList
                     games={games}
                     onSelectGame={handleSelect}
-                    onLoadMore={() => void handleLoadMore()}
+                    onLoadMore={() => void loadMore()}
                     isLoading={isLoading}
-                    hasMore={nextCursor !== undefined}
+                    hasMore={hasMore}
                     emptyMessage="現在進行中の対局はありません。"
                 />
             </PageContainer>

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -296,10 +296,10 @@ describe("subscribeRshogiLiveGame: Floodgate コメント (eval / PV)", () => {
         });
     });
 
-    it("live: onMove は即時発火し、RshogiLiveMoveEvent.comment は付かない (コメントは後追い)", () => {
+    it("live: onMove は即時発火し、コメントは onMoveComment で後追い配信される", () => {
         const { ws, events } = openWithSnapshot();
         ws.fireLines(["+7776FU,T8", "'* 100"]);
-        expect(events.moves[0].comment).toBeUndefined();
+        expect(events.moves[0]).toEqual({ csaMove: "7g7f", elapsedSec: 8 });
         expect(events.moveComments[0]).toEqual({ ply: 1, comment: { raw: "* 100", evalCp: 100 } });
     });
 
@@ -351,6 +351,42 @@ describe("subscribeRshogiLiveGame: Floodgate コメント (eval / PV)", () => {
                 elapsedSec: 8,
                 comment: { raw: "* 30 -3334FU", evalCp: 30, pv: ["-3334FU"] },
             },
+            {
+                csaMove: "3c3d",
+                elapsedSec: 7,
+                comment: { raw: "* -20 +2726FU", evalCp: -20, pv: ["+2726FU"] },
+            },
+        ]);
+    });
+
+    it("snapshot: 解析不能な手が混ざっても以降の elapsedSec/comment が 1 手ずれない", () => {
+        const { events } = (() => {
+            const mocks = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: mocks.wsFactory },
+                mocks.callbacks,
+            );
+            const ws = mocks.wsInstances[0];
+            ws.fireOpen();
+            // 2 行目は違法手 (7776FU の重複) で parse に落ちる。skip した entry の
+            // elapsedSec/comment ごと落とし、3 行目のメタ情報が 2 行目のものに
+            // ずれないことを固定する。
+            ws.fireLines(
+                buildSnapshotLines([
+                    "+7776FU,T8",
+                    "+7776FU,T99",
+                    "'* 999 ずれ検出用",
+                    "-3334FU,T7",
+                    "'* -20 +2726FU",
+                ]),
+            );
+            return mocks;
+        })();
+        const snap = events.snapshot[0];
+        expect(snap.moves).toEqual(["7g7f", "3c3d"]);
+        expect(snap.moveDetails).toEqual([
+            { csaMove: "7g7f", elapsedSec: 8, comment: undefined },
             {
                 csaMove: "3c3d",
                 elapsedSec: 7,

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -24,8 +24,8 @@
  * `<gameId>` 末尾の epoch suffix を剥がすため、URL に game_id をそのまま渡せば
  * room_id 形式に変換される。
  *
- * 注: 本モジュールは `@shogi/app-core` の CSA decode helper (`parseSingleCsaMove`
- * / `parseCsaMovesWithState`) に依存する。設計コメント v5 §6.4 に基づき、
+ * 注: 本モジュールは `@shogi/app-core` の CSA decode helper (`parseSingleCsaMove`)
+ * に依存する。設計コメント v5 §6.4 に基づき、
  * 「snapshot block 内の moves をフル再パース」「broadcast move を 1 行ずつ
  * apply」を `subscribeRshogiLiveGame` 内に閉じ込めるための判断。一般的な WS
  * クライアント実装 (`createRoomClient` 等) は app-core に依存しないが、live
@@ -38,7 +38,6 @@
 import {
     createInitialPositionState,
     type PositionState,
-    parseCsaMovesWithState,
     parseSingleCsaMove,
 } from "@shogi/app-core";
 import type { RshogiGameMeta, RshogiGameResult, RshogiGameResultKind } from "./client";
@@ -124,15 +123,6 @@ export interface RshogiLiveMoveEvent {
     csaMove: string;
     /** 消費秒数 (`,T<elapsed_sec>` の値)。秒数行が無ければ 0。 */
     elapsedSec: number;
-    /**
-     * 指した側のコメント (eval / PV)。
-     *
-     * live stream ではコメントは move 行の *後* に別行で届くため、`onMove` 発火時点
-     * では確定しておらず本フィールドは常に undefined になる (コメントは後続の
-     * `onMoveComment` で ply 紐付きで届く)。型の対称性と将来利用のための予約。
-     * snapshot 由来の手のコメントは {@link RshogiLiveSnapshot.moveDetails} で届く。
-     */
-    comment?: RshogiLiveComment;
 }
 
 /**
@@ -347,16 +337,25 @@ const decodeSnapshotBlock = (
 
     const summary = parseGameSummaryLines(summaryLines);
 
-    const movesText = moveEntries.map((e) => e.token).join("\n");
-    const initial = createInitialPositionState();
-    const { moves, state } = parseCsaMovesWithState(movesText, initial);
-    // `moves` (USI) と同順・同長でメタ情報を並べる。parse で token が脱落しても
-    // index 対応が崩れないよう moves 側を基準に index する。
-    const moveDetails: RshogiLiveMove[] = moves.map((usi, i) => ({
-        csaMove: usi,
-        elapsedSec: moveEntries[i]?.elapsedSec ?? 0,
-        comment: moveEntries[i]?.comment,
-    }));
+    // moves (USI) と moveDetails を同じループで対にして構築する。
+    // `parseCsaMovesWithState` は解析不能な手を skip して続行するため、moves 配列
+    // だけ後から index 対応させると skip 以降の消費秒/コメントが 1 手ずれる。
+    // entry 単位で parse し、失敗した entry は elapsedSec/comment ごと落とすことで
+    // 両配列の index 対応を構造的に保証する (skip の挙動自体は従来と同じ)。
+    let state = createInitialPositionState();
+    const moves: string[] = [];
+    const moveDetails: RshogiLiveMove[] = [];
+    for (const entry of moveEntries) {
+        const applied = parseSingleCsaMove(entry.token, state);
+        if (!applied) continue;
+        state = applied.nextState;
+        moves.push(applied.move);
+        moveDetails.push({
+            csaMove: applied.move,
+            elapsedSec: entry.elapsedSec,
+            comment: entry.comment,
+        });
+    }
 
     const meta: RshogiGameMeta = {
         gameId: summary.gameId ?? gameId,

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -153,10 +153,13 @@ describe("RshogiLiveMetaPanel: 読み筋の表示", () => {
         expect(screen.getByText("読み筋")).toBeDefined();
         expect(screen.getByText("+7776FU -3334FU")).toBeDefined();
     });
-    it("長い PV は末尾を省略する", () => {
+    it("長い PV は表示を末尾省略しつつ title には全文を渡す", () => {
         const pv = Array.from({ length: 20 }, (_, i) => `+m${i}`);
         render(<RshogiLiveMetaPanel meta={META} latestPv={pv} />);
-        expect(screen.getByText(/…$/)).toBeDefined();
+        const truncated = screen.getByText(/…$/);
+        expect(truncated).toBeDefined();
+        // ツールチップ (title) は省略前の全文。
+        expect(truncated.getAttribute("title")).toBe(pv.join(" "));
     });
     it("PV が無いときは読み筋を表示しない", () => {
         render(<RshogiLiveMetaPanel meta={META} />);

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -129,13 +129,11 @@ export function applyMoveComment(
 export function summarizeMoveDetails(moveDetails: RshogiLiveMove[]): LiveEvalState & {
     lastMoveElapsedSec?: number;
 } {
-    let evalState: LiveEvalState = {};
-    for (let i = 0; i < moveDetails.length; i++) {
-        const comment = moveDetails[i].comment;
-        if (!comment) continue;
-        // ply = i + 1。奇数 = 先手の指し手、偶数 = 後手の指し手。
-        evalState = applyMoveComment(evalState, i + 1, comment);
-    }
+    // ply = i + 1。奇数 = 先手の指し手、偶数 = 後手の指し手。
+    const evalState = moveDetails.reduce<LiveEvalState>(
+        (acc, detail, i) => (detail.comment ? applyMoveComment(acc, i + 1, detail.comment) : acc),
+        {},
+    );
     const last = moveDetails[moveDetails.length - 1];
     return { ...evalState, lastMoveElapsedSec: last?.elapsedSec };
 }
@@ -369,8 +367,10 @@ export function RshogiLiveMetaPanel({
     /** 最新コメントの読み筋 (CSA トークン列)。無ければ非表示。 */
     latestPv?: string[];
 }): ReactElement {
+    // 表示は MAX_PV_TOKENS で省略し、title (ツールチップ) には全文を渡す。
+    const pvFullText = latestPv && latestPv.length > 0 ? latestPv.join(" ") : undefined;
     const pvText =
-        latestPv && latestPv.length > 0
+        latestPv && pvFullText
             ? latestPv.slice(0, MAX_PV_TOKENS).join(" ") +
               (latestPv.length > MAX_PV_TOKENS ? " …" : "")
             : undefined;
@@ -392,7 +392,7 @@ export function RshogiLiveMetaPanel({
                     </span>
                     <span
                         className="truncate font-mono text-xs text-muted-foreground"
-                        title={pvText}
+                        title={pvFullText}
                     >
                         {pvText}
                     </span>

--- a/packages/ui/src/hooks/useRshogiLiveGameList.test.tsx
+++ b/packages/ui/src/hooks/useRshogiLiveGameList.test.tsx
@@ -1,0 +1,112 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useRshogiLiveGameList } from "./useRshogiLiveGameList";
+
+const mockFetchRshogiLiveGameList = vi.fn();
+
+vi.mock("@shogi/match-client", () => ({
+    fetchRshogiLiveGameList: (
+        ...args: Parameters<typeof mockFetchRshogiLiveGameList>
+    ): ReturnType<typeof mockFetchRshogiLiveGameList> => mockFetchRshogiLiveGameList(...args),
+}));
+
+const game = (gameId: string) => ({
+    gameId,
+    senteName: "sente",
+    goteName: "gote",
+});
+
+afterEach(() => {
+    mockFetchRshogiLiveGameList.mockReset();
+});
+
+describe("useRshogiLiveGameList", () => {
+    it("マウント時に先頭ページを取得して games に反映する", async () => {
+        mockFetchRshogiLiveGameList.mockResolvedValueOnce({
+            liveGames: [game("g1"), game("g2")],
+            nextCursor: "2",
+        });
+        const { result, unmount } = renderHook(() => useRshogiLiveGameList("https://example.com"));
+
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+        expect(result.current.games.map((g) => g.gameId)).toEqual(["g1", "g2"]);
+        expect(result.current.hasMore).toBe(true);
+        expect(result.current.errorMessage).toBeNull();
+        unmount();
+    });
+
+    it("loadMore で次ページを末尾に追記し、末尾ページで hasMore が false になる", async () => {
+        mockFetchRshogiLiveGameList
+            .mockResolvedValueOnce({ liveGames: [game("g1")], nextCursor: "1" })
+            .mockResolvedValueOnce({ liveGames: [game("g2")], nextCursor: undefined });
+        const { result, unmount } = renderHook(() => useRshogiLiveGameList("https://example.com"));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        await act(async () => {
+            await result.current.loadMore();
+        });
+        expect(result.current.games.map((g) => g.gameId)).toEqual(["g1", "g2"]);
+        expect(result.current.hasMore).toBe(false);
+        // 2 回目の fetch には cursor が渡っている。
+        expect(mockFetchRshogiLiveGameList).toHaveBeenLastCalledWith(
+            expect.objectContaining({ cursor: "1" }),
+        );
+        unmount();
+    });
+
+    it("取得エラーで errorMessage が入る", async () => {
+        mockFetchRshogiLiveGameList.mockRejectedValueOnce(new Error("boom"));
+        const { result, unmount } = renderHook(() => useRshogiLiveGameList("https://example.com"));
+
+        await waitFor(() => expect(result.current.errorMessage).toBe("boom"));
+        expect(result.current.isLoading).toBe(false);
+        unmount();
+    });
+
+    it("refresh で先頭ページを取り直す", async () => {
+        mockFetchRshogiLiveGameList
+            .mockResolvedValueOnce({ liveGames: [game("g1")], nextCursor: undefined })
+            .mockResolvedValueOnce({ liveGames: [game("g9")], nextCursor: undefined });
+        const { result, unmount } = renderHook(() => useRshogiLiveGameList("https://example.com"));
+        await waitFor(() => expect(result.current.games).toHaveLength(1));
+
+        act(() => {
+            result.current.refresh();
+        });
+        await waitFor(() => expect(result.current.games.map((g) => g.gameId)).toEqual(["g9"]));
+        expect(mockFetchRshogiLiveGameList).toHaveBeenCalledTimes(2);
+        unmount();
+    });
+
+    it("アンマウント後に解決した loadMore は state を更新しない (abort ガード)", async () => {
+        mockFetchRshogiLiveGameList.mockResolvedValueOnce({
+            liveGames: [game("g1")],
+            nextCursor: "1",
+        });
+        const { result, unmount } = renderHook(() => useRshogiLiveGameList("https://example.com"));
+        await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+        // 解決を保留したまま loadMore を発火し、途中でアンマウントする。
+        let resolveLoadMore: (v: unknown) => void = () => {};
+        mockFetchRshogiLiveGameList.mockImplementationOnce(
+            (options: { signal?: AbortSignal }) =>
+                new Promise((resolve, reject) => {
+                    resolveLoadMore = resolve;
+                    options.signal?.addEventListener("abort", () =>
+                        reject(new DOMException("aborted", "AbortError")),
+                    );
+                }),
+        );
+        let pending: Promise<void> = Promise.resolve();
+        act(() => {
+            pending = result.current.loadMore();
+        });
+        unmount();
+        // アンマウントで abort 済み。解決/拒否どちらが先でも throw せず完了する。
+        resolveLoadMore({ liveGames: [game("g2")], nextCursor: undefined });
+        await act(async () => {
+            await pending;
+        });
+    });
+});

--- a/packages/ui/src/hooks/useRshogiLiveGameList.ts
+++ b/packages/ui/src/hooks/useRshogiLiveGameList.ts
@@ -1,0 +1,133 @@
+import type { RshogiLiveGameSummary } from "@shogi/match-client";
+import { fetchRshogiLiveGameList } from "@shogi/match-client";
+import { useEffect, useRef, useState } from "react";
+
+/** 一覧 fetch の 1 ページ件数。 */
+const PAGE_LIMIT = 50;
+// サーバの edge cache TTL (60 秒) に合わせて自動再取得する。それより短くしても
+// stale cache が返るだけで新鮮なデータは得られないため 60 秒固定。
+const AUTO_REFRESH_MS = 60_000;
+
+export interface UseRshogiLiveGameListReturn {
+    /** 取得済みの進行中対局 (先頭ページ + `loadMore` で追記した分)。 */
+    games: RshogiLiveGameSummary[];
+    /** 初回 / 再取得 / ページ追加読み込み中フラグ。 */
+    isLoading: boolean;
+    /** 直近の取得エラー文言 (無ければ null)。 */
+    errorMessage: string | null;
+    /** 次ページが存在するか。 */
+    hasMore: boolean;
+    /** 先頭ページから取り直す (自動更新タイマーもリセットされる)。 */
+    refresh: () => void;
+    /** 次ページを末尾に追記する。 */
+    loadMore: () => Promise<void>;
+}
+
+/**
+ * rshogi 進行中対局一覧の取得・自動更新・ページングを担う共有フック。
+ *
+ * Web (`RshogiLiveGamesPage`) と Desktop (`RshogiLiveGamesView`) で同一の
+ * データ取得ロジックを共有する。挙動:
+ * - マウント時に先頭ページを取得し、60 秒ごと (サーバ edge cache TTL に一致) に
+ *   自動で先頭ページを取り直す
+ * - `refresh()` で先頭ページ取り直し + 自動更新タイマーのリセット
+ * - `loadMore()` で `next_cursor` を辿って末尾に追記
+ * - アンマウント時は初回/自動更新・`loadMore` の in-flight リクエストをともに
+ *   abort し、アンマウント後の state 更新を残さない
+ */
+export function useRshogiLiveGameList(apiBaseUrl: string | undefined): UseRshogiLiveGameListReturn {
+    const [games, setGames] = useState<RshogiLiveGameSummary[]>([]);
+    const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    // 手動更新のたびに増やして effect を再実行させる (先頭ページ取り直し +
+    // 自動更新タイマーのリセットを一括処理)。
+    const [refreshNonce, setRefreshNonce] = useState<number>(0);
+    /** `loadMore` の in-flight リクエスト。アンマウント/refresh 時に abort する。 */
+    const loadMoreControllerRef = useRef<AbortController | null>(null);
+
+    // 初回ロード + 60 秒ごとの自動更新。手動更新 (refreshNonce 変化) でも再実行する。
+    // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce は手動更新の再取得トリガー。effect 本体では読まないが、依存に含めることで再実行させる。
+    useEffect(() => {
+        const controller = new AbortController();
+        const loadFirstPage = async (): Promise<void> => {
+            setIsLoading(true);
+            setErrorMessage(null);
+            try {
+                const page = await fetchRshogiLiveGameList({
+                    baseUrl: apiBaseUrl,
+                    limit: PAGE_LIMIT,
+                    signal: controller.signal,
+                });
+                if (controller.signal.aborted) return;
+                setGames(page.liveGames);
+                setNextCursor(page.nextCursor);
+            } catch (error) {
+                if (controller.signal.aborted) return;
+                setErrorMessage(
+                    error instanceof Error
+                        ? error.message
+                        : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+                );
+            } finally {
+                if (!controller.signal.aborted) setIsLoading(false);
+            }
+        };
+        void loadFirstPage();
+        const intervalId = setInterval(() => {
+            void loadFirstPage();
+        }, AUTO_REFRESH_MS);
+        return () => {
+            controller.abort();
+            clearInterval(intervalId);
+            // ページング中のアンマウント/refresh でも state 更新を残さない。
+            loadMoreControllerRef.current?.abort();
+            loadMoreControllerRef.current = null;
+        };
+    }, [apiBaseUrl, refreshNonce]);
+
+    const loadMore = async (): Promise<void> => {
+        if (!nextCursor || isLoading) return;
+        const controller = new AbortController();
+        loadMoreControllerRef.current = controller;
+        setIsLoading(true);
+        setErrorMessage(null);
+        try {
+            const page = await fetchRshogiLiveGameList({
+                baseUrl: apiBaseUrl,
+                cursor: nextCursor,
+                limit: PAGE_LIMIT,
+                signal: controller.signal,
+            });
+            if (controller.signal.aborted) return;
+            // append (開始が新しい順で連結)
+            setGames((prev) => [...prev, ...page.liveGames]);
+            setNextCursor(page.nextCursor);
+        } catch (error) {
+            if (controller.signal.aborted) return;
+            setErrorMessage(
+                error instanceof Error
+                    ? error.message
+                    : `進行中対局一覧の取得に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            if (!controller.signal.aborted) setIsLoading(false);
+            if (loadMoreControllerRef.current === controller) {
+                loadMoreControllerRef.current = null;
+            }
+        }
+    };
+
+    const refresh = (): void => {
+        setRefreshNonce((n) => n + 1);
+    };
+
+    return {
+        games,
+        isLoading,
+        errorMessage,
+        hasMore: nextCursor !== undefined,
+        refresh,
+        loadMore,
+    };
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -16,6 +16,8 @@ export { useDevMode } from "./hooks/useDevMode";
 export { useNnueStorage } from "./hooks/useNnueStorage";
 export type { UseRoomConnectionOptions, UseRoomConnectionReturn } from "./hooks/useRoomConnection";
 export { useRoomConnection } from "./hooks/useRoomConnection";
+export type { UseRshogiLiveGameListReturn } from "./hooks/useRshogiLiveGameList";
+export { useRshogiLiveGameList } from "./hooks/useRshogiLiveGameList";
 // ============================================================
 // Components
 // ============================================================


### PR DESCRIPTION
## 概要

マージ済みの #61 / #62 に付いたレビュー指摘への follow-up。

## #61 (live 対局一覧) への対応

- **共有フック化**: web/desktop で完全重複していた取得・60秒自動更新・手動更新・cursor ページングを `useRshogiLiveGameList` (packages/ui) に集約
- **loadMore の abort 欠落を修正**: in-flight のページングをアンマウント/refresh 時に abort（`AbortController` を ref 管理）し、アンマウント後の `setState` を排除
- **apiBaseUrl 解決の統一**: desktop もモジュールスコープで解決

## #62 (評価値/消費時間表示) への対応

- **snapshot index ずれ（実バグ）を修正**: `parseCsaMovesWithState` は解析不能な手を skip **して続行**するため、`moves` と `moveEntries` を別 index で対応付けると skip 以降の消費秒/コメントが1手ずれる。entry 単位で `parseSingleCsaMove` を適用し `moves` / `moveDetails` を対で構築して構造的に排除（回帰テスト追加）
- **読み筋ツールチップ修正**: `title` に省略後テキストを渡していたのを全文に（テストで固定）
- **`RshogiLiveMoveEvent.comment` を削除**: 常に undefined の予約フィールドは YAGNI 違反のため、必要になった時点で追加する方針に変更
- **`summarizeMoveDetails` を reduce に**（可変変数の排除）

## 見送った指摘

- 「コメントは最大1行」ルール: AGENTS.md / CLAUDE.md に該当規則が存在しないことを確認したため対応しない（bot レビューの誤引用）

## テスト / 品質ゲート

- lint / typecheck / knip: green
- test: match-client **73 pass**（index ずれ回帰テスト追加）/ ui **303 pass**（フック 5 件・title 検証追加）/ desktop 7 pass
- web の 2 テストファイル失敗は既存の `engine-wasm/pkg` 未生成問題（#61/#62 時点と同一、本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL