### PR TITLE
feat: live viewer に評価値グラフと棋譜パネル内評価値を表示

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -3,6 +3,7 @@ import {
     __test_internals,
     type RshogiLiveCallbacks,
     type RshogiLiveConnectionState,
+    type RshogiLiveSnapshot,
     subscribeRshogiLiveGame,
 } from "./live";
 
@@ -104,14 +105,7 @@ const makeMocks = () => {
         return ws as unknown as WebSocket;
     };
     const events = {
-        snapshot: [] as Array<{
-            moves: string[];
-            moveDetails: Array<{
-                csaMove: string;
-                elapsedSec: number;
-                comment?: { raw: string; evalCp?: number; pv?: string[] };
-            }>;
-        }>,
+        snapshot: [] as RshogiLiveSnapshot[],
         moves: [] as Array<{
             csaMove: string;
             elapsedSec: number;
@@ -613,6 +607,107 @@ describe("subscribeRshogiLiveGame: NOT_FOUND", () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+describe("subscribeRshogiLiveGame: モック (apiBaseUrl 未指定 + gameId が mock- prefix)", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("固定 snapshot を配信し、eval コメント付き moveDetails を載せる", () => {
+        const { events, callbacks } = makeMocks();
+        // apiBaseUrl 未指定 + `mock-` prefix → WS を張らずモックが動く
+        subscribeRshogiLiveGame("mock-demo-game", {}, callbacks);
+        // connecting は同期で通知される
+        expect(events.states).toContain("connecting");
+        expect(events.snapshot.length).toBe(0);
+
+        // タイマー tick で snapshot / clock が届く
+        vi.advanceTimersByTime(0);
+        expect(events.states).toContain("connected");
+        expect(events.snapshot.length).toBe(1);
+        expect(events.clocks.length).toBe(1);
+
+        const snap = events.snapshot[0];
+        // 15 手すべてが decode され moveDetails と同順・同長で並ぶ
+        expect(snap.moves.length).toBe(15);
+        expect(snap.moveDetails.length).toBe(15);
+
+        // 1 手目: 消費秒と先手視点 eval / PV が載る
+        expect(snap.moveDetails[0]).toEqual({
+            csaMove: "7g7f",
+            elapsedSec: 3,
+            comment: { raw: "* 30 -3334FU +2726FU", evalCp: 30, pv: ["-3334FU", "+2726FU"] },
+        });
+        // ply6 は後手有利 (先手視点で負値) の連続下げの起点
+        expect(snap.moveDetails[5].comment?.evalCp).toBe(-25);
+        expect(snap.moveDetails[6].comment?.evalCp).toBe(-40);
+        expect(snap.moveDetails[9].comment?.evalCp).toBe(-90);
+        // 最終手は詰みセンチネル ±100000 (先手が詰みを発見)。wire レベルでは生値の
+        // まま届き、表示用の丸め (±2000) は viewer 側 (rshogi-csa-live-viewer) で行う。
+        const last = snap.moveDetails[snap.moveDetails.length - 1];
+        expect(last.comment?.evalCp).toBe(100000);
+
+        // Game_ID を省いているので meta.gameId は購読 gameId にフォールバックする
+        expect(snap.meta.gameId).toBe("mock-demo-game");
+        // 15 手 (奇数) 適用後の手番は後手
+        expect(snap.clocks.sideToMove).toBe("gote");
+        expect(events.clocks[0].remainingMs).toEqual({ sente: 540000, gote: 552000 });
+    });
+
+    it("disconnect() で保留中の配信を止め closed を通知する", () => {
+        const { events, callbacks } = makeMocks();
+        const session = subscribeRshogiLiveGame("mock-demo-game", {}, callbacks);
+        // snapshot 配信前に切断すると snapshot は届かない
+        session.disconnect();
+        vi.advanceTimersByTime(0);
+        expect(events.snapshot.length).toBe(0);
+        expect(events.states.at(-1)).toBe("closed");
+    });
+
+    it("timer impl を this 非束縛で呼ぶ (browser window.setTimeout の Illegal invocation 回帰防止)", () => {
+        // ブラウザの window.setTimeout/clearTimeout は this が window 以外に束縛される
+        // と TypeError: Illegal invocation を throw する。`deps.setTimeoutImpl(...)` の
+        // ようなメソッド呼びだと this=deps になり実ブラウザで落ちる (Node/happy-dom は
+        // this を見ないため素通りする)。その挙動を再現する shim で回帰を固定する。
+        const strictThis = <T extends (...args: never[]) => unknown>(fn: T): T =>
+            function (this: unknown, ...args: never[]) {
+                if (this !== undefined && this !== globalThis) {
+                    throw new TypeError("Illegal invocation");
+                }
+                return fn(...args);
+            } as T;
+        const strictImpls = {
+            setTimeoutImpl: strictThis(setTimeout) as typeof setTimeout,
+            clearTimeoutImpl: strictThis(clearTimeout) as typeof clearTimeout,
+        };
+        // setTimeoutImpl 経由の snapshot 配信が throw せず届く
+        const delivered = makeMocks();
+        subscribeRshogiLiveGame("mock-demo-game", strictImpls, delivered.callbacks);
+        vi.advanceTimersByTime(0);
+        expect(delivered.events.errors).toEqual([]);
+        expect(delivered.events.snapshot.length).toBe(1);
+        // clearTimeoutImpl 経路 (timer 保留中の disconnect) も throw しない
+        const cancelled = makeMocks();
+        const session = subscribeRshogiLiveGame("mock-demo-game", strictImpls, cancelled.callbacks);
+        session.disconnect();
+        expect(cancelled.events.errors).toEqual([]);
+        expect(cancelled.events.states.at(-1)).toBe("closed");
+    });
+
+    it("mock- prefix でない gameId は apiBaseUrl 未指定だとエラーで閉じる (偽対局を配信しない)", () => {
+        const { events, callbacks } = makeMocks();
+        // 設定漏れ (VITE_RSHOGI_API_BASE 未設定) の実 gameId → PR 前と同じエラー経路
+        subscribeRshogiLiveGame("real-game-123", {}, callbacks);
+        vi.advanceTimersByTime(60000);
+        expect(events.snapshot.length).toBe(0);
+        expect(events.errors.length).toBe(1);
+        expect(events.errors[0].message).toContain("apiBaseUrl is required");
+        expect(events.states).toEqual(["closed"]);
     });
 });
 

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -550,10 +550,184 @@ const parseLiveComment = (line: string): RshogiLiveComment => {
 };
 
 /**
+ * モック観戦 (apiBaseUrl 未指定かつ gameId が `mock-` で始まる場合) が配信する
+ * 固定 snapshot の wire 行群。
+ *
+ * `##[MONITOR2] BEGIN/END` を含まない「snapshot block 本文」形式で、
+ * {@link decodeSnapshotBlock} にそのまま渡せる。各 move 行の直後に Floodgate 形
+ * コメント (`'* <cp> <pv...>`) を並べ、消費秒 (`,T<sec>`) も付与している。
+ * eval は先手視点 (+ = 先手有利) で、序盤 (ply1-5) は先手有利 → ply6-10 で
+ * 後手有利の連続下げ → ply11 以降で先手が挽回 → 最終手 (ply15) で詰み
+ * センチネル `100000` に至る、という現実味のある評価値の振れを持たせている。
+ * これによりサーバ無しでも評価値グラフ・棋譜評価値カラムをローカルで確認できる。
+ *
+ * `Game_ID` / `To_Move` はあえて省き、`meta.gameId` は購読時の gameId に、
+ * `sideToMove` は全手 replay 後の手番 (= 後手) にフォールバックさせている。
+ */
+const MOCK_SNAPSHOT_LINES: string[] = [
+    "BEGIN Game_Summary",
+    "Protocol_Version:1.2",
+    "Protocol_Mode:Server",
+    "Format:Shogi 1.0",
+    "Name+:先手デモエンジン",
+    "Name-:後手デモエンジン",
+    "Rematch_On_Draw:NO",
+    "BEGIN Time",
+    "Time_Unit:1sec",
+    "Total_Time:600",
+    "Byoyomi:10",
+    "Least_Time_Per_Move:0",
+    "END Time",
+    "BEGIN Position",
+    "P1-KY-KE-GI-KI-OU-KI-GI-KE-KY",
+    "P2 * -HI *  *  *  *  * -KA * ",
+    "P3-FU-FU-FU-FU-FU-FU-FU-FU-FU",
+    "P4 *  *  *  *  *  *  *  *  * ",
+    "P5 *  *  *  *  *  *  *  *  * ",
+    "P6 *  *  *  *  *  *  *  *  * ",
+    "P7+FU+FU+FU+FU+FU+FU+FU+FU+FU",
+    "P8 * +KA *  *  *  *  * +HI * ",
+    "P9+KY+KE+GI+KI+OU+KI+GI+KE+KY",
+    "+",
+    "END Position",
+    "Black_Time_Remaining_Ms:540000",
+    "White_Time_Remaining_Ms:552000",
+    "END Game_Summary",
+    // ply1-5: 先手やや有利で推移
+    "+7776FU,T3",
+    "'* 30 -3334FU +2726FU",
+    "-3334FU,T5",
+    "'* 20 +2726FU -8384FU",
+    "+2726FU,T2",
+    "'* 45 -8384FU +2625FU",
+    "-8384FU,T4",
+    "'* 15 +2625FU -8485FU",
+    "+2625FU,T3",
+    "'* 60 -8485FU +6978KI",
+    // ply6-10: 後手有利の連続下げ (先手視点で負値が続く)
+    "-8485FU,T6",
+    "'* -25 +6978KI -7162GI",
+    "+6978KI,T8",
+    "'* -40 -7162GI +8877KA",
+    "-7162GI,T7",
+    "'* -70 +8877KA -2233KA",
+    "+8877KA,T9",
+    "'* -55 -2233KA +7968GI",
+    "-2233KA,T6",
+    "'* -90 +7968GI -3132GI",
+    // ply11-14: 先手が挽回
+    "+7968GI,T10",
+    "'* 35 -3132GI +3736FU",
+    "-3132GI,T7",
+    "'* 10 +3736FU -3435FU",
+    "+3736FU,T4",
+    "'* 80 -3435FU +3635FU",
+    "-3435FU,T5",
+    "'* 120 +3635FU",
+    // ply15: 詰みセンチネル (先手が詰みを発見)
+    "+3635FU,T3",
+    "'* 100000",
+];
+
+/**
+ * モック観戦セッションを開始する (apiBaseUrl 未指定かつ gameId が `mock-` で始まる場合のみ)。
+ *
+ * サーバへは接続せず、{@link MOCK_SNAPSHOT_LINES} を decode した固定 snapshot を
+ * 1 回だけ配信する (broadcast move は流さない)。server 無しの開発・デモで live
+ * viewer の評価値グラフ / 棋譜評価値カラムを表示するための経路。
+ *
+ * `disconnect()` / `signal` abort で保留中のタイマーを止め、`closed` を通知する。
+ */
+function startMockLiveGame(
+    gameId: string,
+    callbacks: RshogiLiveCallbacks,
+    deps: {
+        setTimeoutImpl: typeof setTimeout;
+        clearTimeoutImpl: typeof clearTimeout;
+        signal?: AbortSignal;
+    },
+): RshogiLiveSession {
+    // 注意: `deps.setTimeoutImpl(...)` のようにオブジェクトのメソッドとして呼ぶと、
+    // ブラウザ実装の window.setTimeout/clearTimeout は this が deps に束縛され
+    // "Illegal invocation" を throw する (Node/happy-dom は this を見ないため
+    // テストでは顕在化しない)。必ずローカル変数へ剥がして裸で呼ぶこと。
+    const { setTimeoutImpl, clearTimeoutImpl } = deps;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const emit = (fn: () => void) => {
+        try {
+            fn();
+        } catch (err) {
+            try {
+                callbacks.onError(
+                    err instanceof Error ? err : new Error(`mock handler threw: ${String(err)}`),
+                );
+            } catch (handlerErr) {
+                console.error("[rshogi live mock] onError handler threw", handlerErr);
+            }
+        }
+    };
+
+    const dispose = () => {
+        if (disposed) return;
+        disposed = true;
+        if (timer !== null) {
+            clearTimeoutImpl(timer);
+            timer = null;
+        }
+        emit(() => callbacks.onConnectionState("closed"));
+    };
+
+    if (deps.signal) {
+        if (deps.signal.aborted) {
+            dispose();
+            return { disconnect: () => {} };
+        }
+        deps.signal.addEventListener("abort", dispose, { once: true });
+    }
+
+    emit(() => callbacks.onConnectionState("connecting"));
+
+    timer = setTimeoutImpl(() => {
+        timer = null;
+        if (disposed) return;
+        emit(() => callbacks.onConnectionState("connected"));
+        try {
+            const { snapshot } = decodeSnapshotBlock(gameId, MOCK_SNAPSHOT_LINES);
+            emit(() => callbacks.onSnapshot(snapshot));
+            emit(() =>
+                callbacks.onClock({
+                    remainingMs: { sente: snapshot.clocks.sente, gote: snapshot.clocks.gote },
+                    sideToMove: snapshot.clocks.sideToMove,
+                }),
+            );
+        } catch (err) {
+            emit(() =>
+                callbacks.onError(
+                    err instanceof Error
+                        ? err
+                        : new Error(`mock snapshot decode failed: ${String(err)}`),
+                ),
+            );
+        }
+    }, 0);
+
+    return { disconnect: dispose };
+}
+
+/** モック観戦を有効にする gameId の prefix (apiBaseUrl 未指定時のみ有効)。 */
+const MOCK_GAME_ID_PREFIX = "mock-";
+
+/**
  * 進行中対局の WebSocket 観戦を開始する。
  *
- * `apiBaseUrl` 未指定時はサーバ接続を行わず、固定 snapshot を即時配信する MVP
- * 動作。`apiBaseUrl` 指定時は `wss://<host>/ws/<gameId>/spectate` に open する。
+ * `apiBaseUrl` 指定時は `wss://<host>/ws/<gameId>/spectate` に open する。
+ * `apiBaseUrl` 未指定時は:
+ * - gameId が `mock-` で始まる場合のみ、固定 snapshot を配信するモックで動く
+ *   (サーバ無しの開発・デモ用の明示 opt-in 規約)。
+ * - それ以外はエラー (`onError` + `closed`)。設定漏れ (VITE_RSHOGI_API_BASE 未設定
+ *   等) の production ビルドが偽の対局を本物のように表示しないための防御。
  *
  * 戻り値の `disconnect()` で reconnect 経路を含めて完全停止する。`signal` を
  * 渡した場合は abort で同様に停止する。
@@ -565,6 +739,32 @@ export function subscribeRshogiLiveGame(
 ): RshogiLiveSession {
     const setTimeoutImpl = options.setTimeoutImpl ?? setTimeout;
     const clearTimeoutImpl = options.clearTimeoutImpl ?? clearTimeout;
+    if (!options.apiBaseUrl) {
+        // モックは gameId の `mock-` prefix による明示 opt-in のみ。apiBaseUrl の
+        // 設定漏れで実 gameId が来た場合は従来どおりエラーで閉じる (偽対局の防止)。
+        if (gameId.startsWith(MOCK_GAME_ID_PREFIX)) {
+            return startMockLiveGame(gameId, callbacks, {
+                setTimeoutImpl,
+                clearTimeoutImpl,
+                signal: options.signal,
+            });
+        }
+        try {
+            callbacks.onError(
+                new Error(
+                    `subscribeRshogiLiveGame: apiBaseUrl is required for live spectate (mock mode is only for gameId with "${MOCK_GAME_ID_PREFIX}" prefix)`,
+                ),
+            );
+        } catch (handlerErr) {
+            console.error("[rshogi live] onError handler threw", handlerErr);
+        }
+        try {
+            callbacks.onConnectionState("closed");
+        } catch (handlerErr) {
+            console.error("[rshogi live] onConnectionState handler threw", handlerErr);
+        }
+        return { disconnect: () => {} };
+    }
     const wsFactory =
         options.webSocketFactory ??
         ((url: string) => new (globalThis.WebSocket as typeof WebSocket)(url));
@@ -803,21 +1003,14 @@ export function subscribeRshogiLiveGame(
 
     const openSocket = () => {
         if (disposed) return;
-        if (!options.apiBaseUrl) {
-            // モック動作: 接続を張らずに固定 snapshot を擬似配信する。
-            emitError(
-                new Error(
-                    "subscribeRshogiLiveGame: apiBaseUrl is required for live spectate (no mock implementation in MVP)",
-                ),
-            );
-            disposed = true;
-            emitConnectionState("closed");
-            return;
-        }
+        // apiBaseUrl 未指定は関数冒頭でモック経路に分岐済みのため、ここには到達しない。
+        // 型の絞り込み (URL に string を渡す) のための防御ガード。
+        const apiBaseUrl = options.apiBaseUrl;
+        if (!apiBaseUrl) return;
         // `apiBaseUrl` は REST と共用で path (`/api/v1` 等) を含みうるが、観戦 WS は
         // ルート直下 (`/ws/<id>/spectate`) にあるため origin だけ使い path は捨てる。
         // scheme は https/wss→wss、http/ws→ws に揃える。
-        const apiUrl = new URL(options.apiBaseUrl);
+        const apiUrl = new URL(apiBaseUrl);
         const wsScheme =
             apiUrl.protocol === "https:" || apiUrl.protocol === "wss:" ? "wss:" : "ws:";
         const url = `${wsScheme}//${apiUrl.host}/ws/${encodeURIComponent(gameId)}/spectate`;

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -2,11 +2,14 @@ import type { RshogiGameMeta, RshogiLiveMove } from "@shogi/match-client";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
+    appendMoveEval,
     applyMoveComment,
     computeRemaining,
     formatOwnEval,
+    moveDetailsToEvals,
     RshogiLiveMetaPanel,
     RshogiLiveScoreboard,
+    setMoveEvalAtPly,
     summarizeMoveDetails,
 } from "./rshogi-csa-live-viewer";
 
@@ -107,6 +110,98 @@ describe("summarizeMoveDetails", () => {
             latestPv: undefined,
             lastMoveElapsedSec: undefined,
         });
+    });
+});
+
+describe("moveEvals accumulation (initialReview.moveData の材料)", () => {
+    const move = (
+        csaMove: string,
+        elapsedSec: number,
+        comment?: RshogiLiveMove["comment"],
+    ): RshogiLiveMove => ({ csaMove, elapsedSec, comment });
+
+    it("moveDetailsToEvals: snapshot を moves と同順・同長の付随情報に変換する", () => {
+        const details = [
+            // 先手 (奇数 ply): 先手視点 +30
+            move("7g7f", 3, { raw: "* 30 -3334FU", evalCp: 30, pv: ["-3334FU"] }),
+            // 後手 (偶数 ply): 先手視点 -20 (符号そのまま = 反転しない)
+            move("3c3d", 5, { raw: "* -20", evalCp: -20 }),
+            // 消費秒のみ (コメント無し)
+            move("2g2f", 4),
+            // eval も T も無い (旧サーバ) → undefined
+            move("8c8d", 0),
+        ];
+        expect(moveDetailsToEvals(details)).toEqual([
+            { elapsedMs: 3000, evalCp: 30 },
+            { elapsedMs: 5000, evalCp: -20 },
+            { elapsedMs: 4000, evalCp: undefined },
+            undefined,
+        ]);
+    });
+
+    it("moveDetailsToEvals: 詰みセンチネル ±100000 は ±2000 に丸める (evalMate 化しない・グラフ autoscale を潰さない)", () => {
+        // ±100000 を素通しすると EvalGraph の autoscale が引き伸ばされ通常評価値が
+        // 中央線に潰れるため、表示用に ±2000 へ丸める。evalMate は捏造しない。
+        const details = [
+            move("3f3e", 3, { raw: "* 100000", evalCp: 100000 }),
+            move("5a4b", 2, { raw: "* -100000", evalCp: -100000 }),
+        ];
+        expect(moveDetailsToEvals(details)).toEqual([
+            { elapsedMs: 3000, evalCp: 2000 },
+            { elapsedMs: 2000, evalCp: -2000 },
+        ]);
+    });
+
+    it("setMoveEvalAtPly: 後追いコメントの詰みセンチネルも ±2000 に丸める", () => {
+        const prev = [{ elapsedMs: 3000, evalCp: 30 }, { elapsedMs: 6000 }];
+        expect(setMoveEvalAtPly(prev, 2, { evalCp: -100000 })).toEqual([
+            { elapsedMs: 3000, evalCp: 30 },
+            { elapsedMs: 6000, evalCp: -2000 },
+        ]);
+    });
+
+    it("appendMoveEval: broadcast move は消費秒のみで追加し eval は後追い", () => {
+        const prev = [{ elapsedMs: 3000, evalCp: 30 }];
+        // T 付きの新規手 → elapsedMs のみ (eval 未確定)
+        expect(appendMoveEval(prev, 6)).toEqual([
+            { elapsedMs: 3000, evalCp: 30 },
+            { elapsedMs: 6000 },
+        ]);
+        // T 無し (旧サーバ) → undefined を追加
+        expect(appendMoveEval(prev, 0)).toEqual([{ elapsedMs: 3000, evalCp: 30 }, undefined]);
+    });
+
+    it("setMoveEvalAtPly: 該当 ply に eval を後追いし、消費秒は保持する", () => {
+        // onMove で消費秒だけ入った状態に、onMoveComment で ply2 の eval を書き込む
+        const prev = [{ elapsedMs: 3000, evalCp: 30 }, { elapsedMs: 6000 }];
+        const next = setMoveEvalAtPly(prev, 2, { evalCp: -45 });
+        expect(next).toEqual([
+            { elapsedMs: 3000, evalCp: 30 },
+            { elapsedMs: 6000, evalCp: -45 },
+        ]);
+        // 元配列は不変
+        expect(prev[1]).toEqual({ elapsedMs: 6000 });
+    });
+
+    it("setMoveEvalAtPly: eval 無しコメント・範囲外 ply は配列を据え置く", () => {
+        const prev = [{ elapsedMs: 3000, evalCp: 30 }];
+        expect(setMoveEvalAtPly(prev, 1, {})).toBe(prev); // eval 無し
+        expect(setMoveEvalAtPly(prev, 5, { evalCp: 10 })).toBe(prev); // 範囲外
+    });
+
+    it("snapshot → 増分 move → 増分 comment の一連で moves と整合する", () => {
+        // snapshot: 1 手 (eval 付き)
+        let evals = moveDetailsToEvals([move("7g7f", 3, { raw: "* 30", evalCp: 30 })]);
+        expect(evals).toEqual([{ elapsedMs: 3000, evalCp: 30 }]);
+        // broadcast move (ply2): 消費秒のみ
+        evals = appendMoveEval(evals, 5);
+        expect(evals).toEqual([{ elapsedMs: 3000, evalCp: 30 }, { elapsedMs: 5000 }]);
+        // move comment (ply2): 後手視点でも先手視点 -20 のまま
+        evals = setMoveEvalAtPly(evals, 2, { evalCp: -20 });
+        expect(evals).toEqual([
+            { elapsedMs: 3000, evalCp: 30 },
+            { elapsedMs: 5000, evalCp: -20 },
+        ]);
     });
 });
 

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -25,6 +25,7 @@ import {
 } from "@shogi/match-client";
 import { type ReactElement, type ReactNode, useEffect, useRef, useState } from "react";
 import { ShogiMatch } from "./shogi-match";
+import type { ReviewMoveEval } from "./shogi-match/hooks/useKifuImportExport";
 import type { EngineOption } from "./shogi-match/types";
 
 export interface RshogiCsaLiveViewerProps {
@@ -46,6 +47,13 @@ interface LiveState {
     snapshot: RshogiLiveSnapshot | null;
     /** snapshot 後に到着した broadcast move を含む累計 moves。 */
     moves: string[];
+    /**
+     * `moves` と同順・同長の各手付随情報 (先手視点 eval / 消費秒)。
+     * `initialReview.moveData` としてそのまま `<ShogiMatch>` に渡し、棋譜評価値
+     * カラム・評価値グラフを点灯させる。scoreboard 用の latest-only 値 (senteEvalCp
+     * 等) とは独立に、全手分を保持する。
+     */
+    moveEvals: (ReviewMoveEval | undefined)[];
     /** 表示中の対局結果 (終局後)。 */
     result?: RshogiGameResult;
     /**
@@ -77,6 +85,7 @@ interface LiveState {
 const initialLiveState: LiveState = {
     snapshot: null,
     moves: [],
+    moveEvals: [],
     snapshotEpoch: 0,
     clocks: null,
     clockAnchorAtMs: null,
@@ -136,6 +145,73 @@ export function summarizeMoveDetails(moveDetails: RshogiLiveMove[]): LiveEvalSta
     );
     const last = moveDetails[moveDetails.length - 1];
     return { ...evalState, lastMoveElapsedSec: last?.elapsedSec };
+}
+
+/**
+ * 詰みセンチネルを moveData (棋譜評価値カラム / 評価値グラフ) 用に丸める値 (cp)。
+ *
+ * ## 詰みセンチネルの扱い (設計判断)
+ * wire は詰みを `±100000` センチネルで符号化するだけで **詰み手数を持たない**
+ * (rshogi は mate-in-N を潰す)。これを `evalMate=±1` として渡すと `formatEval` /
+ * `getEvalTooltipInfo` が「+詰1」「1手詰み」と **存在しない手数を偽って** 表示して
+ * しまうため、`evalMate` は設定しない (手数を捏造しない)。
+ * かつ `evalCp=±100000` を素通しすると EvalGraph の autoscale が ±100000 級に
+ * 引き伸ばされ、通常の評価値 (数百 cp) が全て中央線に潰れてグラフが死ぬ。
+ * そこでセンチネルは ±2000 (グラフの見やすい決定的優勢域) に丸めて `evalCp` に
+ * 格納する。詰みに近い決定的優勢を、捏造した手数なしに・グラフを潰さずに伝える。
+ */
+const MATE_DISPLAY_EVAL_CP = 2000;
+
+/** wire eval (先手視点) の詰みセンチネル ±100000 を表示用 ±2000 に丸める。 */
+function clampWireEvalForDisplay(evalCp: number | undefined): number | undefined {
+    if (evalCp === undefined) return undefined;
+    if (evalCp >= MATE_EVAL_SENTINEL) return MATE_DISPLAY_EVAL_CP;
+    if (evalCp <= -MATE_EVAL_SENTINEL) return -MATE_DISPLAY_EVAL_CP;
+    return evalCp;
+}
+
+/**
+ * elapsedSec と wire eval (先手視点) から `initialReview.moveData` の 1 手分を作る
+ * (両方無ければ undefined)。moves と同じ index で対応する。
+ * 詰みセンチネルの丸めは {@link MATE_DISPLAY_EVAL_CP} を参照。
+ */
+function toMoveEval(elapsedSec: number, evalCp: number | undefined): ReviewMoveEval | undefined {
+    const elapsedMs = elapsedSec > 0 ? elapsedSec * 1000 : undefined;
+    if (elapsedMs === undefined && evalCp === undefined) return undefined;
+    return { elapsedMs, evalCp: clampWireEvalForDisplay(evalCp) };
+}
+
+/** snapshot の moveDetails を moves と同順・同長の付随情報配列 (moveData) に変換する。 */
+export function moveDetailsToEvals(details: RshogiLiveMove[]): (ReviewMoveEval | undefined)[] {
+    return details.map((d) => toMoveEval(d.elapsedSec, d.comment?.evalCp));
+}
+
+/**
+ * broadcast move 到着時に付随情報配列へ 1 手を追加する。
+ * この時点では消費秒のみ確定し、eval は直後の onMoveComment で後追いで書き込む。
+ */
+export function appendMoveEval(
+    prev: (ReviewMoveEval | undefined)[],
+    elapsedSec: number,
+): (ReviewMoveEval | undefined)[] {
+    return [...prev, toMoveEval(elapsedSec, undefined)];
+}
+
+/**
+ * onMoveComment 到着時に該当 ply の付随情報へ eval (先手視点) を後追いで書き込む。
+ * ply は 1 始まり。範囲外・eval 無しコメントは配列を据え置く (消費秒は保持)。
+ * 詰みセンチネルは snapshot 経路と同じく ±{@link MATE_DISPLAY_EVAL_CP} に丸める。
+ */
+export function setMoveEvalAtPly(
+    prev: (ReviewMoveEval | undefined)[],
+    ply: number,
+    comment: { evalCp?: number },
+): (ReviewMoveEval | undefined)[] {
+    const idx = ply - 1;
+    if (comment.evalCp === undefined || idx < 0 || idx >= prev.length) return prev;
+    const next = prev.slice();
+    next[idx] = { ...next[idx], evalCp: clampWireEvalForDisplay(comment.evalCp) };
+    return next;
 }
 
 const formatMs = (ms: number): string => {
@@ -435,6 +511,8 @@ export function RshogiCsaLiveViewer({
                     ...prev,
                     snapshot,
                     moves: snapshot.moves,
+                    // snapshot は全置換。全手分の付随情報 (moveData) も moveDetails から再導出。
+                    moveEvals: moveDetailsToEvals(snapshot.moveDetails),
                     result: snapshot.finalResult ?? prev.result,
                     snapshotEpoch: prev.snapshotEpoch + 1,
                     clocks: snapshot.clocks,
@@ -451,6 +529,8 @@ export function RshogiCsaLiveViewer({
                 setState((prev) => ({
                     ...prev,
                     moves: [...prev.moves, csaMove],
+                    // 新規手を付随情報配列にも追加 (この時点では消費秒のみ、eval は後追い)。
+                    moveEvals: appendMoveEval(prev.moveEvals, elapsedSec),
                     // broadcast move 到着時に手番側を切り替える (= clock の anchor も
                     // 更新してロジックを単純化する。サーバから次 snapshot が来たら
                     // 上書きされる)。
@@ -480,7 +560,12 @@ export function RshogiCsaLiveViewer({
                 }));
             },
             onMoveComment({ ply, comment }) {
-                setState((prev) => ({ ...prev, ...applyMoveComment(prev, ply, comment) }));
+                setState((prev) => ({
+                    ...prev,
+                    ...applyMoveComment(prev, ply, comment),
+                    // 該当 ply の付随情報へ eval を後追いで書き込む (scoreboard とは独立)。
+                    moveEvals: setMoveEvalAtPly(prev.moveEvals, ply, comment),
+                }));
             },
             onClock({ remainingMs, sideToMove }) {
                 setState((prev) => ({
@@ -584,8 +669,15 @@ export function RshogiCsaLiveViewer({
                     sente: { role: "human" },
                     gote: { role: "human" },
                 }}
-                initialReview={{ sfen: "startpos", moves: state.moves }}
+                initialReview={{
+                    sfen: "startpos",
+                    moves: state.moves,
+                    // 各手の評価値・消費秒。棋譜評価値カラム・評価値グラフを点灯させる。
+                    moveData: state.moveEvals,
+                }}
                 reviewMode={true}
+                // 観戦は表示設定を別名前空間で扱い、棋譜評価値カラムを既定 ON にする。
+                spectateMode={true}
                 reviewTopContent={
                     <RshogiLiveScoreboard
                         meta={meta}

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -38,7 +38,7 @@ import { useEditModeActions } from "./shogi-match/hooks/useEditModeActions";
 import { useEngineManager } from "./shogi-match/hooks/useEngineManager";
 import { useEnginePool } from "./shogi-match/hooks/useEnginePool";
 import { useGameControls } from "./shogi-match/hooks/useGameControls";
-import { useKifuImportExport } from "./shogi-match/hooks/useKifuImportExport";
+import { type ReviewMoveEval, useKifuImportExport } from "./shogi-match/hooks/useKifuImportExport";
 import { useKifuKeyboardNavigation } from "./shogi-match/hooks/useKifuKeyboardNavigation";
 import { useKifuNavigation } from "./shogi-match/hooks/useKifuNavigation";
 import { useLegalMovePrefetch } from "./shogi-match/hooks/useLegalMovePrefetch";
@@ -89,6 +89,16 @@ import { TooltipProvider } from "./tooltip";
 
 const EMPTY_ANALYSIS_MARKERS: Array<{ seat: "b" | "w"; ply: number }> = [];
 
+/** 対局用の表示設定 localStorage キー。 */
+const DISPLAY_SETTINGS_KEY = "shogi-display-settings";
+/** ライブ観戦用の表示設定 localStorage キー (対局用と分離してチート防止既定を汚さない)。 */
+const SPECTATE_DISPLAY_SETTINGS_KEY = "rshogi-live-display-settings";
+/** ライブ観戦の既定表示設定。棋譜評価値カラムを既定 ON にする。 */
+const SPECTATE_DISPLAY_SETTINGS: DisplaySettings = {
+    ...DEFAULT_DISPLAY_SETTINGS,
+    showKifuEval: true,
+};
+
 interface ShogiMatchProps {
     engineOptions: EngineOption[];
     defaultSides?: { sente: SideSetting; gote: SideSetting };
@@ -116,8 +126,16 @@ interface ShogiMatchProps {
     allowAnalysisDuringMatch?: boolean;
     /** 棋譜パネルに表示する AI 解析使用マーカー */
     analysisMarkers?: Array<{ seat: "b" | "w"; ply: number }>;
-    /** マウント時に読み込む棋譜（指定時は検討室モードで開始） */
-    initialReview?: { sfen: string; moves: string[] };
+    /**
+     * マウント時に読み込む棋譜（指定時は検討室モードで開始）。
+     * `moveData` は `moves` と同じ index で対応する各手の評価値・消費時間
+     * (先手視点)。ライブ観戦の評価値グラフ / 棋譜評価値カラム用。省略可 (後方互換)。
+     */
+    initialReview?: {
+        sfen: string;
+        moves: string[];
+        moveData?: (ReviewMoveEval | undefined)[];
+    };
     /** 現在局面のスナップショットを通知 */
     onPositionSnapshot?: (snapshot: { sfen: string; moves: string[]; label?: string }) => void;
     /** 現在の解析結果スナップショットを通知 */
@@ -126,6 +144,13 @@ interface ShogiMatchProps {
     initialAnalysisEntries?: AnalysisSnapshotEntryDraft[] | null;
     /** 棋譜検討モード: 対局設定サイドバーを非表示にする */
     reviewMode?: boolean;
+    /**
+     * ライブ観戦モード。表示設定を対局用とは別 localStorage 名前空間で扱い、
+     * 棋譜評価値カラム (`showKifuEval`) を既定 ON にする。対局モードのチート防止
+     * 既定 (OFF) や、ユーザーが対局用に設定した表示設定を汚さない。観戦側で
+     * 明示的にトグルした値は観戦用名前空間に永続化され尊重される。
+     */
+    spectateMode?: boolean;
     /** 棋譜検討モード時に左サイドバー位置に表示するコンテンツ */
     reviewLeftContent?: React.ReactNode;
     /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
@@ -163,6 +188,7 @@ export function ShogiMatch({
     onAnalysisSnapshotChange,
     initialAnalysisEntries = null,
     reviewMode,
+    spectateMode,
     reviewLeftContent,
     reviewTopContent,
     onOpenEngineManager,
@@ -248,12 +274,19 @@ export function ShogiMatch({
     // 検討モード: 編集モードでも対局中でも一時停止中でもない状態
     // 自由に棋譜を閲覧し、分岐を作成できる
     const isReviewMode = !isEditMode && !isMatchRunning && !isPaused;
+    // ライブ観戦は表示設定を別名前空間で扱い、棋譜評価値カラムを既定 ON にする。
+    // 対局用の設定 (チート防止で showKifuEval=OFF 既定) を汚さず、観戦側で明示
+    // トグルした値は観戦用キーに永続化されて尊重される。
+    const displaySettingsKey = spectateMode ? SPECTATE_DISPLAY_SETTINGS_KEY : DISPLAY_SETTINGS_KEY;
+    const displaySettingsDefaults = spectateMode
+        ? SPECTATE_DISPLAY_SETTINGS
+        : DEFAULT_DISPLAY_SETTINGS;
     const [storedDisplaySettings, setDisplaySettings] = useLocalStorage<DisplaySettings>(
-        "shogi-display-settings",
-        DEFAULT_DISPLAY_SETTINGS,
+        displaySettingsKey,
+        displaySettingsDefaults,
     );
     // 既存の localStorage データに新フィールド（enableSound 等）がない場合のマージ
-    const displaySettings = { ...DEFAULT_DISPLAY_SETTINGS, ...storedDisplaySettings };
+    const displaySettings = { ...displaySettingsDefaults, ...storedDisplaySettings };
     const { playSound } = useShogiSound();
     // 解析設定（古いlocalStorageデータとの互換性のためデフォルト値とマージ）
     const [storedAnalysisSettings, setAnalysisSettings] = useLocalStorage<AnalysisSettings>(
@@ -1292,7 +1325,11 @@ export function ShogiMatch({
     // や moves 配列は呼び出し側で毎レンダー再生成され得るが、内容が同じなら再 import
     // しない (clock tick 等の無関係な再 render や、同内容を再生成する親に強い)。
     // importSfen / navigation は毎レンダー再生成されるため ref 経由で参照する。
-    const loadedReviewRef = useRef<{ sfen: string; movesKey: string } | null>(null);
+    const loadedReviewRef = useRef<{
+        sfen: string;
+        movesKey: string;
+        moveDataKey: string;
+    } | null>(null);
     const importSfenRef = useRef(importSfen);
     importSfenRef.current = importSfen;
     const navigationRef = useRef(navigation);
@@ -1300,7 +1337,13 @@ export function ShogiMatch({
     const initialAnalysisAppliedRef = useRef<string | null>(null);
     const reviewSfen = initialReview?.sfen;
     const reviewMoves = initialReview?.moves;
+    const reviewMoveData = initialReview?.moveData;
     const reviewMovesKey = reviewMoves?.join(" ");
+    // moveData (評価値・消費時間) だけが変わった場合 (= 指し手の後にコメントが遅れて
+    // 届くライブ観戦) も再取込を発火させるため、内容シグネチャを取込判定に含める。
+    // コメント到着で 1 回だけ安価な再取込が走るが、下の restorePly 復元でカーソルは
+    // 維持され、盤・棋譜も据え置き再構築なのでちらつかない。
+    const reviewMoveDataKey = reviewMoveData ? JSON.stringify(reviewMoveData) : "";
     useEffect(() => {
         if (
             !positionReady ||
@@ -1311,7 +1354,12 @@ export function ShogiMatch({
             return;
         }
         const loaded = loadedReviewRef.current;
-        if (loaded && loaded.sfen === reviewSfen && loaded.movesKey === reviewMovesKey) {
+        if (
+            loaded &&
+            loaded.sfen === reviewSfen &&
+            loaded.movesKey === reviewMovesKey &&
+            loaded.moveDataKey === reviewMoveDataKey
+        ) {
             return;
         }
 
@@ -1323,13 +1371,19 @@ export function ShogiMatch({
 
         // await 前に確定して StrictMode の二重実行を冪等化する。連続着手で先行 import が
         // 後着 import に追い越されたら、isStale で古い import の state 適用を中止する。
-        loadedReviewRef.current = { sfen: reviewSfen, movesKey: reviewMovesKey };
+        loadedReviewRef.current = {
+            sfen: reviewSfen,
+            movesKey: reviewMovesKey,
+            moveDataKey: reviewMoveDataKey,
+        };
         void importSfenRef
             .current(reviewSfen, reviewMoves, {
                 gotoPly: wasFollowingTip ? undefined : restorePly,
+                moveData: reviewMoveData,
                 isStale: () =>
                     loadedReviewRef.current?.sfen !== reviewSfen ||
-                    loadedReviewRef.current?.movesKey !== reviewMovesKey,
+                    loadedReviewRef.current?.movesKey !== reviewMovesKey ||
+                    loadedReviewRef.current?.moveDataKey !== reviewMoveDataKey,
             })
             .catch((err) => {
                 // SFEN 解析失敗などで取り込みが reject したら loaded マークを巻き戻し、
@@ -1337,13 +1391,14 @@ export function ShogiMatch({
                 // 先行していれば (参照不一致) リセットしない。
                 if (
                     loadedReviewRef.current?.sfen === reviewSfen &&
-                    loadedReviewRef.current?.movesKey === reviewMovesKey
+                    loadedReviewRef.current?.movesKey === reviewMovesKey &&
+                    loadedReviewRef.current?.moveDataKey === reviewMoveDataKey
                 ) {
                     loadedReviewRef.current = null;
                 }
                 console.error("[rshogi] initialReview の取り込みに失敗しました", err);
             });
-    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey]);
+    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey, reviewMoveData, reviewMoveDataKey]);
 
     useEffect(() => {
         if (!positionReady || !initialAnalysisEntries || initialAnalysisEntries.length === 0) {
@@ -1624,6 +1679,8 @@ export function ShogiMatch({
         reviewMode,
         reviewLeftContent,
         reviewTopContent,
+        // 評価値グラフの初期展開はライブ観戦のみ。検討/静的 viewer/対局は既定閉のまま。
+        evalPanelInitialOpen: spectateMode === true,
     };
 
     // Props グループ化: Mobile専用

--- a/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
@@ -24,9 +24,17 @@ interface PCKifuSectionProps {
     /** 観戦/検討モード。対局モードは盤上に時計があり pt-16 でその分を空けて
      *  棋譜パネルの頭を盤面と揃えるが、検討モードは時計が無いので頭詰めにする。 */
     reviewMode?: boolean;
+    /**
+     * 評価値グラフパネルを初期展開するか (ライブ観戦専用、ShogiMatch の
+     * spectateMode 由来)。検討/静的 viewer/対局は未指定 (= 既定閉) のまま。
+     */
+    evalPanelInitialOpen?: boolean;
 }
 
-export function PCKifuSection({ reviewMode }: PCKifuSectionProps): ReactElement {
+export function PCKifuSection({
+    reviewMode,
+    evalPanelInitialOpen,
+}: PCKifuSectionProps): ReactElement {
     const [activeTab, setActiveTab] = useState<"kifu" | "ai">("kifu");
 
     // 分析関連は Context から取得
@@ -90,12 +98,16 @@ export function PCKifuSection({ reviewMode }: PCKifuSectionProps): ReactElement 
 
             {/* 棋譜タブ */}
             <div className={`flex flex-col gap-2 ${activeTab !== "kifu" ? "hidden" : ""}`}>
-                {/* 評価値グラフパネル（折りたたみ） */}
+                {/* 評価値グラフパネル（折りたたみ）。
+                    既定は閉 (対局はチート防止、検討/静的 viewer は従来挙動維持)。
+                    ライブ観戦のみ evalPanelInitialOpen=true で初期展開し、評価値
+                    グラフを一目で見せる。展開状態はユーザーが自由に切り替えられる
+                    (EvalPanel 内 state)。 */}
                 <EvalPanel
                     evalHistory={displayEvalHistory}
                     currentPly={navigationState.currentPly}
                     onPlySelect={handlePlySelect}
-                    initialOpen={false}
+                    initialOpen={evalPanelInitialOpen ?? false}
                 />
 
                 {/* 棋譜パネル + ドロワー（横並び） */}

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.test.ts
@@ -1,0 +1,150 @@
+import type { KifuEval, PositionService } from "@shogi/app-core";
+import { createInitialPositionState, setPositionServiceFactory } from "@shogi/app-core";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DEFAULT_PASS_RIGHTS_SETTINGS } from "../types";
+import { normalizeEvalToSentePerspective } from "../utils/branchTreeUtils";
+import { useKifuImportExport } from "./useKifuImportExport";
+import type { UseKifuNavigationResult } from "./useKifuNavigation";
+
+/**
+ * `useKifuImportExport` は React フックを内部で使わない factory なので、テストから
+ * 直接呼び出して `importSfen` の `initialReview.moveData` スレッディングを検証する。
+ *
+ * ここで固定したいのは「wire (先手視点) の評価値が符号そのままで `normalized: true`
+ * として addMove に渡り、奇数 ply でも偶数 ply でも符号反転しない」ことと、
+ * 「詰みセンチネル ±100000 が evalCp のまま流れる」「elapsedMs が保持される」こと。
+ */
+
+// startpos を返すだけの最小 PositionService。importSfen は parseSfen のみ使う。
+const setupMockPositionService = () => {
+    setPositionServiceFactory(
+        () =>
+            ({
+                getInitialBoard: async () => createInitialPositionState(),
+                parseSfen: async () => createInitialPositionState(),
+                boardToSfen: async () => "startpos",
+                getLegalMoves: async () => [],
+                replayMovesStrict: async () => ({ applied: [], error: undefined }),
+            }) as unknown as PositionService,
+    );
+};
+
+interface AddMoveCall {
+    move: string;
+    options?: { elapsedMs?: number; eval?: KifuEval };
+}
+
+const makeHarness = () => {
+    const addMoveCalls: AddMoveCall[] = [];
+    const noop = () => {};
+    const navigation = {
+        reset: noop,
+        addMove: (move: string, _next: unknown, options?: AddMoveCall["options"]) => {
+            addMoveCalls.push({ move, options });
+        },
+        goToPly: noop,
+        state: { currentPly: 0, totalPly: 0 },
+    } as unknown as UseKifuNavigationResult;
+
+    const { importSfen } = useKifuImportExport({
+        navigation,
+        passRightsSettings: DEFAULT_PASS_RIGHTS_SETTINGS,
+        clearLegalCache: noop,
+        resetClocks: noop,
+        kifMoves: [],
+        boardHistory: [],
+        sides: { sente: { role: "human" }, gote: { role: "human" } },
+        startSfen: "startpos",
+        setLastMove: noop,
+        setSelection: noop,
+        setMessage: noop,
+        setPositionReady: noop,
+        setBasePosition: noop,
+        setStartSfen: noop,
+        setInitialBoard: noop,
+        setLastAddedBranchInfo: noop,
+        setIsEditMode: noop,
+        setIsMatchRunning: noop,
+    });
+
+    return { importSfen, addMoveCalls };
+};
+
+describe("importSfen: initialReview.moveData スレッディング", () => {
+    beforeEach(() => {
+        setupMockPositionService();
+    });
+
+    it("先手視点 eval を normalized:true で addMove に渡す (奇数/偶数 ply とも符号反転しない)", async () => {
+        const { importSfen, addMoveCalls } = makeHarness();
+        await importSfen("startpos", ["7g7f", "3c3d"], {
+            moveData: [
+                { evalCp: 120, elapsedMs: 3000 }, // ply1 (奇数=先手)
+                { evalCp: -80, elapsedMs: 7000 }, // ply2 (偶数=後手)
+            ],
+        });
+
+        expect(addMoveCalls).toHaveLength(2);
+        // 符号そのまま + normalized:true (KIF インポートと同じ扱い)
+        expect(addMoveCalls[0].options).toEqual({
+            elapsedMs: 3000,
+            eval: { scoreCp: 120, scoreMate: undefined, normalized: true },
+        });
+        expect(addMoveCalls[1].options).toEqual({
+            elapsedMs: 7000,
+            eval: { scoreCp: -80, scoreMate: undefined, normalized: true },
+        });
+
+        // end-to-end: navigation が normalized:true をそのまま先手視点表示に流す
+        // (奇数 ply でも偶数 ply でも符号が変わらないのが回帰ポイント)
+        expect(normalizeEvalToSentePerspective(addMoveCalls[0].options?.eval, 1)).toEqual({
+            evalCp: 120,
+            evalMate: undefined,
+        });
+        expect(normalizeEvalToSentePerspective(addMoveCalls[1].options?.eval, 2)).toEqual({
+            evalCp: -80,
+            evalMate: undefined,
+        });
+    });
+
+    it("詰みセンチネル (viewer 側で ±2000 に丸め済み) は evalCp のまま流し、詰み手数 (scoreMate) を捏造しない", async () => {
+        // live viewer は wire の ±100000 センチネルを moveData 生成時に ±2000 へ丸める
+        // (rshogi-csa-live-viewer.tsx の MATE_DISPLAY_EVAL_CP。EvalGraph の autoscale を
+        // 潰さないため)。importSfen は受け取った値を符号・大きさとも変えずに素通しする。
+        const { importSfen, addMoveCalls } = makeHarness();
+        await importSfen("startpos", ["7g7f", "3c3d"], {
+            moveData: [{ evalCp: 2000 }, { evalCp: -2000 }],
+        });
+        expect(addMoveCalls[0].options?.eval).toEqual({
+            scoreCp: 2000,
+            scoreMate: undefined,
+            normalized: true,
+        });
+        expect(addMoveCalls[1].options?.eval).toEqual({
+            scoreCp: -2000,
+            scoreMate: undefined,
+            normalized: true,
+        });
+    });
+
+    it("moveData が undefined の手は eval なしで addMove する (後方互換)", async () => {
+        const { importSfen, addMoveCalls } = makeHarness();
+        await importSfen("startpos", ["7g7f", "3c3d"], {
+            moveData: [undefined, { evalCp: 50 }],
+        });
+        // 1 手目: moveData 無し → eval/elapsedMs とも undefined
+        expect(addMoveCalls[0].options).toEqual({ elapsedMs: undefined, eval: undefined });
+        // 2 手目: index 対応が保たれ eval が付く
+        expect(addMoveCalls[1].options?.eval).toEqual({
+            scoreCp: 50,
+            scoreMate: undefined,
+            normalized: true,
+        });
+    });
+
+    it("moveData 省略時も従来どおり eval なしで取り込む", async () => {
+        const { importSfen, addMoveCalls } = makeHarness();
+        await importSfen("startpos", ["7g7f"]);
+        expect(addMoveCalls[0].options).toEqual({ elapsedMs: undefined, eval: undefined });
+    });
+});

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
@@ -14,6 +14,27 @@ import { buildPassRightsOptionForLegalMoves } from "../utils/passRightsSettings"
 import type { UseKifuNavigationResult } from "./useKifuNavigation";
 
 /**
+ * `initialReview.moveData` の 1 手分の評価値・消費時間。
+ *
+ * `initialReview.moves` と同じ index で対応する (undefined = その手の付随情報なし)。
+ * 評価値は **先手視点** (`+` = 先手有利) 前提で、`importSfen` 内で
+ * `navigation.addMove(..., { eval: { normalized: true } })` としてそのまま格納する
+ * (KIF インポート経路と同じ扱い。符号反転しない)。
+ */
+export interface ReviewMoveEval {
+    /** 消費時間 (ミリ秒)。 */
+    elapsedMs?: number;
+    /** 評価値 (センチポーン、先手視点。`+` = 先手有利)。 */
+    evalCp?: number;
+    /**
+     * 詰み手数 (先手視点、`+` = 先手勝ち)。
+     * ライブ観戦の wire は詰み手数を持たない (詰みは大きな evalCp センチネルで表現)
+     * ため通常は未設定。KIF インポート等の経路で詰み手数が判る場合のみ使う。
+     */
+    evalMate?: number;
+}
+
+/**
  * useKifuImportExport の props
  */
 interface UseKifuImportExportProps {
@@ -72,7 +93,12 @@ interface UseKifuImportExportReturn {
     importSfen: (
         sfen: string,
         movesToLoad: string[],
-        options?: { gotoPly?: number; isStale?: () => boolean },
+        options?: {
+            gotoPly?: number;
+            isStale?: () => boolean;
+            /** `movesToLoad` と同じ index で対応する評価値・消費時間 (先手視点)。 */
+            moveData?: (ReviewMoveEval | undefined)[];
+        },
     ) => Promise<void>;
     /** KIF形式をインポート */
     importKif: (
@@ -188,7 +214,11 @@ export function useKifuImportExport({
     const importSfen = async (
         sfen: string,
         movesToLoad: string[],
-        options?: { gotoPly?: number; isStale?: () => boolean },
+        options?: {
+            gotoPly?: number;
+            isStale?: () => boolean;
+            moveData?: (ReviewMoveEval | undefined)[];
+        },
     ) => {
         const service = getPositionService();
         try {
@@ -211,12 +241,25 @@ export function useKifuImportExport({
             if (movesToLoad.length > 0) {
                 let currentPos = newPosition;
                 const appliedMoves: string[] = [];
-                for (const move of movesToLoad) {
+                for (let i = 0; i < movesToLoad.length; i++) {
+                    const move = movesToLoad[i];
                     const applyResult = applyMoveWithState(currentPos, move, {
                         validateTurn: false,
                     });
                     if (applyResult.ok) {
-                        navigation.addMove(move, applyResult.next);
+                        // moveData は先手視点なので loadMoves (KIF) と同じく normalized: true。
+                        const data = options?.moveData?.[i];
+                        navigation.addMove(move, applyResult.next, {
+                            elapsedMs: data?.elapsedMs,
+                            eval:
+                                data?.evalCp !== undefined || data?.evalMate !== undefined
+                                    ? {
+                                          scoreCp: data.evalCp,
+                                          scoreMate: data.evalMate,
+                                          normalized: true,
+                                      }
+                                    : undefined,
+                        });
                         currentPos = applyResult.next;
                         appliedMoves.push(move);
                     } else {

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -81,6 +81,8 @@ interface PCLayoutProps {
     reviewLeftContent?: ReactNode;
     /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
     reviewTopContent?: ReactNode;
+    /** 評価値グラフパネルを初期展開するか (ライブ観戦専用)。未指定は既定閉。 */
+    evalPanelInitialOpen?: boolean;
 }
 
 /**
@@ -109,6 +111,7 @@ export function PCLayout({
     reviewMode,
     reviewLeftContent,
     reviewTopContent,
+    evalPanelInitialOpen,
 }: PCLayoutProps): ReactElement {
     // Context から状態を取得
     const matchSettings = useMatchSettings();
@@ -157,7 +160,7 @@ export function PCLayout({
                         {/* 縦積み時は固定幅の棋譜パネルを中央へ。横並び時は列幅に一致する
                             ので justify-self は既定へ戻す。 */}
                         <div className="order-2 min-w-0 justify-self-center min-[1280px]:order-none min-[1280px]:justify-self-auto">
-                            <PCKifuSection reviewMode />
+                            <PCKifuSection reviewMode evalPanelInitialOpen={evalPanelInitialOpen} />
                         </div>
                     </div>
                 </div>

--- a/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
@@ -240,6 +240,7 @@ export function ShogiMatchLayout({
         reviewMode,
         reviewLeftContent,
         reviewTopContent,
+        evalPanelInitialOpen,
     } = pcSpecificProps;
 
     // グループ化されたpropsを展開: Mobile専用
@@ -604,6 +605,7 @@ export function ShogiMatchLayout({
                                     reviewMode={reviewMode}
                                     reviewLeftContent={reviewLeftContent}
                                     reviewTopContent={reviewTopContent}
+                                    evalPanelInitialOpen={evalPanelInitialOpen}
                                 />
                             </NavigationProvider>
                         </MatchStateProvider>

--- a/packages/ui/src/components/shogi-match/types/layoutProps.ts
+++ b/packages/ui/src/components/shogi-match/types/layoutProps.ts
@@ -284,6 +284,11 @@ export interface PCSpecificProps {
     reviewLeftContent?: import("react").ReactNode;
     /** 棋譜検討モード時に 3 カラムの上部へ全幅で表示するコンテンツ（観戦スコアボード等） */
     reviewTopContent?: import("react").ReactNode;
+    /**
+     * 評価値グラフパネルを初期展開するか (ライブ観戦専用、spectateMode 由来)。
+     * 検討/静的 viewer/対局は従来どおり既定で折りたたむ (undefined = false)。
+     */
+    evalPanelInitialOpen?: boolean;
 }
 
 /**


### PR DESCRIPTION
## 概要

live 観戦 viewer で、**棋譜パネルの各手に評価値を表示し、その直上に評価値グラフを描画**します（要件位置）。既存の `EvalPanel`/`EvalGraph`（もともと棋譜パネル直上に配置済み）と `KifuPanel` の評価値カラムへ、観戦 wire の per-ply 評価値を配線するデータ経路の新設のみで実現し、新規 UI コンポーネントはありません。スコアボード評価値・読み筋メタパネルは据え置き。

## 実装ポイント

- **符号契約**: wire の evalCp は常に先手視点（rshogi `build_floodgate_comment` が正規化）。KIF インポートと同じ `addMove` オプション経路で `normalized: true` を立てて取り込み、`normalizeEvalToSentePerspective` の手番側視点前提の符号反転を抑止（奇数/偶数 ply とも符号不変をテストで固定）。既知の符号往復バグがある `recordEvalByPly`/`initialAnalysisEntries` 経路は不使用
- **`initialReview.moveData`**: `ShogiMatch` の取込 prop を拡張（省略可・後方互換。静的 viewer 等は無影響）
- **詰みセンチネル ±100000**: viewer 側で ±2000 に丸め（素通しすると EvalGraph の autoscale が支配され通常評価値が中央線に潰れる — クリーンレビューで数値検証済み）。詰み手数は wire に無いため捏造しない
- **spectateMode**: 観戦専用の表示設定名前空間（`showKifuEval` 既定 ON）+ 観戦のみ評価値グラフ初期展開。対局/検討/静的 viewer のチート防止既定や永続設定は不変
- **開発用モック**: `gameId` が `mock-` プレフィックスのときのみ評価値コメント付き固定 snapshot を配信（本番で env 欠落時に偽対局を出さないよう opt-in 限定）。`window.setTimeout` の this 束縛による Illegal invocation を回避（実ブラウザで発見・回帰 pin テスト付き）

## 検証

- クリーンコンテキストレビュー（Opus・要件突き合わせ + 8次元）→ MUST-FIX 4件を修正済み
- **実ブラウザ（headless Chromium）スクリーンショット検証**: グラフが棋譜パネル直上に既定展開・各手評価値表示・詰みでグラフが潰れないことを画像で確認
- gates: match-client 77 / ui 314 / desktop 7 全 pass、knip clean（web の RoomPage テスト失敗は既知の env/wasm ローカル未整備由来で本変更と無関係）

## Follow-up（別対応・スコープ外）

- コメント到着ごとの full 再取込頻度（O(n) per event）の間引き
- 既存バグ: `initialAnalysisEntries` 保存→再読込の符号往復反転（`shogi-match.tsx:1360-1367`）
- 棋譜カラムの詰み表記文言（現状 +20.0 表示）
- live viewer の時計 increment/秒読み未適用バグは次 PR で対応予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL