### PR TITLE
fix(ui,match-client): 終局済み対局の live ページを静的表示へフォールバックし満席を区別表示

### DIFF
--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -80,9 +80,10 @@ export type {
     RshogiLiveMoveEvent,
     RshogiLiveSession,
     RshogiLiveSnapshot,
+    RshogiLiveStaticFallbackReason,
     RshogiLiveSubscribeOptions,
 } from "./rshogi-csa/live";
-export { subscribeRshogiLiveGame } from "./rshogi-csa/live";
+export { RshogiLiveRoomFullError, subscribeRshogiLiveGame } from "./rshogi-csa/live";
 export type {
     RoomClient,
     RoomClientOpenEvent,

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -3,7 +3,9 @@ import {
     __test_internals,
     type RshogiLiveCallbacks,
     type RshogiLiveConnectionState,
+    RshogiLiveRoomFullError,
     type RshogiLiveSnapshot,
+    type RshogiLiveStaticFallbackReason,
     subscribeRshogiLiveGame,
 } from "./live";
 
@@ -119,6 +121,7 @@ const makeMocks = () => {
         ends: [] as Array<unknown>,
         states: [] as RshogiLiveConnectionState[],
         errors: [] as Error[],
+        staticFallbacks: [] as RshogiLiveStaticFallbackReason[],
     };
     const callbacks: RshogiLiveCallbacks = {
         onSnapshot: (s) => {
@@ -141,6 +144,9 @@ const makeMocks = () => {
         },
         onError: (e) => {
             events.errors.push(e);
+        },
+        onStaticFallbackRequested: (reason) => {
+            events.staticFallbacks.push(reason);
         },
     };
     return { wsInstances, wsFactory, events, callbacks };
@@ -247,6 +253,7 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         ws.fireLines(buildSnapshotLines(["+7776FU,T8", "-3334FU,T7"], "#RESIGN"));
         expect(events.snapshot.length).toBe(1);
         expect(events.ends.length).toBe(1);
+        expect(events.staticFallbacks).toEqual(["terminal-snapshot"]);
     });
 });
 
@@ -539,6 +546,7 @@ describe("subscribeRshogiLiveGame: 再接続", () => {
         expect(wsInstances.length).toBe(backoff.length + 1);
         expect(events.states.at(-1)).toBe("closed");
         expect(events.errors.some((e) => e.message.includes("上限"))).toBe(true);
+        expect(events.staticFallbacks).toEqual(["reconnect-limit-reached"]);
     });
 
     it("安定接続 (STABLE_CONNECTION_MS 継続) 後は attempt がリセットされ、散発的な切断では上限に達しない", () => {
@@ -600,10 +608,83 @@ describe("subscribeRshogiLiveGame: NOT_FOUND", () => {
             ws.fireOpen();
             ws.fireLines(["##[MONITOR2] NOT_FOUND game-x", "##[MONITOR2] END"]);
             expect(events.errors.length).toBeGreaterThanOrEqual(1);
+            expect(events.staticFallbacks).toEqual(["not-found"]);
             expect(ws.closeArgs?.code).toBe(1000);
             ws.fireClose(1000, "not found");
             vi.advanceTimersByTime(60000);
             expect(wsInstances.length).toBe(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
+
+describe("subscribeRshogiLiveGame: room full", () => {
+    it("close code 1013 + reason room full なら満席エラーとして閉じ、reconnect しない", () => {
+        vi.useFakeTimers();
+        try {
+            const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+                callbacks,
+            );
+            const ws = wsInstances[0];
+            ws.fireOpen();
+            ws.fireClose(1013, "room full");
+
+            vi.advanceTimersByTime(60000);
+            expect(events.states.at(-1)).toBe("closed");
+            expect(events.errors[0]).toBeInstanceOf(RshogiLiveRoomFullError);
+            expect(events.errors[0].message).toContain("観戦者数が上限");
+            expect(wsInstances.length).toBe(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("MONITOR2 の room full エラー行も満席として扱う", () => {
+        vi.useFakeTimers();
+        try {
+            const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+                callbacks,
+            );
+            const ws = wsInstances[0];
+            ws.fireOpen();
+            ws.fireLines(["##[MONITOR2] ERROR 503 room full"]);
+
+            expect(ws.closeArgs?.reason).toBe("room full");
+            expect(events.states.at(-1)).toBe("closed");
+            expect(events.errors[0]).toBeInstanceOf(RshogiLiveRoomFullError);
+            ws.fireClose(1000, "room full");
+            vi.advanceTimersByTime(60000);
+            expect(wsInstances.length).toBe(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("room full ではない MONITOR2 ERROR 行は接続を維持する", () => {
+        vi.useFakeTimers();
+        try {
+            const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+                callbacks,
+            );
+            const ws = wsInstances[0];
+            ws.fireOpen();
+            ws.fireLines(["##[MONITOR2] ERROR temporary backend warning"]);
+
+            expect(ws.closeArgs).toBeUndefined();
+            expect(events.errors).toEqual([]);
+            expect(events.states.at(-1)).toBe("connected");
+            ws.fireLines(buildSnapshotLines(["+7776FU,T8"]));
+            expect(events.snapshot.length).toBe(1);
         } finally {
             vi.useRealTimers();
         }

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -153,6 +153,18 @@ export interface RshogiLiveClockEvent {
 
 export type RshogiLiveConnectionState = "connecting" | "connected" | "reconnecting" | "closed";
 
+export type RshogiLiveStaticFallbackReason =
+    | "terminal-snapshot"
+    | "reconnect-limit-reached"
+    | "not-found";
+
+export class RshogiLiveRoomFullError extends Error {
+    constructor(message = "観戦者数が上限に達しているため、この対局を観戦できません") {
+        super(message);
+        this.name = "RshogiLiveRoomFullError";
+    }
+}
+
 export interface RshogiLiveCallbacks {
     /** 初回 + 再接続時に毎回呼ばれる (state を全置換)。 */
     onSnapshot(snapshot: RshogiLiveSnapshot): void;
@@ -171,6 +183,11 @@ export interface RshogiLiveCallbacks {
     onConnectionState(state: RshogiLiveConnectionState): void;
     /** 解析・WS エラー通知 (致命的でないものも含む)。 */
     onError(err: Error): void;
+    /**
+     * live 接続では進行中表示を続けられないが、終局済棋譜として表示できる可能性が
+     * 高いときに呼ばれる。consumer は `GET /api/v1/games/<id>` に切り替える。
+     */
+    onStaticFallbackRequested?(reason: RshogiLiveStaticFallbackReason): void;
 }
 
 export interface RshogiLiveSubscribeOptions {
@@ -597,6 +614,23 @@ const parseLiveComment = (line: string): RshogiLiveComment => {
     return { raw };
 };
 
+const isRoomFullText = (value: string): boolean => {
+    const normalized = value.toLowerCase();
+    return (
+        normalized.includes("room full") ||
+        (normalized.includes("spectator") && normalized.includes("full")) ||
+        normalized.includes("too many spectators") ||
+        (normalized.includes("観戦") && normalized.includes("上限")) ||
+        normalized.includes("満席")
+    );
+};
+
+const maybeRoomFullLineError = (line: string): RshogiLiveRoomFullError | null =>
+    isRoomFullText(line) ? new RshogiLiveRoomFullError() : null;
+
+const maybeRoomFullCloseError = (event: CloseEvent): RshogiLiveRoomFullError | null =>
+    event.code === 1013 && isRoomFullText(event.reason) ? new RshogiLiveRoomFullError() : null;
+
 /**
  * モック観戦 (apiBaseUrl 未指定かつ gameId が `mock-` で始まる場合) が配信する
  * 固定 snapshot の wire 行群。
@@ -866,6 +900,34 @@ export function subscribeRshogiLiveGame(
         }
     };
 
+    const requestStaticFallback = (reason: RshogiLiveStaticFallbackReason) => {
+        if (disposed) return;
+        try {
+            callbacks.onStaticFallbackRequested?.(reason);
+        } catch (err) {
+            emitError(
+                err instanceof Error
+                    ? err
+                    : new Error(`onStaticFallbackRequested handler threw: ${String(err)}`),
+            );
+        }
+    };
+
+    const closeAsRoomFull = (err: RshogiLiveRoomFullError) => {
+        emitError(err);
+        disposed = true;
+        cancelReconnect();
+        clearStableTimer();
+        const currentWs = ws;
+        ws = null;
+        try {
+            currentWs?.close(1000, "room full");
+        } catch {
+            // 失敗は無視
+        }
+        emitConnectionState("closed");
+    };
+
     const cancelReconnect = () => {
         if (reconnectTimer !== null) {
             clearTimeoutImpl(reconnectTimer);
@@ -887,6 +949,7 @@ export function subscribeRshogiLiveGame(
         // 上限到達: これ以上は再接続せず確定 closed にする (無限 flap を断ち切る)。
         // emitError は disposed 中は無視される契約なので、disposed を立てる前に通知する。
         if (reconnectAttempt >= MAX_RECONNECT_ATTEMPTS) {
+            requestStaticFallback("reconnect-limit-reached");
             emitError(new Error("再接続の上限に達したため観戦を終了しました"));
             disposed = true;
             emitConnectionState("closed");
@@ -944,6 +1007,7 @@ export function subscribeRshogiLiveGame(
             }
             // 終局済 DO に接続したケース: snapshot 内に result_code 行がある。
             if (finalResultLine && snapshot.finalResult) {
+                requestStaticFallback("terminal-snapshot");
                 handleEndDetected(snapshot.finalResult);
             }
         } catch (err) {
@@ -1023,6 +1087,7 @@ export function subscribeRshogiLiveGame(
         if (trimmed.startsWith("##[MONITOR2] NOT_FOUND")) {
             // server 側で active/finished のいずれにも一致しなかった。
             // reconnect しても結果は変わらないので close する。
+            requestStaticFallback("not-found");
             emitError(new Error(`spectate target not found: ${trimmed}`));
             disposed = true;
             cancelReconnect();
@@ -1032,6 +1097,13 @@ export function subscribeRshogiLiveGame(
                 // 失敗は無視
             }
             emitConnectionState("closed");
+            return;
+        }
+        if (trimmed.startsWith("##[MONITOR2] ERROR")) {
+            const roomFullError = maybeRoomFullLineError(trimmed);
+            if (roomFullError) {
+                closeAsRoomFull(roomFullError);
+            }
             return;
         }
         if (inSnapshot) {
@@ -1125,7 +1197,7 @@ export function subscribeRshogiLiveGame(
             emitError(new Error("WebSocket error"));
         };
 
-        socket.onclose = () => {
+        socket.onclose = (event: CloseEvent) => {
             if (ws !== socket) return;
             ws = null;
             // 接続が閉じたので安定判定タイマーは無効化する (close から先は flap 扱い)。
@@ -1135,6 +1207,11 @@ export function subscribeRshogiLiveGame(
             inSnapshot = false;
             if (disposed) {
                 emitConnectionState("closed");
+                return;
+            }
+            const roomFullError = maybeRoomFullCloseError(event);
+            if (roomFullError) {
+                closeAsRoomFull(roomFullError);
                 return;
             }
             // `onEnd` 発火済の場合、close code に関わらず reconnect しない。

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -1,6 +1,7 @@
 import type { RshogiGameMeta, RshogiLiveMove, RshogiTimeControl } from "@shogi/match-client";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     appendMoveEval,
     applyMoveComment,
@@ -10,12 +11,27 @@ import {
     formatOwnEval,
     type LiveClocks,
     moveDetailsToEvals,
+    RshogiCsaLiveViewer,
     RshogiLiveMetaPanel,
     RshogiLiveScoreboard,
     setMoveEvalAtPly,
     summarizeMoveDetails,
 } from "./rshogi-csa-live-viewer";
 import { formatEval, MATE_WITHOUT_PLY } from "./shogi-match/utils/kifFormat";
+
+vi.mock("./shogi-match", () => ({
+    ShogiMatch: ({
+        initialReview,
+        reviewLeftContent,
+    }: {
+        initialReview?: { moves?: string[] };
+        reviewLeftContent?: ReactNode;
+    }) => (
+        <div data-testid="shogi-match" data-move-count={initialReview?.moves?.length ?? 0}>
+            {reviewLeftContent}
+        </div>
+    ),
+}));
 
 const META: RshogiGameMeta = { gameId: "game-1", senteName: "alice", goteName: "bob" };
 
@@ -55,6 +71,189 @@ const SUDDEN_DEATH: RshogiTimeControl = {
     mainSeconds: 300,
     byoyomiSeconds: 0,
 };
+
+class MockWebSocket {
+    static instances: MockWebSocket[] = [];
+    readyState = 0;
+    sent: string[] = [];
+    closeArgs?: { code: number; reason: string };
+    onopen: (() => void) | null = null;
+    onmessage: ((ev: { data: string }) => void) | null = null;
+    onclose: ((ev: { code: number; reason: string; wasClean: boolean }) => void) | null = null;
+    onerror: ((ev: Event) => void) | null = null;
+
+    constructor(public readonly url: string) {
+        MockWebSocket.instances.push(this);
+    }
+
+    send(data: string): void {
+        this.sent.push(data);
+    }
+
+    close(code?: number, reason?: string): void {
+        this.closeArgs = { code: code ?? 1000, reason: reason ?? "" };
+    }
+
+    fireOpen(): void {
+        this.readyState = 1;
+        this.onopen?.();
+    }
+
+    fireLines(lines: string[]): void {
+        this.onmessage?.({ data: `${lines.join("\n")}\n` });
+    }
+
+    fireClose(code: number, reason = ""): void {
+        this.readyState = 3;
+        this.onclose?.({ code, reason, wasClean: code === 1000 });
+    }
+}
+
+const LIVE_SNAPSHOT_LINES = [
+    "##[MONITOR2] BEGIN game-1",
+    "BEGIN Game_Summary",
+    "Game_ID:game-1",
+    "Name+:alice",
+    "Name-:bob",
+    "To_Move:+",
+    "Black_Time_Remaining_Ms:600000",
+    "White_Time_Remaining_Ms:600000",
+    "END Game_Summary",
+];
+
+const buildLiveSnapshot = (moves: string[] = [], finalCode?: string): string[] => {
+    const lines = [...LIVE_SNAPSHOT_LINES, ...moves];
+    if (finalCode) lines.push(finalCode);
+    lines.push("##[MONITOR2] END");
+    return lines;
+};
+
+const createStaticGameFetch = () =>
+    vi.fn(
+        async () =>
+            new Response(
+                JSON.stringify({
+                    game_id: "game-1",
+                    black_handle: "alice",
+                    white_handle: "bob",
+                    result_kind: "WIN_WHITE",
+                    end_reason: "RESIGN",
+                    csa: "V2.2\nN+alice\nN-bob\nPI\n+\n+7776FU\n%TORYO\n",
+                }),
+                { status: 200, headers: { "content-type": "application/json" } },
+            ),
+    ) as unknown as typeof fetch;
+
+describe("RshogiCsaLiveViewer: static fallback", () => {
+    beforeEach(() => {
+        MockWebSocket.instances = [];
+        vi.stubGlobal("WebSocket", MockWebSocket);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("terminal snapshot を受けたら GET /games/<id> の静的終局表示へ切り替える", async () => {
+        const fetchOverride = createStaticGameFetch();
+
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+                fetchOverride={fetchOverride}
+            />,
+        );
+
+        const ws = MockWebSocket.instances[0];
+        act(() => {
+            ws.fireOpen();
+            ws.fireLines(buildLiveSnapshot(["+7776FU,T8"], "#RESIGN"));
+        });
+
+        await waitFor(() => {
+            expect(fetchOverride).toHaveBeenCalledWith(
+                "https://example.com/api/v1/games/game-1",
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
+        });
+        await waitFor(() => {
+            expect(
+                screen.getByText("ライブ接続は終了済みのため、保存済み棋譜を表示しています。"),
+            ).toBeTruthy();
+        });
+        expect(screen.getByTestId("shogi-match").getAttribute("data-move-count")).toBe("1");
+        expect(screen.getByText("後手 (bob) 勝ち (投了)")).toBeTruthy();
+    });
+
+    it("reconnect 上限到達時に静的終局表示へ切り替え、上限エラーを二重表示しない", async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchOverride = createStaticGameFetch();
+            render(
+                <RshogiCsaLiveViewer
+                    gameId="game-1"
+                    engineOptions={[]}
+                    manifestUrl="/nnue/manifest.json"
+                    apiBaseUrl="https://example.com/api/v1"
+                    fetchOverride={fetchOverride}
+                />,
+            );
+
+            const backoff = [1000, 2000, 4000, 8000, 16000, 30000];
+            act(() => {
+                MockWebSocket.instances[0].fireOpen();
+                MockWebSocket.instances[0].fireClose(1006, "flap");
+            });
+            for (let i = 0; i < backoff.length; i++) {
+                await act(async () => {
+                    vi.advanceTimersByTime(backoff[i]);
+                });
+                act(() => {
+                    MockWebSocket.instances[i + 1].fireOpen();
+                    MockWebSocket.instances[i + 1].fireClose(1006, "flap");
+                });
+            }
+
+            await act(async () => {});
+            await act(async () => {});
+            expect(fetchOverride).toHaveBeenCalled();
+            expect(
+                screen.getByText("ライブ接続は終了済みのため、保存済み棋譜を表示しています。"),
+            ).toBeTruthy();
+            expect(screen.queryByText(/再接続の上限/)).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("満席 close は専用メッセージを表示し、reconnect しない", async () => {
+        vi.useFakeTimers();
+        try {
+            render(
+                <RshogiCsaLiveViewer
+                    gameId="game-1"
+                    engineOptions={[]}
+                    manifestUrl="/nnue/manifest.json"
+                    apiBaseUrl="https://example.com/api/v1"
+                />,
+            );
+
+            act(() => {
+                MockWebSocket.instances[0].fireOpen();
+                MockWebSocket.instances[0].fireClose(1013, "room full");
+                vi.advanceTimersByTime(60000);
+            });
+
+            expect(screen.getByText(/観戦者数が上限/)).toBeTruthy();
+            expect(MockWebSocket.instances.length).toBe(1);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});
 
 describe("computeRemaining", () => {
     it("手番側 (sideToMove) のみ経過分を減算し、相手側は据え置く", () => {

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -12,16 +12,23 @@
  * - 終局時に最終結果を表示する。
  */
 
+import { parseCsaMoves } from "@shogi/app-core";
 import { cn } from "@shogi/design-system";
 import {
+    type FetchRshogiGameOptions,
+    fetchRshogiGame,
     type RshogiClockKind,
+    type RshogiGame,
     type RshogiGameMeta,
+    RshogiGameNotFoundError,
     type RshogiGameResult,
     type RshogiLiveCallbacks,
     type RshogiLiveConnectionState,
     type RshogiLiveMove,
+    RshogiLiveRoomFullError,
     type RshogiLiveSession,
     type RshogiLiveSnapshot,
+    type RshogiLiveStaticFallbackReason,
     type RshogiTimeControl,
     subscribeRshogiLiveGame,
 } from "@shogi/match-client";
@@ -37,6 +44,8 @@ export interface RshogiCsaLiveViewerProps {
     manifestUrl: string;
     /** rshogi 観戦 WS のベース URL (例: `wss://csa.example.com`)。空のときは MVP のフォールバックモード。 */
     apiBaseUrl?: string;
+    /** 主にテスト・SSR で静的 fallback の fetch を差し替えるためのフック */
+    fetchOverride?: FetchRshogiGameOptions["fetchImpl"];
     /** ヘッダ等の追加レイアウト要素 */
     header?: ReactNode;
     aiIconUrl?: string;
@@ -105,7 +114,20 @@ interface LiveState {
     latestPv?: string[];
     /** 直近手の消費秒数 (`,T` 由来)。旧サーバや未着手時は undefined。 */
     lastMoveElapsedSec?: number;
+    /** live 観戦から静的終局表示へ切り替える fallback の状態。 */
+    staticFallback?: StaticFallbackState;
 }
+
+type StaticFallbackState =
+    | { status: "loading"; reason: RshogiLiveStaticFallbackReason }
+    | {
+          status: "ready";
+          reason: RshogiLiveStaticFallbackReason;
+          game: RshogiGame;
+          moves: string[];
+      }
+    | { status: "not-found"; reason: RshogiLiveStaticFallbackReason }
+    | { status: "error"; reason: RshogiLiveStaticFallbackReason; errorMessage: string };
 
 const initialLiveState: LiveState = {
     snapshot: null,
@@ -668,6 +690,7 @@ export function RshogiCsaLiveViewer({
     engineOptions,
     manifestUrl,
     apiBaseUrl,
+    fetchOverride,
     header,
     aiIconUrl,
     fetchLegalMoves,
@@ -684,6 +707,73 @@ export function RshogiCsaLiveViewer({
         // gameId / apiBaseUrl が変わったら state をリセットして再購読。
         setState(initialLiveState);
         setTickMs(Date.now());
+        let staticFallbackController: AbortController | null = null;
+        const loadStaticFallback = (reason: RshogiLiveStaticFallbackReason) => {
+            if (staticFallbackController) return;
+            staticFallbackController = new AbortController();
+            setState((prev) => ({
+                ...prev,
+                connectionState: "closed",
+                staticFallback: { status: "loading", reason },
+                lastError: undefined,
+            }));
+            void (async () => {
+                const controller = staticFallbackController;
+                if (!controller) return;
+                try {
+                    const game = await fetchRshogiGame(gameId, {
+                        baseUrl: apiBaseUrl,
+                        fetchImpl: fetchOverride,
+                        signal: controller.signal,
+                    });
+                    if (controller.signal.aborted) return;
+                    let moves: string[];
+                    try {
+                        moves = parseCsaMoves(game.csa);
+                    } catch (parseError) {
+                        setState((prev) => ({
+                            ...prev,
+                            staticFallback: prev.snapshot
+                                ? undefined
+                                : {
+                                      status: "error",
+                                      reason,
+                                      errorMessage: `終局済み棋譜の解析に失敗しました: ${String(parseError)}`,
+                                  },
+                        }));
+                        return;
+                    }
+                    setState((prev) => ({
+                        ...prev,
+                        staticFallback: { status: "ready", reason, game, moves },
+                    }));
+                } catch (error) {
+                    if (controller.signal.aborted) return;
+                    if (error instanceof RshogiGameNotFoundError) {
+                        setState((prev) => ({
+                            ...prev,
+                            staticFallback: prev.snapshot
+                                ? undefined
+                                : { status: "not-found", reason },
+                        }));
+                        return;
+                    }
+                    setState((prev) => ({
+                        ...prev,
+                        staticFallback: prev.snapshot
+                            ? undefined
+                            : {
+                                  status: "error",
+                                  reason,
+                                  errorMessage:
+                                      error instanceof Error
+                                          ? error.message
+                                          : `終局済み棋譜の読み込みに失敗しました: ${String(error)}`,
+                              },
+                    }));
+                }
+            })();
+        };
         const callbacks: RshogiLiveCallbacks = {
             onSnapshot(snapshot) {
                 const summary = summarizeMoveDetails(snapshot.moveDetails);
@@ -774,7 +864,20 @@ export function RshogiCsaLiveViewer({
                 setState((prev) => ({ ...prev, connectionState: connState }));
             },
             onError(err) {
-                setState((prev) => ({ ...prev, lastError: err.message }));
+                setState((prev) => ({
+                    ...prev,
+                    ...(prev.staticFallback?.status === "loading"
+                        ? {}
+                        : {
+                              lastError:
+                                  err instanceof RshogiLiveRoomFullError
+                                      ? err.message
+                                      : `ライブ観戦エラー: ${err.message}`,
+                          }),
+                }));
+            },
+            onStaticFallbackRequested(reason) {
+                loadStaticFallback(reason);
             },
         };
         let session: RshogiLiveSession | null = null;
@@ -789,10 +892,11 @@ export function RshogiCsaLiveViewer({
         }
         sessionRef.current = session;
         return () => {
+            staticFallbackController?.abort();
             session?.disconnect();
             sessionRef.current = null;
         };
-    }, [gameId, apiBaseUrl]);
+    }, [gameId, apiBaseUrl, fetchOverride]);
 
     // 終局が確定したら購読を明示的に閉じる。終局済 DO は「接続成功→即 close」を
     // 繰り返すことがあり、これを止めないと connected↔reconnecting を往復し続ける。
@@ -816,6 +920,37 @@ export function RshogiCsaLiveViewer({
     const elapsedSinceAnchor =
         state.clockAnchorAtMs !== null ? Math.max(0, tickMs - state.clockAnchorAtMs) : 0;
 
+    if (state.staticFallback?.status === "ready") {
+        const { game, moves } = state.staticFallback;
+        return (
+            <div className="flex flex-col gap-2">
+                {header}
+                <div className="px-4 pt-2 text-xs text-muted-foreground">
+                    ライブ接続は終了済みのため、保存済み棋譜を表示しています。
+                </div>
+                <ShogiMatch
+                    key={`static-${game.meta.gameId}`}
+                    engineOptions={engineOptions}
+                    manifestUrl={manifestUrl}
+                    aiIconUrl={aiIconUrl}
+                    fetchLegalMoves={fetchLegalMoves}
+                    onRequestNnueFilePath={onRequestNnueFilePath}
+                    isDevMode={isDevMode}
+                    defaultSides={{
+                        sente: { role: "human" },
+                        gote: { role: "human" },
+                    }}
+                    initialReview={{ sfen: "startpos", moves }}
+                    reviewMode={true}
+                    spectateMode={true}
+                    reviewLeftContent={
+                        <RshogiLiveMetaPanel meta={game.meta} result={game.meta.result} />
+                    }
+                />
+            </div>
+        );
+    }
+
     if (!state.snapshot) {
         // 初回 snapshot 受信前のローディング表示。
         // `packages/ui/AGENTS.md` の規約に従い、コンポーネント自身は margin
@@ -832,6 +967,15 @@ export function RshogiCsaLiveViewer({
                     <span>対局 ID: {gameId}</span>
                 </div>
                 <p>初期 snapshot を待機中...</p>
+                {state.staticFallback?.status === "loading" && <p>終局済み棋譜を読み込み中...</p>}
+                {state.staticFallback?.status === "not-found" && (
+                    <p className="text-destructive">
+                        終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。
+                    </p>
+                )}
+                {state.staticFallback?.status === "error" && (
+                    <p className="text-destructive">{state.staticFallback.errorMessage}</p>
+                )}
                 {state.lastError && <p className="text-destructive">エラー: {state.lastError}</p>}
             </div>
         );
@@ -849,6 +993,21 @@ export function RshogiCsaLiveViewer({
                 行の出現でレイアウトシフトが連発するため、振動する状態では出さない。 */}
             {!state.result && state.connectionState === "closed" && state.lastError && (
                 <div className="px-4 pt-2 text-xs text-destructive">{state.lastError}</div>
+            )}
+            {state.staticFallback?.status === "loading" && (
+                <div className="px-4 pt-2 text-xs text-muted-foreground">
+                    終局済み棋譜を読み込み中...
+                </div>
+            )}
+            {state.staticFallback?.status === "not-found" && (
+                <div className="px-4 pt-2 text-xs text-destructive">
+                    終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。
+                </div>
+            )}
+            {state.staticFallback?.status === "error" && (
+                <div className="px-4 pt-2 text-xs text-destructive">
+                    {state.staticFallback.errorMessage}
+                </div>
             )}
             <ShogiMatch
                 key={matchKey}


### PR DESCRIPTION
Closes #67

## 変更内容

- 終局 snapshot の結果コード受信時 / 再接続上限到達時 / NOT_FOUND 受信時に `GET /api/v1/games/<id>` で棋譜を取得して静的表示へフォールバック（match-client に `onStaticFallbackRequested` を追加）
- 観戦上限（満席）は **close(1013, reason "room full")** と `##[MONITOR2] ERROR` の room full 明示文言の2経路のみで判定し、「満席」として区別表示・リトライなし
  - WebSocket handshake の HTTP 503 拒否はブラウザから検知不能（onclose 1006/reason 空）なため、サーバー側 SH11235/rshogi#864 で「満席時は accept 直後に close(1013, "room full")」契約に統一（対応 PR は rshogi 側で別途）
- 非 room-full の `##[MONITOR2] ERROR` 行は従来どおり無視して接続維持（挙動リグレッションなし）
- terminal snapshot 保持時はフォールバック取得失敗のエラー表示を抑制、再接続上限エラーとの二重表示を解消

## 検証

- クリーンコンテキストレビュアー（Opus）2周: 初回 REQUEST_CHANGES（major 2 / minor 8）→ 全指摘修正後 **APPROVE**
- 追加テスト: 非 room-full ERROR 行での接続維持 / close(1013) 満席停止・リトライなし / NOT_FOUND フォールバック / reconnect 上限→フォールバック統合（fake timer で実 backoff 6回駆動）/ 満席 UI 表示。viewer テストは act() 化済み
- dev サーバー + headless Chromium で `/rshogi-viewer/live/mock-game` の描画に回帰がないことをスクリーンショット確認
- PR #72 マージ後の main に rebase 済み。`turbo lint typecheck test`（RoomPage のローカル env 由来失敗のみ既知許容）、`knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C