### PR TITLE
fix: live viewer の時計に時間制御ルール (fischer increment / 秒読み) を適用

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -783,4 +783,102 @@ describe("__test_internals", () => {
             toMove: "sente",
         });
     });
+    it("parseGameSummaryLines: Time_Unit:1min (StopWatch) を分単位のまま受理する", () => {
+        const r = __test_internals.parseGameSummaryLines([
+            "Time_Unit:1min",
+            "Total_Time:15",
+            "Byoyomi:1",
+        ]);
+        expect(r.timeUnit).toBe("1min");
+        expect(r.totalTime).toBe(15);
+        expect(r.byoyomi).toBe(1);
+    });
+});
+
+describe("deriveTimeControl: kind 判定と単位換算 (REST decodeClock 語彙に合わせる)", () => {
+    it("Increment 行あり → fischer (Time_Unit:1sec、増分は秒)", () => {
+        expect(
+            __test_internals.deriveTimeControl({
+                timeUnit: "1sec",
+                totalTime: 600,
+                increment: 10,
+            }),
+        ).toEqual({
+            kind: "fischer",
+            mainSeconds: 600,
+            byoyomiSeconds: 0,
+            byoyomiMilliseconds: undefined,
+            incrementSeconds: 10,
+        });
+    });
+    it("Byoyomi 行あり Time_Unit:1sec → countdown", () => {
+        const tc = __test_internals.deriveTimeControl({
+            timeUnit: "1sec",
+            totalTime: 600,
+            byoyomi: 10,
+        });
+        expect(tc?.kind).toBe("countdown");
+        expect(tc?.mainSeconds).toBe(600);
+        expect(tc?.byoyomiSeconds).toBe(10);
+        expect(tc?.byoyomiMilliseconds).toBeUndefined();
+        expect(tc?.incrementSeconds).toBeUndefined();
+    });
+    it("Time_Unit:1msec → countdown_msec (ms→秒換算 + byoyomiMilliseconds 保持)", () => {
+        const tc = __test_internals.deriveTimeControl({
+            timeUnit: "1msec",
+            totalTime: 10_000,
+            byoyomi: 100,
+        });
+        expect(tc?.kind).toBe("countdown_msec");
+        expect(tc?.mainSeconds).toBe(10);
+        // round(100 / 1000) = 0 秒だが、生 ms は byoyomiMilliseconds に残す
+        expect(tc?.byoyomiSeconds).toBe(0);
+        expect(tc?.byoyomiMilliseconds).toBe(100);
+    });
+    it("Time_Unit:1min → stopwatch (分→秒換算)", () => {
+        const tc = __test_internals.deriveTimeControl({
+            timeUnit: "1min",
+            totalTime: 15,
+            byoyomi: 1,
+        });
+        expect(tc?.kind).toBe("stopwatch");
+        expect(tc?.mainSeconds).toBe(900);
+        expect(tc?.byoyomiSeconds).toBe(60);
+        expect(tc?.byoyomiMilliseconds).toBeUndefined();
+    });
+    it("Byoyomi も Increment も無い → sudden-death countdown (byoyomiSeconds 0)", () => {
+        const tc = __test_internals.deriveTimeControl({ timeUnit: "1sec", totalTime: 300 });
+        expect(tc?.kind).toBe("countdown");
+        expect(tc?.mainSeconds).toBe(300);
+        expect(tc?.byoyomiSeconds).toBe(0);
+    });
+    it("時間フィールドが皆無なら timeControl ごと undefined", () => {
+        expect(__test_internals.deriveTimeControl({})).toBeUndefined();
+        expect(__test_internals.deriveTimeControl({ timeUnit: "1sec" })).toBeUndefined();
+    });
+    it("snapshot 経由でも meta.timeControl.kind が付く (fischer / countdown)", () => {
+        const fischer = __test_internals.decodeSnapshotBlock("g", [
+            "BEGIN Game_Summary",
+            "BEGIN Time",
+            "Time_Unit:1sec",
+            "Total_Time:600",
+            "Increment:10",
+            "END Time",
+            "END Game_Summary",
+        ]);
+        expect(fischer.snapshot.meta.timeControl?.kind).toBe("fischer");
+        expect(fischer.snapshot.meta.timeControl?.incrementSeconds).toBe(10);
+
+        const countdown = __test_internals.decodeSnapshotBlock("g", [
+            "BEGIN Game_Summary",
+            "BEGIN Time",
+            "Time_Unit:1sec",
+            "Total_Time:600",
+            "Byoyomi:10",
+            "END Time",
+            "END Game_Summary",
+        ]);
+        expect(countdown.snapshot.meta.timeControl?.kind).toBe("countdown");
+        expect(countdown.snapshot.meta.timeControl?.byoyomiSeconds).toBe(10);
+    });
 });

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -40,7 +40,13 @@ import {
     type PositionState,
     parseSingleCsaMove,
 } from "@shogi/app-core";
-import type { RshogiGameMeta, RshogiGameResult, RshogiGameResultKind } from "./client";
+import type {
+    RshogiClockKind,
+    RshogiGameMeta,
+    RshogiGameResult,
+    RshogiGameResultKind,
+    RshogiTimeControl,
+} from "./client";
 
 /**
  * Floodgate コメント (`'* <eval> <pv...>`) を解析した結果。
@@ -217,7 +223,13 @@ interface ParsedSummary {
     gameId?: string;
     senteName?: string;
     goteName?: string;
-    timeUnit?: "1sec" | "1msec";
+    /**
+     * 持ち時間の単位。`Total_Time` / `Byoyomi` の解釈が単位ごとに変わる:
+     * - `1sec`:  秒 (Countdown / Fischer)
+     * - `1msec`: ミリ秒 (CountdownMsec)
+     * - `1min`:  分 (StopWatch)
+     */
+    timeUnit?: "1sec" | "1msec" | "1min";
     totalTime?: number;
     byoyomi?: number;
     increment?: number;
@@ -245,7 +257,7 @@ const parseGameSummaryLines = (summaryLines: string[]): ParsedSummary => {
                 out.goteName = value;
                 break;
             case "Time_Unit":
-                if (value === "1sec" || value === "1msec") out.timeUnit = value;
+                if (value === "1sec" || value === "1msec" || value === "1min") out.timeUnit = value;
                 break;
             case "Total_Time": {
                 const n = Number(value);
@@ -281,6 +293,57 @@ const parseGameSummaryLines = (summaryLines: string[]): ParsedSummary => {
         }
     }
     return out;
+};
+
+/**
+ * `parseGameSummaryLines` の結果を `RshogiTimeControl` に変換する。
+ *
+ * ## kind 判定 (REST `decodeClock` の語彙に合わせる)
+ * サーバの clock 方式は `BEGIN Time` セクションの `Time_Unit` + `Increment` /
+ * `Byoyomi` の有無で一意に決まる (server `ClockSpec::format_time_section`)。
+ * - `Increment` 行あり → `fischer` (Time_Unit は常に 1sec)
+ * - `Time_Unit:1min`  → `stopwatch` (Total_Time / Byoyomi は分単位)
+ * - `Time_Unit:1msec` → `countdown_msec` (Total_Time / Byoyomi は ms 単位)
+ * - それ以外 (`Time_Unit:1sec` / 未指定) → `countdown`。`Byoyomi` が無い/0 の
+ *   場合は sudden-death (byoyomiSeconds=0) として扱う。
+ *
+ * ## 単位換算
+ * `mainSeconds` / `byoyomiSeconds` は Time_Unit に応じて秒へ正規化する:
+ * - `1sec`:  秒そのまま
+ * - `1msec`: ms → `round(/1000)`
+ * - `1min`:  分 → `*60`
+ * `byoyomiMilliseconds` は `1msec` のときだけ生 ms を保持する (ms 粒度の秒読み表示用)。
+ */
+const deriveTimeControl = (summary: ParsedSummary): RshogiTimeControl | undefined => {
+    if (
+        summary.totalTime === undefined &&
+        summary.byoyomi === undefined &&
+        summary.increment === undefined
+    ) {
+        return undefined;
+    }
+    const unit = summary.timeUnit;
+    const toSeconds = (value: number | undefined): number => {
+        if (value === undefined) return 0;
+        if (unit === "1msec") return Math.round(value / 1000);
+        if (unit === "1min") return value * 60;
+        return value;
+    };
+    const kind: RshogiClockKind =
+        summary.increment !== undefined
+            ? "fischer"
+            : unit === "1min"
+              ? "stopwatch"
+              : unit === "1msec"
+                ? "countdown_msec"
+                : "countdown";
+    return {
+        kind,
+        mainSeconds: toSeconds(summary.totalTime),
+        byoyomiSeconds: toSeconds(summary.byoyomi),
+        byoyomiMilliseconds: unit === "1msec" ? summary.byoyomi : undefined,
+        incrementSeconds: summary.increment,
+    };
 };
 
 /**
@@ -361,22 +424,7 @@ const decodeSnapshotBlock = (
         gameId: summary.gameId ?? gameId,
         senteName: summary.senteName ?? "",
         goteName: summary.goteName ?? "",
-        timeControl:
-            summary.totalTime !== undefined || summary.byoyomi !== undefined
-                ? {
-                      mainSeconds:
-                          summary.timeUnit === "1msec"
-                              ? Math.round((summary.totalTime ?? 0) / 1000)
-                              : (summary.totalTime ?? 0),
-                      byoyomiSeconds:
-                          summary.timeUnit === "1msec"
-                              ? Math.round((summary.byoyomi ?? 0) / 1000)
-                              : (summary.byoyomi ?? 0),
-                      byoyomiMilliseconds:
-                          summary.timeUnit === "1msec" ? summary.byoyomi : undefined,
-                      incrementSeconds: summary.increment,
-                  }
-                : undefined,
+        timeControl: deriveTimeControl(summary),
     };
 
     const sideToMove: "sente" | "gote" = summary.toMove ?? state.turn;
@@ -572,10 +620,12 @@ const MOCK_SNAPSHOT_LINES: string[] = [
     "Name+:先手デモエンジン",
     "Name-:後手デモエンジン",
     "Rematch_On_Draw:NO",
+    // Fischer 方式 (Increment) にして、dev screenshot でも kind 判定 + 増分加算の
+    // 新パス (viewer `applyMoveToClocks`) を素通しで確認できるようにする。
     "BEGIN Time",
     "Time_Unit:1sec",
     "Total_Time:600",
-    "Byoyomi:10",
+    "Increment:10",
     "Least_Time_Per_Move:0",
     "END Time",
     "BEGIN Position",
@@ -1167,6 +1217,7 @@ export function subscribeRshogiLiveGame(
 // (テスト外では使わない契約)
 export const __test_internals = {
     decodeSnapshotBlock,
+    deriveTimeControl,
     detectEndLine,
     extractElapsedSec,
     parseGameSummaryLines,

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -1,11 +1,14 @@
-import type { RshogiGameMeta, RshogiLiveMove } from "@shogi/match-client";
+import type { RshogiGameMeta, RshogiLiveMove, RshogiTimeControl } from "@shogi/match-client";
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import {
     appendMoveEval,
     applyMoveComment,
+    applyMoveToClocks,
     computeRemaining,
+    deriveInByoyomi,
     formatOwnEval,
+    type LiveClocks,
     moveDetailsToEvals,
     RshogiLiveMetaPanel,
     RshogiLiveScoreboard,
@@ -15,33 +18,98 @@ import {
 
 const META: RshogiGameMeta = { gameId: "game-1", senteName: "alice", goteName: "bob" };
 
+/** テスト用の clock 生成ヘルパ (秒読みフラグは既定 false)。 */
+const mkClocks = (over: Partial<LiveClocks> & Pick<LiveClocks, "sideToMove">): LiveClocks => ({
+    sente: 60_000,
+    gote: 60_000,
+    senteInByoyomi: false,
+    goteInByoyomi: false,
+    ...over,
+});
+
+const FISCHER: RshogiTimeControl = {
+    kind: "fischer",
+    mainSeconds: 60,
+    byoyomiSeconds: 0,
+    incrementSeconds: 5,
+};
+const COUNTDOWN: RshogiTimeControl = {
+    kind: "countdown",
+    mainSeconds: 600,
+    byoyomiSeconds: 10,
+};
+const COUNTDOWN_MSEC: RshogiTimeControl = {
+    kind: "countdown_msec",
+    mainSeconds: 10,
+    byoyomiSeconds: 0,
+    byoyomiMilliseconds: 500,
+};
+const STOPWATCH: RshogiTimeControl = {
+    kind: "stopwatch",
+    mainSeconds: 900,
+    byoyomiSeconds: 60,
+};
+const SUDDEN_DEATH: RshogiTimeControl = {
+    kind: "countdown",
+    mainSeconds: 300,
+    byoyomiSeconds: 0,
+};
+
 describe("computeRemaining", () => {
     it("手番側 (sideToMove) のみ経過分を減算し、相手側は据え置く", () => {
         const remaining = computeRemaining(
-            { sente: 60_000, gote: 45_000, sideToMove: "sente" },
+            mkClocks({ sente: 60_000, gote: 45_000, sideToMove: "sente" }),
             5_000,
         );
-        expect(remaining).toEqual({ sente: 55_000, gote: 45_000 });
+        expect(remaining.sente).toEqual({ mainMs: 55_000, inByoyomi: false });
+        expect(remaining.gote).toEqual({ mainMs: 45_000, inByoyomi: false });
     });
 
     it("後手番では後手側のみ減算する", () => {
         const remaining = computeRemaining(
-            { sente: 60_000, gote: 45_000, sideToMove: "gote" },
+            mkClocks({ sente: 60_000, gote: 45_000, sideToMove: "gote" }),
             5_000,
         );
-        expect(remaining).toEqual({ sente: 60_000, gote: 40_000 });
+        expect(remaining.sente.mainMs).toBe(60_000);
+        expect(remaining.gote.mainMs).toBe(40_000);
     });
 
     it("手番側の残時間が経過分を下回っても 0 で止める", () => {
         const remaining = computeRemaining(
-            { sente: 3_000, gote: 45_000, sideToMove: "sente" },
+            mkClocks({ sente: 3_000, gote: 45_000, sideToMove: "sente" }),
             5_000,
         );
-        expect(remaining).toEqual({ sente: 0, gote: 45_000 });
+        expect(remaining.sente.mainMs).toBe(0);
+        expect(remaining.gote.mainMs).toBe(45_000);
     });
 
-    it("clocks 未取得時は両者 0 を返す", () => {
-        expect(computeRemaining(null, 5_000)).toEqual({ sente: 0, gote: 0 });
+    it("clocks 未取得時は両者 mainMs 0・非秒読みを返す", () => {
+        expect(computeRemaining(null, 5_000)).toEqual({
+            sente: { mainMs: 0, inByoyomi: false },
+            gote: { mainMs: 0, inByoyomi: false },
+        });
+    });
+
+    it("秒読み中の手番側は本体 0・秒読みを full から補間減算する", () => {
+        const remaining = computeRemaining(
+            mkClocks({ sente: 0, gote: 45_000, sideToMove: "sente", senteInByoyomi: true }),
+            3_000,
+            COUNTDOWN,
+        );
+        // 手番側 (先手): 本体 0、秒読み full 10s から 3s 補間減算 → 7000ms
+        expect(remaining.sente).toEqual({ mainMs: 0, byoyomiMs: 7_000, inByoyomi: true });
+        // 相手側 (後手): 通常表示
+        expect(remaining.gote).toEqual({ mainMs: 45_000, inByoyomi: false });
+    });
+
+    it("秒読み中の相手側 (非手番) は full の秒読みを据え置き表示する", () => {
+        const remaining = computeRemaining(
+            mkClocks({ sente: 30_000, gote: 0, sideToMove: "sente", goteInByoyomi: true }),
+            3_000,
+            COUNTDOWN,
+        );
+        // 後手は非手番かつ秒読み → full 10s を減算せず表示
+        expect(remaining.gote).toEqual({ mainMs: 0, byoyomiMs: 10_000, inByoyomi: true });
     });
 });
 
@@ -54,6 +122,156 @@ describe("formatOwnEval", () => {
     it("±100000 の詰みセンチネルは詰み表記にする", () => {
         expect(formatOwnEval(100_000)).toBe("詰み");
         expect(formatOwnEval(-100_000)).toBe("詰まされ");
+    });
+});
+
+describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラー)", () => {
+    it("fischer: mover.main = max(0, main - elapsed) + increment (post-increment)", () => {
+        // 先手 65s (=60+5)、10s 消費 → max(0, 65000-10000)+5000 = 60000
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 65_000, gote: 65_000, sideToMove: "sente" }),
+            "fischer",
+            FISCHER,
+            "sente",
+            10,
+        );
+        expect(next.sente).toBe(60_000);
+        expect(next.gote).toBe(65_000); // 相手側は不変
+        expect(next.sideToMove).toBe("gote"); // 手番が相手へ
+        expect(next.senteInByoyomi).toBe(false);
+    });
+
+    it("fischer: max(0, main - elapsed) + inc の clamp を固定する (main 0 / elapsed 3s / inc 5s → 5000)", () => {
+        // 式の clamp 部分の防御的ケースを固定する。inc>0 の fischer で broadcast
+        // される手は必ず elapsed <= main のため、この状態はサーバ上では到達しない
+        // (client がドリフトで main を小さく見積もった場合の安全側挙動の確認)。
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 0, gote: 60_000, sideToMove: "sente" }),
+            "fischer",
+            FISCHER,
+            "sente",
+            3,
+        );
+        expect(next.sente).toBe(5_000);
+    });
+
+    it("countdown: 本体内なら減算、本体使い切りで秒読みへ移行する", () => {
+        // 本体 8s の側が 8s 消費 → 本体 0、秒読み (byoyomi 10s>0) へ
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 8_000, gote: 60_000, sideToMove: "sente" }),
+            "countdown",
+            COUNTDOWN,
+            "sente",
+            8,
+        );
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(true);
+    });
+
+    it("countdown: 本体超過で即秒読みへ (elapsed > main)", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 3_000, gote: 60_000, sideToMove: "sente" }),
+            "countdown",
+            COUNTDOWN,
+            "sente",
+            9,
+        );
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(true);
+    });
+
+    it("countdown: 秒読みは以降の手でも持続し本体 0 のまま (毎手 full リセット・持続量は保持しない)", () => {
+        // 既に秒読み中 (main 0 / inByoyomi) の側がさらに指しても本体 0・秒読み継続。
+        const inByoyomi = mkClocks({
+            sente: 0,
+            gote: 60_000,
+            sideToMove: "sente",
+            senteInByoyomi: true,
+        });
+        const next = applyMoveToClocks(inByoyomi, "countdown", COUNTDOWN, "sente", 7);
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(true);
+    });
+
+    it("countdown_msec: byoyomiMilliseconds>0 でも本体使い切りで秒読みへ移行する", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 500, gote: 10_000, sideToMove: "sente" }),
+            "countdown_msec",
+            COUNTDOWN_MSEC,
+            "sente",
+            1,
+        );
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(true);
+    });
+
+    it("stopwatch: 分単位切り捨て (elapsed 59s → 消費 0)", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 900_000, gote: 900_000, sideToMove: "sente" }),
+            "stopwatch",
+            STOPWATCH,
+            "sente",
+            59,
+        );
+        // 59 秒は分単位切り捨てで消費 0
+        expect(next.sente).toBe(900_000);
+        expect(next.senteInByoyomi).toBe(false);
+        // 60 秒ちょうどで 1 分消費
+        const after60 = applyMoveToClocks(
+            mkClocks({ sente: 900_000, gote: 900_000, sideToMove: "sente" }),
+            "stopwatch",
+            STOPWATCH,
+            "sente",
+            60,
+        );
+        expect(after60.sente).toBe(840_000);
+    });
+
+    it("sudden-death (byoyomi 0): 0 でクランプし秒読みには入らない", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 3_000, gote: 300_000, sideToMove: "sente" }),
+            "countdown",
+            SUDDEN_DEATH,
+            "sente",
+            9,
+        );
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(false); // byoyomi 0 → 秒読みに入らない
+    });
+
+    it("後手番の move は後手側だけを更新し先手を据え置く", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 60_000, gote: 40_000, sideToMove: "gote" }),
+            "countdown",
+            COUNTDOWN,
+            "gote",
+            5,
+        );
+        expect(next.gote).toBe(35_000);
+        expect(next.sente).toBe(60_000);
+        expect(next.sideToMove).toBe("sente");
+    });
+});
+
+describe("deriveInByoyomi: snapshot / onClock resync の秒読み派生", () => {
+    it("本体 0 + countdown + byoyomi>0 → true", () => {
+        expect(deriveInByoyomi(0, COUNTDOWN)).toBe(true);
+    });
+    it("本体残あり → false", () => {
+        expect(deriveInByoyomi(5_000, COUNTDOWN)).toBe(false);
+    });
+    it("countdown_msec も byoyomiMilliseconds>0 なら true", () => {
+        expect(deriveInByoyomi(0, COUNTDOWN_MSEC)).toBe(true);
+    });
+    it("sudden-death (byoyomi 0) → false", () => {
+        expect(deriveInByoyomi(0, SUDDEN_DEATH)).toBe(false);
+    });
+    it("fischer / stopwatch は countdown 系でないため false", () => {
+        expect(deriveInByoyomi(0, FISCHER)).toBe(false);
+        expect(deriveInByoyomi(0, STOPWATCH)).toBe(false);
+    });
+    it("timeControl 未取得なら false", () => {
+        expect(deriveInByoyomi(0, undefined)).toBe(false);
     });
 });
 
@@ -211,7 +429,7 @@ describe("RshogiLiveScoreboard: 評価値 / 消費時間の表示", () => {
             <RshogiLiveScoreboard
                 meta={META}
                 moveCount={2}
-                clocks={{ sente: 60_000, gote: 60_000, sideToMove: "sente" }}
+                clocks={mkClocks({ sideToMove: "sente" })}
                 elapsedSinceAnchor={0}
                 connectionState="connected"
                 senteEvalCp={120}
@@ -232,13 +450,35 @@ describe("RshogiLiveScoreboard: 評価値 / 消費時間の表示", () => {
             <RshogiLiveScoreboard
                 meta={META}
                 moveCount={0}
-                clocks={{ sente: 60_000, gote: 60_000, sideToMove: "sente" }}
+                clocks={mkClocks({ sideToMove: "sente" })}
                 elapsedSinceAnchor={0}
                 connectionState="connected"
             />,
         );
         expect(screen.queryByText(/評価値/)).toBeNull();
         expect(screen.queryByText(/直前手/)).toBeNull();
+    });
+
+    it("秒読み中の手番側は 00:00 で固まらず「秒読み」と残秒を表示する", () => {
+        render(
+            <RshogiLiveScoreboard
+                meta={{ ...META, timeControl: COUNTDOWN }}
+                moveCount={40}
+                clocks={mkClocks({
+                    sente: 0,
+                    gote: 30_000,
+                    sideToMove: "sente",
+                    senteInByoyomi: true,
+                })}
+                elapsedSinceAnchor={3_000}
+                connectionState="connected"
+            />,
+        );
+        // 秒読みラベルと残秒 (full 10s から 3s 補間 → ceil(7000/1000)=7 → "0:07")
+        expect(screen.getByText("秒読み")).toBeDefined();
+        expect(screen.getByText("0:07")).toBeDefined();
+        // 後手は本体表示のまま (秒読みラベルは 1 件のみ)
+        expect(screen.getByText("00:30")).toBeDefined();
     });
 });
 

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -14,6 +14,7 @@
 
 import { cn } from "@shogi/design-system";
 import {
+    type RshogiClockKind,
     type RshogiGameMeta,
     type RshogiGameResult,
     type RshogiLiveCallbacks,
@@ -21,6 +22,7 @@ import {
     type RshogiLiveMove,
     type RshogiLiveSession,
     type RshogiLiveSnapshot,
+    type RshogiTimeControl,
     subscribeRshogiLiveGame,
 } from "@shogi/match-client";
 import { type ReactElement, type ReactNode, useEffect, useRef, useState } from "react";
@@ -40,6 +42,28 @@ export interface RshogiCsaLiveViewerProps {
     fetchLegalMoves?: React.ComponentProps<typeof ShogiMatch>["fetchLegalMoves"];
     onRequestNnueFilePath?: React.ComponentProps<typeof ShogiMatch>["onRequestNnueFilePath"];
     isDevMode?: boolean;
+}
+
+/**
+ * client 側で保持する時計状態。
+ *
+ * `sente` / `gote` は **本体残時間 (ms)**。server の `remaining_main_ms` と同義で、
+ * 秒読みは含まない (server は秒読み残量を persist しない)。秒読みフェーズに入った
+ * かどうかは per-side の `*InByoyomi` フラグで表す。秒読みは毎手 full リセットされ
+ * 持続量の概念が無いため、残量ではなくフラグだけを保持し、表示時に full から
+ * anchor 補間する ({@link computeRemaining})。
+ */
+export interface LiveClocks {
+    /** 先手の本体残時間 (ms、秒読み中は 0)。 */
+    sente: number;
+    /** 後手の本体残時間 (ms、秒読み中は 0)。 */
+    gote: number;
+    /** wire 上の手番 (= server `current_turn()`)。 */
+    sideToMove: "sente" | "gote";
+    /** 先手が秒読みフェーズに入っているか。 */
+    senteInByoyomi: boolean;
+    /** 後手が秒読みフェーズに入っているか。 */
+    goteInByoyomi: boolean;
 }
 
 interface LiveState {
@@ -62,8 +86,8 @@ interface LiveState {
      * move では key を変えず prop 更新で反映する (毎手 remount を避けてちらつきを防ぐ)。
      */
     snapshotEpoch: number;
-    /** 最後に server から受け取った clock 残時間 (ms)。 */
-    clocks: { sente: number; gote: number; sideToMove: "sente" | "gote" } | null;
+    /** 最後に server から受け取った clock 状態 (本体残時間 + 秒読みフラグ)。 */
+    clocks: LiveClocks | null;
     /** clock を local timer で減算するための anchor (ms epoch)。 */
     clockAnchorAtMs: number | null;
     connectionState: RshogiLiveConnectionState;
@@ -222,6 +246,114 @@ const formatMs = (ms: number): string => {
     return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
 };
 
+/**
+ * 秒読み残時間 (ms) を `m:ss` に整形する。
+ *
+ * 本体時計 (`formatMs`) は floor だが、秒読みは「あと N 秒」という残数表示のため
+ * ceil にする (full 10 秒の秒読み開始直後に 9 と出さない)。実際の time-up 判定は
+ * server 側で行われ end 行として届くので、client 表示は 0 でクランプするだけ。
+ */
+const formatByoyomiClock = (ms: number): string => {
+    const totalSec = Number.isFinite(ms) ? Math.max(0, Math.ceil(ms / 1000)) : 0;
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return `${min}:${String(sec).padStart(2, "0")}`;
+};
+
+/** timeControl から秒読みの full 量 (ms) を取り出す (ms 粒度優先、無ければ秒→ms)。 */
+function byoyomiFullMs(timeControl: RshogiTimeControl | undefined): number {
+    if (!timeControl) return 0;
+    return timeControl.byoyomiMilliseconds ?? (timeControl.byoyomiSeconds ?? 0) * 1000;
+}
+
+/** countdown 系 (秒読みを持ちうる方式) かどうか。stopwatch / fischer は含めない。 */
+function isCountdownFamily(kind: RshogiClockKind | undefined): boolean {
+    return kind === "countdown" || kind === "countdown_msec";
+}
+
+/**
+ * ある側の本体残時間 + timeControl から「秒読みフェーズに入っているか」を導出する。
+ *
+ * 本体 0 かつ countdown 系かつ byoyomi>0 のときだけ true。snapshot / onClock の
+ * resync 経路で使い、遅れて参加した観戦者が秒読み中の局面を即座に秒読み表示できる
+ * ようにする。fischer / stopwatch / sudden-death (byoyomi 0) は常に false。
+ */
+export function deriveInByoyomi(
+    mainMs: number,
+    timeControl: RshogiTimeControl | undefined,
+): boolean {
+    return mainMs <= 0 && isCountdownFamily(timeControl?.kind) && byoyomiFullMs(timeControl) > 0;
+}
+
+/**
+ * broadcast move 1 手を時計状態に適用する純関数 (kind ごとのルールを server
+ * `game/clock.rs` に合わせる)。`onMove` から呼び、unit テスト可能にするため純関数化。
+ *
+ * `elapsedSec` は wire の `,T<sec>` (server 計算・秒切り捨て済みの権威ある経過秒) を
+ * 渡す。従来の実装は local wall-clock 経過を引いていたため、時間切れで 00:00 に
+ * 張り付いたり fischer 増分が反映されなかった。ここで authoritative elapsed を
+ * 使うのが本 fix の要点。秒切り捨て由来の最大 1 秒のドリフトは許容し、snapshot
+ * resync (`onClock`) が上書き補正する。
+ *
+ * - fischer:  mover.main = max(0, main - elapsedSec*1000) + increment*1000
+ *             (`FischerClock::consume` の post-increment のミラー。なお inc>0 の
+ *              fischer で broadcast される手は必ず elapsed <= main なので、
+ *              max(0, …) の clamp が効く「本体 0 からの回復」はサーバ上は到達
+ *              しない防御的ケース)。
+ * - countdown / countdown_msec:
+ *             本体内なら減算。超過したら本体 0 で秒読みへ移行 (byoyomi>0 のときだけ
+ *             `inByoyomi` を立てる)。秒読みは毎手 full リセットのため持続量は保持しない。
+ *             既知の制約: countdown_msec は wire の `,T<sec>` が秒切り捨てのため、
+ *             ms 粒度の秒読み移行判定に最大 1 秒未満の誤差が出る (snapshot resync
+ *             でのみ補正)。
+ * - stopwatch: floor(elapsedSec/60)*60000 を減算 (分単位切り捨て。elapsed 59s → 消費 0)。
+ *             既知の制約: stopwatch の秒読み (分単位) フェーズ表示は未対応
+ *             (本番プリセットは fischer / countdown のみで stopwatch 配信が無いため)。
+ *             本体 0 到達後は 00:00 のまま。対応する場合は countdown 系と同様に
+ *             `inByoyomi` を分粒度で扱うこと。
+ * - sudden-death (byoyomi 0 / increment 無し) / kind 不明: 0 でクランプするだけ
+ *   (`inByoyomi` は立てない)。
+ */
+export function applyMoveToClocks(
+    clocks: LiveClocks,
+    kind: RshogiClockKind | undefined,
+    timeControl: RshogiTimeControl | undefined,
+    moverSide: "sente" | "gote",
+    elapsedSec: number,
+): LiveClocks {
+    const elapsedMs = Math.max(0, elapsedSec) * 1000;
+    const main = moverSide === "sente" ? clocks.sente : clocks.gote;
+    const alreadyInByoyomi = moverSide === "sente" ? clocks.senteInByoyomi : clocks.goteInByoyomi;
+
+    let nextMain: number;
+    let nextInByoyomi: boolean;
+    if (kind === "fischer") {
+        const incMs = (timeControl?.incrementSeconds ?? 0) * 1000;
+        nextMain = Math.max(0, main - elapsedMs) + incMs;
+        nextInByoyomi = false;
+    } else if (kind === "stopwatch") {
+        const consumedMs = Math.floor(Math.max(0, elapsedSec) / 60) * 60_000;
+        nextMain = Math.max(0, main - consumedMs);
+        nextInByoyomi = false;
+    } else {
+        // countdown / countdown_msec / sudden-death / kind 不明。
+        // 既に秒読みなら本体は 0 のまま (秒読みは毎手 full リセットで持続量を保持しない)、
+        // そうでなければ本体から減算する。本体が 0 に達したら (ちょうど使い切りも含め)
+        // byoyomi>0 のときだけ秒読みフェーズへ移行する ({@link deriveInByoyomi} と同義)。
+        nextMain = alreadyInByoyomi ? 0 : Math.max(0, main - elapsedMs);
+        nextInByoyomi = nextMain <= 0 && byoyomiFullMs(timeControl) > 0;
+    }
+
+    const nextSide: "sente" | "gote" = moverSide === "sente" ? "gote" : "sente";
+    return {
+        sente: moverSide === "sente" ? nextMain : clocks.sente,
+        gote: moverSide === "gote" ? nextMain : clocks.gote,
+        sideToMove: nextSide,
+        senteInByoyomi: moverSide === "sente" ? nextInByoyomi : clocks.senteInByoyomi,
+        goteInByoyomi: moverSide === "gote" ? nextInByoyomi : clocks.goteInByoyomi,
+    };
+}
+
 const CONNECTION_LABEL: Record<RshogiLiveConnectionState, string> = {
     connecting: "接続中...",
     connected: "観戦中",
@@ -259,20 +391,68 @@ const formatResultText = (meta: RshogiGameMeta | undefined, result: RshogiGameRe
     return `${winnerLabel} (${reason})`;
 };
 
-/** 手番側だけ countdown した先手・後手の残時間 (ms)。 */
-export function computeRemaining(
-    clocks: LiveState["clocks"],
+/** スコアボード片側分の表示用残時間 (本体 or 秒読み)。 */
+interface SideRemaining {
+    /** 本体残時間 (ms、秒読み中は 0)。 */
+    mainMs: number;
+    /** 秒読み残 (ms)。秒読みフェーズのときだけ設定する (非秒読み時は undefined)。 */
+    byoyomiMs?: number;
+    /** 秒読みフェーズか (true のとき byoyomiMs を表示する)。 */
+    inByoyomi: boolean;
+}
+
+/** 1 側分の表示残時間を求める (手番側のみ anchor 補間で減算する)。 */
+function sideRemaining(
+    main: number,
+    inByoyomi: boolean,
+    isActive: boolean,
     elapsedSinceAnchor: number,
-): { sente: number; gote: number } {
+    byoyomiFull: number,
+): SideRemaining {
+    if (inByoyomi) {
+        // 秒読み: 本体は 0。手番側は full から anchor 補間で減算、相手側は full 表示。
+        // 実際の time-up は server が判定し end 行で届くため、client は 0 でクランプする。
+        const byoyomiMs = isActive ? Math.max(0, byoyomiFull - elapsedSinceAnchor) : byoyomiFull;
+        return { mainMs: 0, byoyomiMs, inByoyomi: true };
+    }
+    const mainMs = isActive ? Math.max(0, main - elapsedSinceAnchor) : main;
+    return { mainMs, inByoyomi: false };
+}
+
+/**
+ * 手番側だけ 1Hz 補間で減算した先手・後手の表示残時間を求める。
+ *
+ * 秒読みフェーズ (`*InByoyomi`) の側は本体 0 の代わりに秒読み残 (`byoyomiMs`) を返す。
+ * 補間はあくまで手 (move) 間の見た目のためで、権威ある値は次の move / snapshot で
+ * 上書きされる。`timeControl` は秒読みの full 量を知るために渡す。
+ */
+export function computeRemaining(
+    clocks: LiveClocks | null,
+    elapsedSinceAnchor: number,
+    timeControl?: RshogiTimeControl,
+): { sente: SideRemaining; gote: SideRemaining } {
+    if (!clocks) {
+        return {
+            sente: { mainMs: 0, inByoyomi: false },
+            gote: { mainMs: 0, inByoyomi: false },
+        };
+    }
+    const byoyomiFull = byoyomiFullMs(timeControl);
     return {
-        sente:
-            clocks && clocks.sideToMove === "sente"
-                ? Math.max(0, clocks.sente - elapsedSinceAnchor)
-                : (clocks?.sente ?? 0),
-        gote:
-            clocks && clocks.sideToMove === "gote"
-                ? Math.max(0, clocks.gote - elapsedSinceAnchor)
-                : (clocks?.gote ?? 0),
+        sente: sideRemaining(
+            clocks.sente,
+            clocks.senteInByoyomi,
+            clocks.sideToMove === "sente",
+            elapsedSinceAnchor,
+            byoyomiFull,
+        ),
+        gote: sideRemaining(
+            clocks.gote,
+            clocks.goteInByoyomi,
+            clocks.sideToMove === "gote",
+            elapsedSinceAnchor,
+            byoyomiFull,
+        ),
     };
 }
 
@@ -280,18 +460,20 @@ export function computeRemaining(
 function ScoreboardSide({
     side,
     name,
-    remainingMs,
+    remaining,
     active,
     ownEvalCp,
 }: {
     side: "sente" | "gote";
     name: string;
-    remainingMs: number;
+    /** 表示用残時間 (本体 or 秒読み)。 */
+    remaining: SideRemaining;
     active: boolean;
     /** その手番自身の視点に直した最新評価値 (`+` = その手番が有利)。無ければ非表示。 */
     ownEvalCp?: number;
 }): ReactElement {
     const isSente = side === "sente";
+    const showByoyomi = remaining.inByoyomi && remaining.byoyomiMs !== undefined;
     return (
         <div
             className={cn(
@@ -321,6 +503,8 @@ function ScoreboardSide({
                     </div>
                 )}
             </div>
+            {/* 時計スロット: 本体表示と秒読み表示で高さを変えない (PR #56 の CLS 回帰防止)。
+                秒読み中は同じ text-2xl の数字スロットに「秒読み」ラベル + 残秒を差し替える。 */}
             <div
                 className={cn(
                     "flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-2xl font-bold leading-none tabular-nums transition-colors",
@@ -334,7 +518,14 @@ function ScoreboardSide({
                         aria-hidden="true"
                     />
                 )}
-                {formatMs(remainingMs)}
+                {showByoyomi ? (
+                    <>
+                        <span className="text-xs font-semibold">秒読み</span>
+                        <span>{formatByoyomiClock(remaining.byoyomiMs ?? 0)}</span>
+                    </>
+                ) : (
+                    formatMs(remaining.mainMs)
+                )}
             </div>
         </div>
     );
@@ -372,7 +563,7 @@ export function RshogiLiveScoreboard({
     /** 直近手の消費秒数。無ければ非表示。 */
     lastMoveElapsedSec?: number;
 }): ReactElement {
-    const remaining = computeRemaining(clocks, elapsedSinceAnchor);
+    const remaining = computeRemaining(clocks, elapsedSinceAnchor, meta.timeControl);
     const isConnected = connectionState === "connected";
     const turnLabel = result
         ? "終局"
@@ -389,7 +580,7 @@ export function RshogiLiveScoreboard({
             <ScoreboardSide
                 side="sente"
                 name={meta.senteName}
-                remainingMs={remaining.sente}
+                remaining={remaining.sente}
                 active={!result && clocks?.sideToMove === "sente"}
                 ownEvalCp={toOwnEval("sente", senteEvalCp)}
             />
@@ -421,7 +612,7 @@ export function RshogiLiveScoreboard({
             <ScoreboardSide
                 side="gote"
                 name={meta.goteName}
-                remainingMs={remaining.gote}
+                remaining={remaining.gote}
                 active={!result && clocks?.sideToMove === "gote"}
                 ownEvalCp={toOwnEval("gote", goteEvalCp)}
             />
@@ -507,6 +698,7 @@ export function RshogiCsaLiveViewer({
         const callbacks: RshogiLiveCallbacks = {
             onSnapshot(snapshot) {
                 const summary = summarizeMoveDetails(snapshot.moveDetails);
+                const timeControl = snapshot.meta.timeControl;
                 setState((prev) => ({
                     ...prev,
                     snapshot,
@@ -515,7 +707,15 @@ export function RshogiCsaLiveViewer({
                     moveEvals: moveDetailsToEvals(snapshot.moveDetails),
                     result: snapshot.finalResult ?? prev.result,
                     snapshotEpoch: prev.snapshotEpoch + 1,
-                    clocks: snapshot.clocks,
+                    // 本体残 0 かつ countdown 系秒読み局面なら、遅れて参加した観戦者にも
+                    // 秒読み表示を即座に出せるよう inByoyomi を派生する。
+                    clocks: {
+                        sente: snapshot.clocks.sente,
+                        gote: snapshot.clocks.gote,
+                        sideToMove: snapshot.clocks.sideToMove,
+                        senteInByoyomi: deriveInByoyomi(snapshot.clocks.sente, timeControl),
+                        goteInByoyomi: deriveInByoyomi(snapshot.clocks.gote, timeControl),
+                    },
                     clockAnchorAtMs: Date.now(),
                     lastError: undefined,
                     // snapshot は全置換なので eval/PV/消費秒も moveDetails から再導出する。
@@ -526,38 +726,30 @@ export function RshogiCsaLiveViewer({
                 }));
             },
             onMove({ csaMove, elapsedSec }) {
-                setState((prev) => ({
-                    ...prev,
-                    moves: [...prev.moves, csaMove],
-                    // 新規手を付随情報配列にも追加 (この時点では消費秒のみ、eval は後追い)。
-                    moveEvals: appendMoveEval(prev.moveEvals, elapsedSec),
-                    // broadcast move 到着時に手番側を切り替える (= clock の anchor も
-                    // 更新してロジックを単純化する。サーバから次 snapshot が来たら
-                    // 上書きされる)。
-                    clocks: prev.clocks
-                        ? {
-                              sente:
-                                  prev.clocks.sideToMove === "sente"
-                                      ? Math.max(
-                                            0,
-                                            prev.clocks.sente -
-                                                (Date.now() - (prev.clockAnchorAtMs ?? Date.now())),
-                                        )
-                                      : prev.clocks.sente,
-                              gote:
-                                  prev.clocks.sideToMove === "gote"
-                                      ? Math.max(
-                                            0,
-                                            prev.clocks.gote -
-                                                (Date.now() - (prev.clockAnchorAtMs ?? Date.now())),
-                                        )
-                                      : prev.clocks.gote,
-                              sideToMove: prev.clocks.sideToMove === "sente" ? "gote" : "sente",
-                          }
-                        : prev.clocks,
-                    clockAnchorAtMs: Date.now(),
-                    lastMoveElapsedSec: elapsedSec,
-                }));
+                setState((prev) => {
+                    const timeControl = prev.snapshot?.meta.timeControl;
+                    return {
+                        ...prev,
+                        moves: [...prev.moves, csaMove],
+                        // 新規手を付随情報配列にも追加 (この時点では消費秒のみ、eval は後追い)。
+                        moveEvals: appendMoveEval(prev.moveEvals, elapsedSec),
+                        // broadcast move 到着時に手番側 (= mover) の時計を kind ごとの
+                        // ルールで更新し、手番を相手側へ切り替える。local wall-clock では
+                        // なく wire の権威ある elapsedSec を使う (本 fix の要点)。
+                        // 秒切り捨て由来の最大 1 秒のドリフトは snapshot resync で補正される。
+                        clocks: prev.clocks
+                            ? applyMoveToClocks(
+                                  prev.clocks,
+                                  timeControl?.kind,
+                                  timeControl,
+                                  prev.clocks.sideToMove,
+                                  elapsedSec,
+                              )
+                            : prev.clocks,
+                        clockAnchorAtMs: Date.now(),
+                        lastMoveElapsedSec: elapsedSec,
+                    };
+                });
             },
             onMoveComment({ ply, comment }) {
                 setState((prev) => ({
@@ -568,11 +760,23 @@ export function RshogiCsaLiveViewer({
                 }));
             },
             onClock({ remainingMs, sideToMove }) {
-                setState((prev) => ({
-                    ...prev,
-                    clocks: { sente: remainingMs.sente, gote: remainingMs.gote, sideToMove },
-                    clockAnchorAtMs: Date.now(),
-                }));
+                setState((prev) => {
+                    // onClock は snapshot 完了直後 (onSnapshot の後) にのみ発火するため、
+                    // prev.snapshot は既に最新へ更新済み。そこから timeControl を引き、
+                    // 本体残 0 の countdown 系秒読み局面を即座に秒読み表示へ乗せる。
+                    const timeControl = prev.snapshot?.meta.timeControl;
+                    return {
+                        ...prev,
+                        clocks: {
+                            sente: remainingMs.sente,
+                            gote: remainingMs.gote,
+                            sideToMove,
+                            senteInByoyomi: deriveInByoyomi(remainingMs.sente, timeControl),
+                            goteInByoyomi: deriveInByoyomi(remainingMs.gote, timeControl),
+                        },
+                        clockAnchorAtMs: Date.now(),
+                    };
+                });
             },
             onEnd(result) {
                 setState((prev) => ({ ...prev, result }));


### PR DESCRIPTION
## 概要

live 観戦 viewer の時計表示バグ修正。サーバーは 1 手ごとに時間制御ルールを適用する（fischer の post-increment / 秒読みの毎手フルリセット）が、クライアントは**手番側の残時間をローカル壁時計差分で減算して 0 で clamp するだけ**だったため:

- fischer の増分（例: +2s/手）が表示に反映されない
- 本体を使い切った側が秒読み継続中も **00:00 に固着**

## 修正内容

- **時計遷移の純関数化** `applyMoveToClocks`: broadcast の権威値 `,T<sec>` を用い、サーバー実装（rshogi `game/clock.rs::consume`）を kind 別に厳密ミラー
  - fischer: `max(0, 残り − 消費) + increment`（post-increment）
  - countdown / countdown_msec: 本体消化で秒読みフェーズへ（毎手フルリセット、持続量は保持しない = サーバーと同じ）
  - stopwatch: 分単位切り捨て減算 / sudden-death: 従来 clamp
- **秒読み表示**: 本体 0 の countdown 系は「秒読み m:ss」を同一スロット内で差し替え表示（高さ不変 = CLS 回帰なし）。手番側はカウントダウン、非手番側は full
- **途中参加対応**: snapshot / onClock 再同期時に `deriveInByoyomi` で秒読み状態を導出
- **match-client**: live 経路で `timeControl.kind` が未設定だった欠落を `deriveTimeControl` で補完（REST `decodeClock` と同語彙）+ `Time_Unit:1min`（stopwatch）誤解釈の修正

## 既知の制約（コード内に明記）

- countdown_msec: `T` の秒切り捨てにより ms 粒度の移行判定に最大 1 秒未満の誤差（snapshot resync で補正）
- stopwatch の秒読み表示は未対応（本番プリセットは fischer / countdown のみで stopwatch 配信なし）

## 検証

- クリーンコンテキストレビュー（Opus）: **MUST-FIX 0 / 条件付き承認**。fischer/countdown 系の全境界値（exact-fit、超過移行、秒読み持続、sudden-death、59s/60s 分切り捨て）がサーバールールと厳密一致することを数値検証済み
- 実ブラウザスクリーンショットで描画回帰なしを確認（mock は fischer Increment:10 で新 kind 判定パスを通過）
- gates: match-client 85 / ui 332 / desktop 7 全 pass、knip clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6yGTQx3k1SaqA1sYhDEQL