### PR TITLE
fix(ui,web): 検討モード評価値の符号往復バグと手数なし詰みの表記を修正

### DIFF
--- a/apps/web/src/pages/games/GameReviewPage.tsx
+++ b/apps/web/src/pages/games/GameReviewPage.tsx
@@ -55,6 +55,8 @@ async function createAnalysisSnapshot(
             "Content-Type": "application/json",
         },
         credentials: "same-origin",
+        // JSON.stringify は Infinity を null にする。live 由来の手数なし詰み
+        // (evalMate=±Infinity) を流す場合は stringifyReviewMoveData 相当の変換が必要。
         body: JSON.stringify(requestBody),
     });
 

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -15,6 +15,7 @@ import {
     setMoveEvalAtPly,
     summarizeMoveDetails,
 } from "./rshogi-csa-live-viewer";
+import { formatEval, MATE_WITHOUT_PLY } from "./shogi-match/utils/kifFormat";
 
 const META: RshogiGameMeta = { gameId: "game-1", senteName: "alice", goteName: "bob" };
 
@@ -357,25 +358,27 @@ describe("moveEvals accumulation (initialReview.moveData の材料)", () => {
         ]);
     });
 
-    it("moveDetailsToEvals: 詰みセンチネル ±100000 は ±2000 に丸める (evalMate 化しない・グラフ autoscale を潰さない)", () => {
-        // ±100000 を素通しすると EvalGraph の autoscale が引き伸ばされ通常評価値が
-        // 中央線に潰れるため、表示用に ±2000 へ丸める。evalMate は捏造しない。
+    it("moveDetailsToEvals: 詰みセンチネル ±100000 は手数不明の詰みとして表示できる形にする", () => {
         const details = [
             move("3f3e", 3, { raw: "* 100000", evalCp: 100000 }),
             move("5a4b", 2, { raw: "* -100000", evalCp: -100000 }),
         ];
         expect(moveDetailsToEvals(details)).toEqual([
-            { elapsedMs: 3000, evalCp: 2000 },
-            { elapsedMs: 2000, evalCp: -2000 },
+            { elapsedMs: 3000, evalMate: MATE_WITHOUT_PLY },
+            { elapsedMs: 2000, evalMate: -MATE_WITHOUT_PLY },
         ]);
+        expect(formatEval(undefined, moveDetailsToEvals(details)[0]?.evalMate)).toBe("+詰");
+        expect(formatEval(undefined, moveDetailsToEvals(details)[1]?.evalMate)).toBe("-詰");
     });
 
-    it("setMoveEvalAtPly: 後追いコメントの詰みセンチネルも ±2000 に丸める", () => {
+    it("setMoveEvalAtPly: 後追いコメントの詰みセンチネルも手数不明の詰みとして表示できる形にする", () => {
         const prev = [{ elapsedMs: 3000, evalCp: 30 }, { elapsedMs: 6000 }];
-        expect(setMoveEvalAtPly(prev, 2, { evalCp: -100000 })).toEqual([
+        const next = setMoveEvalAtPly(prev, 2, { evalCp: -100000 });
+        expect(next).toEqual([
             { elapsedMs: 3000, evalCp: 30 },
-            { elapsedMs: 6000, evalCp: -2000 },
+            { elapsedMs: 6000, evalCp: undefined, evalMate: -MATE_WITHOUT_PLY },
         ]);
+        expect(formatEval(next[1]?.evalCp, next[1]?.evalMate)).toBe("-詰");
     });
 
     it("appendMoveEval: broadcast move は消費秒のみで追加し eval は後追い", () => {

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -29,6 +29,7 @@ import { type ReactElement, type ReactNode, useEffect, useRef, useState } from "
 import { ShogiMatch } from "./shogi-match";
 import type { ReviewMoveEval } from "./shogi-match/hooks/useKifuImportExport";
 import type { EngineOption } from "./shogi-match/types";
+import { MATE_WITHOUT_PLY } from "./shogi-match/utils/kifFormat";
 
 export interface RshogiCsaLiveViewerProps {
     gameId: string;
@@ -171,38 +172,25 @@ export function summarizeMoveDetails(moveDetails: RshogiLiveMove[]): LiveEvalSta
     return { ...evalState, lastMoveElapsedSec: last?.elapsedSec };
 }
 
-/**
- * 詰みセンチネルを moveData (棋譜評価値カラム / 評価値グラフ) 用に丸める値 (cp)。
- *
- * ## 詰みセンチネルの扱い (設計判断)
- * wire は詰みを `±100000` センチネルで符号化するだけで **詰み手数を持たない**
- * (rshogi は mate-in-N を潰す)。これを `evalMate=±1` として渡すと `formatEval` /
- * `getEvalTooltipInfo` が「+詰1」「1手詰み」と **存在しない手数を偽って** 表示して
- * しまうため、`evalMate` は設定しない (手数を捏造しない)。
- * かつ `evalCp=±100000` を素通しすると EvalGraph の autoscale が ±100000 級に
- * 引き伸ばされ、通常の評価値 (数百 cp) が全て中央線に潰れてグラフが死ぬ。
- * そこでセンチネルは ±2000 (グラフの見やすい決定的優勢域) に丸めて `evalCp` に
- * 格納する。詰みに近い決定的優勢を、捏造した手数なしに・グラフを潰さずに伝える。
- */
-const MATE_DISPLAY_EVAL_CP = 2000;
-
-/** wire eval (先手視点) の詰みセンチネル ±100000 を表示用 ±2000 に丸める。 */
-function clampWireEvalForDisplay(evalCp: number | undefined): number | undefined {
-    if (evalCp === undefined) return undefined;
-    if (evalCp >= MATE_EVAL_SENTINEL) return MATE_DISPLAY_EVAL_CP;
-    if (evalCp <= -MATE_EVAL_SENTINEL) return -MATE_DISPLAY_EVAL_CP;
-    return evalCp;
+/** wire eval (先手視点) の詰みセンチネル ±100000 を手数不明の mate に変換する。 */
+function wireEvalToReviewEval(
+    evalCp: number | undefined,
+): Pick<ReviewMoveEval, "evalCp" | "evalMate"> {
+    if (evalCp === undefined) return {};
+    if (evalCp >= MATE_EVAL_SENTINEL) return { evalMate: MATE_WITHOUT_PLY };
+    if (evalCp <= -MATE_EVAL_SENTINEL) return { evalMate: -MATE_WITHOUT_PLY };
+    return { evalCp };
 }
 
 /**
  * elapsedSec と wire eval (先手視点) から `initialReview.moveData` の 1 手分を作る
  * (両方無ければ undefined)。moves と同じ index で対応する。
- * 詰みセンチネルの丸めは {@link MATE_DISPLAY_EVAL_CP} を参照。
+ * 詰みセンチネルは手数不明の mate として扱い、手数を捏造しない。
  */
 function toMoveEval(elapsedSec: number, evalCp: number | undefined): ReviewMoveEval | undefined {
     const elapsedMs = elapsedSec > 0 ? elapsedSec * 1000 : undefined;
     if (elapsedMs === undefined && evalCp === undefined) return undefined;
-    return { elapsedMs, evalCp: clampWireEvalForDisplay(evalCp) };
+    return { elapsedMs, ...wireEvalToReviewEval(evalCp) };
 }
 
 /** snapshot の moveDetails を moves と同順・同長の付随情報配列 (moveData) に変換する。 */
@@ -224,7 +212,7 @@ export function appendMoveEval(
 /**
  * onMoveComment 到着時に該当 ply の付随情報へ eval (先手視点) を後追いで書き込む。
  * ply は 1 始まり。範囲外・eval 無しコメントは配列を据え置く (消費秒は保持)。
- * 詰みセンチネルは snapshot 経路と同じく ±{@link MATE_DISPLAY_EVAL_CP} に丸める。
+ * 詰みセンチネルは snapshot 経路と同じく手数不明の mate として扱う。
  */
 export function setMoveEvalAtPly(
     prev: (ReviewMoveEval | undefined)[],
@@ -233,8 +221,9 @@ export function setMoveEvalAtPly(
 ): (ReviewMoveEval | undefined)[] {
     const idx = ply - 1;
     if (comment.evalCp === undefined || idx < 0 || idx >= prev.length) return prev;
+    const evalData = wireEvalToReviewEval(comment.evalCp);
     const next = prev.slice();
-    next[idx] = { ...next[idx], evalCp: clampWireEvalForDisplay(comment.evalCp) };
+    next[idx] = { ...next[idx], evalCp: evalData.evalCp, evalMate: evalData.evalMate };
     return next;
 }
 

--- a/packages/ui/src/components/shogi-match.test.ts
+++ b/packages/ui/src/components/shogi-match.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { analysisSnapshotEntryToRecordedEvalInfoEvent } from "./shogi-match";
+
+describe("analysisSnapshotEntryToRecordedEvalInfoEvent", () => {
+    it("initialAnalysisEntries 再適用用イベントには normalized:true を付ける", () => {
+        expect(
+            analysisSnapshotEntryToRecordedEvalInfoEvent({
+                ply: 1,
+                evalCp: 123,
+                evalMate: null,
+                depth: 10,
+                pv: ["3c3d"],
+                multiPv: null,
+            }),
+        ).toMatchObject({
+            type: "info",
+            scoreCp: 123,
+            scoreMate: undefined,
+            depth: 10,
+            pv: ["3c3d"],
+            multipv: 1,
+            normalized: true,
+        });
+    });
+});

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -40,7 +40,10 @@ import { useEnginePool } from "./shogi-match/hooks/useEnginePool";
 import { useGameControls } from "./shogi-match/hooks/useGameControls";
 import { type ReviewMoveEval, useKifuImportExport } from "./shogi-match/hooks/useKifuImportExport";
 import { useKifuKeyboardNavigation } from "./shogi-match/hooks/useKifuKeyboardNavigation";
-import { useKifuNavigation } from "./shogi-match/hooks/useKifuNavigation";
+import {
+    type RecordedEvalInfoEvent,
+    useKifuNavigation,
+} from "./shogi-match/hooks/useKifuNavigation";
 import { useLegalMovePrefetch } from "./shogi-match/hooks/useLegalMovePrefetch";
 import { useLocalStorage } from "./shogi-match/hooks/useLocalStorage";
 import { useIsMobile } from "./shogi-match/hooks/useMediaQuery";
@@ -98,6 +101,29 @@ const SPECTATE_DISPLAY_SETTINGS: DisplaySettings = {
     ...DEFAULT_DISPLAY_SETTINGS,
     showKifuEval: true,
 };
+
+const stringifyReviewMoveData = (moveData: (ReviewMoveEval | undefined)[] | undefined): string =>
+    moveData
+        ? JSON.stringify(moveData, (_key, value: unknown) =>
+              typeof value === "number" && !Number.isFinite(value)
+                  ? value > 0
+                      ? "Infinity"
+                      : "-Infinity"
+                  : value,
+          )
+        : "";
+
+export const analysisSnapshotEntryToRecordedEvalInfoEvent = (
+    entry: AnalysisSnapshotEntryDraft,
+): RecordedEvalInfoEvent => ({
+    type: "info",
+    scoreCp: entry.evalCp ?? undefined,
+    scoreMate: entry.evalMate ?? undefined,
+    depth: entry.depth ?? undefined,
+    pv: entry.pv ?? undefined,
+    multipv: 1,
+    normalized: true,
+});
 
 interface ShogiMatchProps {
     engineOptions: EngineOption[];
@@ -514,6 +540,8 @@ export function ShogiMatch({
     const lastAnalysisSnapshotSignatureRef = useRef<string | null>(null);
 
     useEffect(() => {
+        // JSON.stringify は Infinity を null にする。live 由来の手数なし詰み
+        // (evalMate=±Infinity) を流す場合は stringifyReviewMoveData 相当の変換が必要。
         const signature = analysisSnapshotDraft ? JSON.stringify(analysisSnapshotDraft) : null;
         if (lastAnalysisSnapshotSignatureRef.current === signature) {
             return;
@@ -1343,7 +1371,7 @@ export function ShogiMatch({
     // 届くライブ観戦) も再取込を発火させるため、内容シグネチャを取込判定に含める。
     // コメント到着で 1 回だけ安価な再取込が走るが、下の restorePly 復元でカーソルは
     // 維持され、盤・棋譜も据え置き再構築なのでちらつかない。
-    const reviewMoveDataKey = reviewMoveData ? JSON.stringify(reviewMoveData) : "";
+    const reviewMoveDataKey = stringifyReviewMoveData(reviewMoveData);
     useEffect(() => {
         if (
             !positionReady ||
@@ -1412,14 +1440,7 @@ export function ShogiMatch({
 
         for (const entry of initialAnalysisEntries) {
             clearEvalByPly(entry.ply);
-            recordEvalByPly(entry.ply, {
-                type: "info",
-                scoreCp: entry.evalCp ?? undefined,
-                scoreMate: entry.evalMate ?? undefined,
-                depth: entry.depth ?? undefined,
-                pv: entry.pv ?? undefined,
-                multipv: 1,
-            });
+            recordEvalByPly(entry.ply, analysisSnapshotEntryToRecordedEvalInfoEvent(entry));
         }
 
         initialAnalysisAppliedRef.current = signature;

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.test.ts
@@ -3,6 +3,7 @@ import { createInitialPositionState, setPositionServiceFactory } from "@shogi/ap
 import { beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_PASS_RIGHTS_SETTINGS } from "../types";
 import { normalizeEvalToSentePerspective } from "../utils/branchTreeUtils";
+import { formatEval, MATE_WITHOUT_PLY } from "../utils/kifFormat";
 import { useKifuImportExport } from "./useKifuImportExport";
 import type { UseKifuNavigationResult } from "./useKifuNavigation";
 
@@ -12,7 +13,7 @@ import type { UseKifuNavigationResult } from "./useKifuNavigation";
  *
  * ここで固定したいのは「wire (先手視点) の評価値が符号そのままで `normalized: true`
  * として addMove に渡り、奇数 ply でも偶数 ply でも符号反転しない」ことと、
- * 「詰みセンチネル ±100000 が evalCp のまま流れる」「elapsedMs が保持される」こと。
+ * 「手数不明の詰みが evalMate のまま流れる」「elapsedMs が保持される」こと。
  */
 
 // startpos を返すだけの最小 PositionService。importSfen は parseSfen のみ使う。
@@ -107,24 +108,40 @@ describe("importSfen: initialReview.moveData スレッディング", () => {
         });
     });
 
-    it("詰みセンチネル (viewer 側で ±2000 に丸め済み) は evalCp のまま流し、詰み手数 (scoreMate) を捏造しない", async () => {
-        // live viewer は wire の ±100000 センチネルを moveData 生成時に ±2000 へ丸める
-        // (rshogi-csa-live-viewer.tsx の MATE_DISPLAY_EVAL_CP。EvalGraph の autoscale を
-        // 潰さないため)。importSfen は受け取った値を符号・大きさとも変えずに素通しする。
+    it("手数不明の詰みは evalMate のまま流し、詰み手数を捏造しない", async () => {
         const { importSfen, addMoveCalls } = makeHarness();
         await importSfen("startpos", ["7g7f", "3c3d"], {
-            moveData: [{ evalCp: 2000 }, { evalCp: -2000 }],
+            moveData: [{ evalMate: MATE_WITHOUT_PLY }, { evalMate: -MATE_WITHOUT_PLY }],
         });
         expect(addMoveCalls[0].options?.eval).toEqual({
-            scoreCp: 2000,
-            scoreMate: undefined,
+            scoreCp: undefined,
+            scoreMate: MATE_WITHOUT_PLY,
             normalized: true,
         });
         expect(addMoveCalls[1].options?.eval).toEqual({
-            scoreCp: -2000,
-            scoreMate: undefined,
+            scoreCp: undefined,
+            scoreMate: -MATE_WITHOUT_PLY,
             normalized: true,
         });
+        expect(formatEval(undefined, addMoveCalls[0].options?.eval?.scoreMate)).toBe("+詰");
+        expect(formatEval(undefined, addMoveCalls[1].options?.eval?.scoreMate)).toBe("-詰");
+    });
+
+    it("実 mate は手数付きのまま analysis/kifu 表示まで維持される", async () => {
+        const { importSfen, addMoveCalls } = makeHarness();
+        await importSfen("startpos", ["7g7f", "3c3d"], {
+            moveData: [{ evalMate: 5 }, { evalMate: -7 }],
+        });
+        expect(normalizeEvalToSentePerspective(addMoveCalls[0].options?.eval, 1)).toEqual({
+            evalCp: undefined,
+            evalMate: 5,
+        });
+        expect(normalizeEvalToSentePerspective(addMoveCalls[1].options?.eval, 2)).toEqual({
+            evalCp: undefined,
+            evalMate: -7,
+        });
+        expect(formatEval(undefined, addMoveCalls[0].options?.eval?.scoreMate)).toBe("+詰5");
+        expect(formatEval(undefined, addMoveCalls[1].options?.eval?.scoreMate)).toBe("-詰7");
     });
 
     it("moveData が undefined の手は eval なしで addMove する (後方互換)", async () => {

--- a/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuImportExport.ts
@@ -28,8 +28,8 @@ export interface ReviewMoveEval {
     evalCp?: number;
     /**
      * 詰み手数 (先手視点、`+` = 先手勝ち)。
-     * ライブ観戦の wire は詰み手数を持たない (詰みは大きな evalCp センチネルで表現)
-     * ため通常は未設定。KIF インポート等の経路で詰み手数が判る場合のみ使う。
+     * 手数不明の詰みは ±Infinity で表す。KIF インポート等の経路で詰み手数が判る場合は
+     * 有限値を使う。
      */
     evalMate?: number;
 }

--- a/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.test.ts
@@ -1,0 +1,58 @@
+import { createInitialPositionState } from "@shogi/app-core";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useKifuNavigation } from "./useKifuNavigation";
+
+const setup = () =>
+    renderHook(() =>
+        useKifuNavigation({
+            initialPosition: createInitialPositionState(),
+            initialSfen: "startpos",
+        }),
+    );
+
+describe("useKifuNavigation", () => {
+    it("recordEvalByPly は normalized を KifuEval に転送する", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+        });
+        act(() => {
+            result.current.recordEvalByPly(1, {
+                type: "info",
+                scoreCp: 123,
+                depth: 10,
+                multipv: 1,
+                normalized: true,
+            });
+        });
+
+        const node = [...result.current.tree.nodes.values()].find((n) => n.ply === 1);
+        expect(node?.eval).toMatchObject({ scoreCp: 123, normalized: true });
+        expect(node?.multiPvEvals?.[0]).toMatchObject({ scoreCp: 123, normalized: true });
+    });
+
+    it("recordEvalByNodeId は normalized を KifuEval に転送する", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+        });
+        const nodeId = result.current.tree.currentNodeId;
+
+        act(() => {
+            result.current.recordEvalByNodeId(nodeId, {
+                type: "info",
+                scoreMate: 5,
+                depth: 12,
+                multipv: 1,
+                normalized: true,
+            });
+        });
+
+        const node = result.current.tree.nodes.get(nodeId);
+        expect(node?.eval).toMatchObject({ scoreMate: 5, normalized: true });
+        expect(node?.multiPvEvals?.[0]).toMatchObject({ scoreMate: 5, normalized: true });
+    });
+});

--- a/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
@@ -40,6 +40,8 @@ import { normalizeEvalToSentePerspective } from "../utils/branchTreeUtils";
 import type { EvalHistory, KifMove, MultiPvNodeData, NodeData } from "../utils/kifFormat";
 import { convertMovesToKif } from "../utils/kifFormat";
 
+export type RecordedEvalInfoEvent = EngineInfoEvent & Pick<KifuEval, "normalized">;
+
 /** USI形式の指し手からlastMove情報を導出 */
 function deriveLastMoveFromUsi(usiMove: string | null): { from?: string; to: string } | undefined {
     if (!usiMove) return undefined;
@@ -116,9 +118,9 @@ export interface UseKifuNavigationResult {
     /** 指し手を追加（分岐生成含む） */
     addMove: (usiMove: string, positionAfter: PositionState, options?: AddMoveOptions) => void;
     /** 評価値を記録（手数で指定） */
-    recordEvalByPly: (ply: number, event: EngineInfoEvent) => void;
+    recordEvalByPly: (ply: number, event: RecordedEvalInfoEvent) => void;
     /** 評価値を記録（ノードIDで指定、分岐内のノード用） */
-    recordEvalByNodeId: (nodeId: string, event: EngineInfoEvent) => void;
+    recordEvalByNodeId: (nodeId: string, event: RecordedEvalInfoEvent) => void;
     /** 評価値をクリア（手数で指定、再解析用） */
     clearEvalByPly: (ply: number) => void;
     /** 評価値をクリア（ノードIDで指定、再解析用） */
@@ -346,7 +348,7 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
      * 評価値を記録（手数で指定）
      * findNodeByPlyInCurrentPathを使用し、見つからなければfindNodeByPlyInMainLineで検索
      */
-    const recordEvalByPly = (ply: number, event: EngineInfoEvent) => {
+    const recordEvalByPly = (ply: number, event: RecordedEvalInfoEvent) => {
         setTree((prev) => {
             // 最適化: 現在位置からルートまで遡りながらplyに一致するノードを探す
             let nodeId = findNodeByPlyInCurrentPath(prev, ply);
@@ -365,6 +367,7 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
                 scoreMate: event.scoreMate,
                 depth: event.depth,
                 pv: event.pv,
+                normalized: event.normalized,
             };
 
             const multipv = event.multipv ?? 1;
@@ -402,7 +405,7 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
      * ノードIDを指定して評価値を記録
      * 分岐内のノードなど、plyだけでは特定できないノードに評価値を保存する場合に使用
      */
-    const recordEvalByNodeId = (nodeId: string, event: EngineInfoEvent) => {
+    const recordEvalByNodeId = (nodeId: string, event: RecordedEvalInfoEvent) => {
         setTree((prev) => {
             const node = prev.nodes.get(nodeId);
             if (!node) return prev;
@@ -412,6 +415,7 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
                 scoreMate: event.scoreMate,
                 depth: event.depth,
                 pv: event.pv,
+                normalized: event.normalized,
             };
 
             const multipv = event.multipv ?? 1;

--- a/packages/ui/src/components/shogi-match/utils/branchTreeUtils.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/branchTreeUtils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { normalizeEvalToSentePerspective } from "./branchTreeUtils";
+
+describe("normalizeEvalToSentePerspective", () => {
+    it("保存済みの先手視点 eval は normalized:true で奇数/偶数 ply とも bit 一致で往復する", () => {
+        const cases = [
+            { ply: 1, evalCp: 123, evalMate: undefined },
+            { ply: 2, evalCp: -456, evalMate: undefined },
+            { ply: 3, evalCp: undefined, evalMate: 7 },
+            { ply: 4, evalCp: undefined, evalMate: -9 },
+        ];
+
+        for (const { ply, evalCp, evalMate } of cases) {
+            const restored = normalizeEvalToSentePerspective(
+                {
+                    scoreCp: evalCp,
+                    scoreMate: evalMate,
+                    normalized: true,
+                },
+                ply,
+            );
+
+            expect(Object.is(restored.evalCp, evalCp)).toBe(true);
+            expect(Object.is(restored.evalMate, evalMate)).toBe(true);
+        }
+    });
+});

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
@@ -7,7 +7,9 @@ import {
     formatEval,
     formatMoveSimple,
     formatMoveToKif,
+    getEvalTooltipInfo,
     getPieceName,
+    MATE_WITHOUT_PLY,
     parseToSquare,
     squareToKanji,
 } from "./kifFormat";
@@ -234,9 +236,39 @@ describe("formatEval", () => {
         expect(formatEval(undefined, -3, 2)).toBe("-詰3");
     });
 
+    it("手数不明の詰みは手数を捏造せずにフォーマットする", () => {
+        expect(formatEval(undefined, MATE_WITHOUT_PLY)).toBe("+詰");
+        expect(formatEval(undefined, -MATE_WITHOUT_PLY)).toBe("-詰");
+        expect(getEvalTooltipInfo(undefined, MATE_WITHOUT_PLY)).toMatchObject({
+            description: "☗先手の勝ち",
+            detail: "手数不明の詰み",
+            advantage: "sente",
+        });
+        expect(getEvalTooltipInfo(undefined, -MATE_WITHOUT_PLY)).toMatchObject({
+            description: "☖後手の勝ち",
+            detail: "手数不明の詰み",
+            advantage: "gote",
+        });
+    });
+
     it("詰みが評価値より優先される", () => {
         expect(formatEval(100, 5)).toBe("+詰5");
         expect(formatEval(-100, -3)).toBe("-詰3");
+    });
+
+    it("実 mate は従来どおり手数付きで表示する", () => {
+        expect(formatEval(undefined, 7)).toBe("+詰7");
+        expect(formatEval(undefined, -11)).toBe("-詰11");
+        expect(getEvalTooltipInfo(undefined, 7)).toMatchObject({
+            description: "☗先手の勝ち",
+            detail: "7手詰み",
+            advantage: "sente",
+        });
+        expect(getEvalTooltipInfo(undefined, -11)).toMatchObject({
+            description: "☖後手の勝ち",
+            detail: "11手詰み",
+            advantage: "gote",
+        });
     });
 
     it("undefined の場合は空文字を返す", () => {

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.ts
@@ -8,6 +8,11 @@ import type { BoardState, Piece, PieceType, Player, PositionState, Square } from
 import { applyMoveWithState } from "@shogi/app-core";
 import { parseSfen } from "./kifParser";
 
+/** 手数不明の詰みを表す evalMate センチネル。符号は勝つ側を先手視点で表す。 */
+export const MATE_WITHOUT_PLY = Number.POSITIVE_INFINITY;
+
+const isMateWithoutPly = (evalMate: number): boolean => !Number.isFinite(evalMate);
+
 /** 単一PVの評価値情報 */
 export interface PvEvalInfo {
     /** PV番号（1-indexed） */
@@ -330,12 +335,16 @@ function squareToSimple(sq: string): string {
  * @param evalCp 評価値（センチポーン、先手視点）
  * @param evalMate 詰み手数（先手視点）
  * @param _ply 手数（後方互換性のため残すが使用しない）
- * @returns フォーマットされた文字列（例: "+5.0", "+詰3", "-詰5"）
+ * @returns フォーマットされた文字列（例: "+5.0", "+詰3", "-詰5", "+詰", "-詰"）
  */
 export function formatEval(evalCp?: number, evalMate?: number, _ply?: number): string {
     if (evalMate !== undefined && evalMate !== null) {
         // 先手視点に正規化済みなので、符号だけで判定
         // 符号式: +詰N（先手勝ち）、-詰N（後手勝ち）
+        // 手数不明の詰みは N を表示しない。
+        if (isMateWithoutPly(evalMate)) {
+            return evalMate > 0 ? "+詰" : "-詰";
+        }
         if (evalMate > 0) {
             return `+詰${evalMate}`;
         }
@@ -390,10 +399,13 @@ export function getEvalTooltipInfo(
         const winningSide = evalMate > 0 ? "sente" : "gote";
         const winnerMark = winningSide === "sente" ? "☗" : "☖";
         const winnerName = winningSide === "sente" ? "先手" : "後手";
+        const detail = isMateWithoutPly(evalMate)
+            ? "手数不明の詰み"
+            : `${Math.abs(evalMate)}手詰み`;
 
         return {
             description: `${winnerMark}${winnerName}の勝ち`,
-            detail: `${Math.abs(evalMate)}手詰み`,
+            detail,
             depthText: depth !== undefined ? `深さ${depth}` : null,
             advantage: winningSide,
         };
@@ -697,7 +709,9 @@ function formatEvalComment(evalCp?: number, evalMate?: number, depth?: number): 
 
     let evalStr: string;
     if (evalMate !== undefined && evalMate !== null) {
-        if (evalMate > 0) {
+        if (isMateWithoutPly(evalMate)) {
+            evalStr = evalMate > 0 ? "詰み" : "被詰み";
+        } else if (evalMate > 0) {
             evalStr = `詰${evalMate}手`;
         } else {
             evalStr = `被詰${Math.abs(evalMate)}手`;


### PR DESCRIPTION
Closes #69
Closes #71

## 変更内容

### #69: initialAnalysisEntries の符号往復バグ
- 再読込時に `normalized: true` を付与（KIF インポート / live importSfen と同じ契約に統一）
- `recordEvalByPly` / `recordEvalByNodeId` 両経路で `normalized` を `KifuEval` に転送
- 回帰テスト: 奇数/偶数 ply の往復で `Object.is` による bit 一致を検証。加えて hook 経由で記録経路そのものを assert するテストを追加（転送処理を外すと red になることを確認済み）

### #71: 手数なし詰みの表記
- `MATE_WITHOUT_PLY`（`evalMate = ±Infinity`）を導入し、wire センチネル ±100000 を ±2000 クランプではなく手数なし詰みとして流す
- 棋譜カラムは「+詰 / -詰」、tooltip は「手数不明の詰み」。実 mate（手数あり）の「+詰7」等は従来どおり
- `moveDataKey` 生成時の `Infinity` null 化対策（カスタム replacer で文字列化）
- 素の `JSON.stringify` 経路（analysisSnapshot signature / snapshot POST）に Infinity 注意コメントを付記

## 検証
- クリーンコンテキストレビュアー（Opus）による要件突き合わせ + コード精査: APPROVE（EvalGraph autoscale が ±Infinity で破壊されないこと、scoreboard の「詰み/詰まされ」経路との分離を確認済み）
- dev サーバー + headless Chromium で `/rshogi-viewer/live/mock-game` をスクリーンショット検証: 15手目の評価値カラムが「+20.0」→「+詰」に変化、評価値グラフは正常に上端へ振れ NaN/スケール破壊なし
- `turbo lint typecheck test`（match-client / ui / web / desktop）green（web の RoomPage は既知のローカル env 由来失敗のみ）、`knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C