### PR TITLE
perf(ui): live 観戦のコメント到着を差分適用にして importSfen full 再取込を排除

### DIFF
--- a/packages/ui/src/components/shogi-match.test.ts
+++ b/packages/ui/src/components/shogi-match.test.ts
@@ -1,5 +1,15 @@
+import { applyMoveWithState, createInitialPositionState } from "@shogi/app-core";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
-import { analysisSnapshotEntryToRecordedEvalInfoEvent } from "./shogi-match";
+import {
+    analysisSnapshotEntryToRecordedEvalInfoEvent,
+    applyReviewMoveDataDiff,
+    getInitialReviewSyncMode,
+    stringifyReviewMoveData,
+    useInitialReviewSync,
+} from "./shogi-match";
+import type { ReviewMoveEval } from "./shogi-match/hooks/useKifuImportExport";
+import { useKifuNavigation } from "./shogi-match/hooks/useKifuNavigation";
 
 describe("analysisSnapshotEntryToRecordedEvalInfoEvent", () => {
     it("initialAnalysisEntries 再適用用イベントには normalized:true を付ける", () => {
@@ -21,5 +31,201 @@ describe("analysisSnapshotEntryToRecordedEvalInfoEvent", () => {
             multipv: 1,
             normalized: true,
         });
+    });
+});
+
+describe("initialReview sync", () => {
+    it("moveData key は NaN と ±Infinity を区別して直列化する", () => {
+        expect(
+            stringifyReviewMoveData([
+                { evalMate: Number.POSITIVE_INFINITY },
+                { evalMate: Number.NEGATIVE_INFINITY },
+                { evalCp: Number.NaN },
+            ]),
+        ).toBe('[{"evalMate":"Infinity"},{"evalMate":"-Infinity"},{"evalCp":null}]');
+    });
+
+    it("指し手が増えた場合は import 経路、moveData のみ変わった場合は差分適用経路を選ぶ", () => {
+        const loaded = {
+            sfen: "startpos",
+            movesKey: "7g7f",
+            moveDataKey: "[null]",
+        };
+
+        expect(getInitialReviewSyncMode(loaded, loaded)).toBe("skip");
+        expect(
+            getInitialReviewSyncMode(loaded, {
+                ...loaded,
+                movesKey: "7g7f 3c3d",
+            }),
+        ).toBe("import");
+        expect(
+            getInitialReviewSyncMode(loaded, {
+                ...loaded,
+                moveDataKey: '[{"evalCp":100}]',
+            }),
+        ).toBe("diff");
+    });
+
+    it("コメント到着時は importSfen 相当を呼ばず、既存 ply へ差分適用する", () => {
+        const calls: Array<{
+            ply: number;
+            update: { elapsedMs?: number; scoreCp?: number; scoreMate?: number };
+            usiMove?: string;
+        }> = [];
+        const navigation = {
+            updateMoveEvalAtPly: (
+                ply: number,
+                update: { elapsedMs?: number; scoreCp?: number; scoreMate?: number } | undefined,
+                options?: { usiMove?: string },
+            ): "applied" | "preserved" | "missing" => {
+                if (!update) return "preserved";
+                calls.push({ ply, update, usiMove: options?.usiMove });
+                return "applied";
+            },
+        };
+
+        applyReviewMoveDataDiff(
+            navigation,
+            ["7g7f", "3c3d"],
+            [{ evalCp: 111, elapsedMs: 1000 }],
+            [{ evalCp: 123, elapsedMs: 1000 }, { evalMate: Number.POSITIVE_INFINITY }],
+        );
+
+        expect(calls).toEqual([
+            {
+                ply: 1,
+                update: { elapsedMs: 1000, scoreCp: 123, scoreMate: undefined },
+                usiMove: "7g7f",
+            },
+            {
+                ply: 2,
+                update: {
+                    elapsedMs: undefined,
+                    scoreCp: undefined,
+                    scoreMate: Number.POSITIVE_INFINITY,
+                },
+                usiMove: "3c3d",
+            },
+        ]);
+    });
+});
+
+const setupInitialReviewSyncHarness = (initialReview: {
+    sfen: string;
+    moves: string[];
+    moveData?: (ReviewMoveEval | undefined)[];
+}) => {
+    const importCalls: Array<{
+        sfen: string;
+        moves: string[];
+        moveData?: (ReviewMoveEval | undefined)[];
+    }> = [];
+
+    const hook = renderHook(
+        ({ review }) => {
+            const navigation = useKifuNavigation({
+                initialPosition: createInitialPositionState(),
+                initialSfen: "startpos",
+            });
+
+            const importSfen = async (
+                sfen: string,
+                moves: string[],
+                options?: {
+                    gotoPly?: number;
+                    moveData?: (ReviewMoveEval | undefined)[];
+                    isStale?: () => boolean;
+                },
+            ) => {
+                importCalls.push({ sfen, moves: [...moves], moveData: options?.moveData });
+                if (options?.isStale?.()) return;
+
+                navigation.reset(createInitialPositionState(), sfen);
+                let position = createInitialPositionState();
+                for (let index = 0; index < moves.length; index++) {
+                    const move = moves[index];
+                    const applied = applyMoveWithState(position, move, { validateTurn: false });
+                    if (!applied.ok) break;
+
+                    const data = options?.moveData?.[index];
+                    navigation.addMove(move, applied.next, {
+                        elapsedMs: data?.elapsedMs,
+                        eval:
+                            data?.evalCp !== undefined || data?.evalMate !== undefined
+                                ? {
+                                      scoreCp: data.evalCp,
+                                      scoreMate: data.evalMate,
+                                      normalized: true,
+                                  }
+                                : undefined,
+                    });
+                    position = applied.next;
+                }
+            };
+
+            useInitialReviewSync({
+                positionReady: true,
+                initialReview: review,
+                navigation,
+                importSfen,
+            });
+
+            return navigation;
+        },
+        { initialProps: { review: initialReview } },
+    );
+
+    return { ...hook, importCalls };
+};
+
+describe("useInitialReviewSync", () => {
+    it("コメントのみが到着した場合は import せず diff 経路で実ナビゲーションへ反映する", async () => {
+        const { result, rerender, importCalls } = setupInitialReviewSyncHarness({
+            sfen: "startpos",
+            moves: ["7g7f"],
+        });
+
+        await waitFor(() => expect(result.current.kifMoves).toHaveLength(1));
+        expect(importCalls).toHaveLength(1);
+
+        await act(async () => {
+            rerender({
+                review: {
+                    sfen: "startpos",
+                    moves: ["7g7f"],
+                    moveData: [{ evalCp: 321, elapsedMs: 1500 }],
+                },
+            });
+        });
+
+        await waitFor(() => expect(result.current.kifMoves[0]?.evalCp).toBe(321));
+        expect(result.current.kifMoves[0]?.elapsedMs).toBe(1500);
+        expect(importCalls).toHaveLength(1);
+    });
+
+    it("指し手とコメントが同時に到着した場合は import 経路で moveData を反映する", async () => {
+        const { result, rerender, importCalls } = setupInitialReviewSyncHarness({
+            sfen: "startpos",
+            moves: ["7g7f"],
+        });
+
+        await waitFor(() => expect(result.current.kifMoves).toHaveLength(1));
+        expect(importCalls).toHaveLength(1);
+
+        await act(async () => {
+            rerender({
+                review: {
+                    sfen: "startpos",
+                    moves: ["7g7f", "3c3d"],
+                    moveData: [undefined, { evalCp: -88, elapsedMs: 2200 }],
+                },
+            });
+        });
+
+        await waitFor(() => expect(result.current.kifMoves).toHaveLength(2));
+        expect(importCalls).toHaveLength(2);
+        expect(importCalls[1]?.moveData?.[1]).toMatchObject({ evalCp: -88, elapsedMs: 2200 });
+        expect(result.current.kifMoves[1]).toMatchObject({ evalCp: -88, elapsedMs: 2200 });
     });
 });

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -102,16 +102,94 @@ const SPECTATE_DISPLAY_SETTINGS: DisplaySettings = {
     showKifuEval: true,
 };
 
-const stringifyReviewMoveData = (moveData: (ReviewMoveEval | undefined)[] | undefined): string =>
-    moveData
-        ? JSON.stringify(moveData, (_key, value: unknown) =>
-              typeof value === "number" && !Number.isFinite(value)
-                  ? value > 0
-                      ? "Infinity"
-                      : "-Infinity"
-                  : value,
-          )
-        : "";
+const reviewMoveDataKeyCache = new WeakMap<(ReviewMoveEval | undefined)[], string>();
+
+export const stringifyReviewMoveData = (
+    moveData: (ReviewMoveEval | undefined)[] | undefined,
+): string => {
+    if (!moveData) return "";
+    const cached = reviewMoveDataKeyCache.get(moveData);
+    if (cached !== undefined) return cached;
+
+    const key = JSON.stringify(moveData, (_key, value: unknown) =>
+        typeof value === "number" && !Number.isNaN(value) && !Number.isFinite(value)
+            ? value > 0
+                ? "Infinity"
+                : "-Infinity"
+            : value,
+    );
+    reviewMoveDataKeyCache.set(moveData, key);
+    return key;
+};
+
+interface LoadedReviewSignature {
+    sfen: string;
+    movesKey: string;
+    moveDataKey: string;
+}
+
+interface InitialReviewInput {
+    sfen: string;
+    moves: string[];
+    moveData?: (ReviewMoveEval | undefined)[];
+}
+
+type InitialReviewSyncMode = "skip" | "import" | "diff";
+
+interface ReviewMoveDataDiffResult {
+    changed: number;
+    applied: number;
+    skipped: number;
+}
+
+export const getInitialReviewSyncMode = (
+    loaded: LoadedReviewSignature | null,
+    next: LoadedReviewSignature,
+): InitialReviewSyncMode => {
+    if (!loaded) return "import";
+    if (loaded.sfen !== next.sfen || loaded.movesKey !== next.movesKey) return "import";
+    if (loaded.moveDataKey !== next.moveDataKey) return "diff";
+    return "skip";
+};
+
+const isSameReviewMoveEval = (
+    a: ReviewMoveEval | undefined,
+    b: ReviewMoveEval | undefined,
+): boolean =>
+    a?.elapsedMs === b?.elapsedMs && a?.evalCp === b?.evalCp && a?.evalMate === b?.evalMate;
+
+export const applyReviewMoveDataDiff = (
+    navigation: Pick<ReturnType<typeof useKifuNavigation>, "updateMoveEvalAtPly">,
+    moves: string[],
+    previousMoveData: (ReviewMoveEval | undefined)[] | undefined,
+    nextMoveData: (ReviewMoveEval | undefined)[] | undefined,
+): ReviewMoveDataDiffResult => {
+    const result: ReviewMoveDataDiffResult = { changed: 0, applied: 0, skipped: 0 };
+    for (let index = 0; index < moves.length; index++) {
+        const data = nextMoveData?.[index];
+        if (isSameReviewMoveEval(previousMoveData?.[index], data)) continue;
+
+        result.changed++;
+        if (!data) continue;
+        const updateResult = navigation.updateMoveEvalAtPly(
+            index + 1,
+            {
+                elapsedMs: data.elapsedMs,
+                scoreCp: data.evalCp,
+                scoreMate: data.evalMate,
+            },
+            {
+                usiMove: moves[index],
+            },
+        );
+        if (updateResult === "missing") {
+            result.skipped++;
+        } else {
+            result.applied++;
+        }
+    }
+    return result;
+};
 
 export const analysisSnapshotEntryToRecordedEvalInfoEvent = (
     entry: AnalysisSnapshotEntryDraft,
@@ -124,6 +202,114 @@ export const analysisSnapshotEntryToRecordedEvalInfoEvent = (
     multipv: 1,
     normalized: true,
 });
+
+export function useInitialReviewSync({
+    positionReady,
+    initialReview,
+    navigation,
+    importSfen,
+}: {
+    positionReady: boolean;
+    initialReview: InitialReviewInput | undefined;
+    navigation: ReturnType<typeof useKifuNavigation>;
+    importSfen: (
+        sfen: string,
+        moves: string[],
+        options?: {
+            gotoPly?: number;
+            isStale?: () => boolean;
+            moveData?: (ReviewMoveEval | undefined)[];
+        },
+    ) => Promise<void>;
+}): void {
+    const loadedReviewRef = useRef<LoadedReviewSignature | null>(null);
+    const loadedReviewMoveDataRef = useRef<(ReviewMoveEval | undefined)[] | undefined>(undefined);
+    const importSfenRef = useRef(importSfen);
+    importSfenRef.current = importSfen;
+    const navigationRef = useRef(navigation);
+    navigationRef.current = navigation;
+    const reviewSfen = initialReview?.sfen;
+    const reviewMoves = initialReview?.moves;
+    const reviewMoveData = initialReview?.moveData;
+    const reviewMovesKey = reviewMoves?.join(" ");
+    const reviewMoveDataKey = stringifyReviewMoveData(reviewMoveData);
+    const getLatestReviewMoveData = useEffectEvent(() => initialReview?.moveData);
+    const applyLatestReviewMoveDataDiff = useEffectEvent((moves: string[]) => {
+        const nextMoveData = getLatestReviewMoveData();
+        const result = applyReviewMoveDataDiff(
+            navigationRef.current,
+            moves,
+            loadedReviewMoveDataRef.current,
+            nextMoveData,
+        );
+        if (result.skipped === 0) {
+            loadedReviewMoveDataRef.current = nextMoveData;
+        }
+        return result;
+    });
+
+    useEffect(() => {
+        if (
+            !positionReady ||
+            reviewSfen === undefined ||
+            reviewMoves === undefined ||
+            reviewMovesKey === undefined
+        ) {
+            return;
+        }
+        const loaded = loadedReviewRef.current;
+        const nextSignature = {
+            sfen: reviewSfen,
+            movesKey: reviewMovesKey,
+            moveDataKey: reviewMoveDataKey,
+        };
+        const syncMode = getInitialReviewSyncMode(loaded, nextSignature);
+        if (syncMode === "skip") {
+            return;
+        }
+        if (syncMode === "diff") {
+            const result = applyLatestReviewMoveDataDiff(reviewMoves);
+            if (result.skipped === 0) {
+                loadedReviewRef.current = nextSignature;
+            }
+            return;
+        }
+
+        // 再構築前のカーソルを捕捉する。末尾追従中 (currentPly === totalPly) なら
+        // 最新手まで進め、途中検討中ならその ply を維持する。
+        const navState = navigationRef.current.state;
+        const wasFollowingTip = navState.currentPly === navState.totalPly;
+        const restorePly = navState.currentPly;
+
+        // await 前に確定して StrictMode の二重実行を冪等化する。連続着手で先行 import が
+        // 後着 import に追い越されたら、isStale で古い import の state 適用を中止する。
+        loadedReviewRef.current = nextSignature;
+        loadedReviewMoveDataRef.current = getLatestReviewMoveData();
+        void importSfenRef
+            .current(reviewSfen, reviewMoves, {
+                gotoPly: wasFollowingTip ? undefined : restorePly,
+                moveData: getLatestReviewMoveData(),
+                isStale: () =>
+                    loadedReviewRef.current?.sfen !== reviewSfen ||
+                    loadedReviewRef.current?.movesKey !== reviewMovesKey ||
+                    loadedReviewRef.current?.moveDataKey !== reviewMoveDataKey,
+            })
+            .catch((err) => {
+                // SFEN 解析失敗などで取り込みが reject したら loaded マークを巻き戻し、
+                // 同一内容の再取り込み (再 snapshot 等) を可能にする。より新しい取り込みが
+                // 先行していれば (参照不一致) リセットしない。
+                if (
+                    loadedReviewRef.current?.sfen === reviewSfen &&
+                    loadedReviewRef.current?.movesKey === reviewMovesKey &&
+                    loadedReviewRef.current?.moveDataKey === reviewMoveDataKey
+                ) {
+                    loadedReviewRef.current = null;
+                    loadedReviewMoveDataRef.current = undefined;
+                }
+                console.error("[rshogi] initialReview の取り込みに失敗しました", err);
+            });
+    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey, reviewMoveDataKey]);
+}
 
 interface ShogiMatchProps {
     engineOptions: EngineOption[];
@@ -157,11 +343,7 @@ interface ShogiMatchProps {
      * `moveData` は `moves` と同じ index で対応する各手の評価値・消費時間
      * (先手視点)。ライブ観戦の評価値グラフ / 棋譜評価値カラム用。省略可 (後方互換)。
      */
-    initialReview?: {
-        sfen: string;
-        moves: string[];
-        moveData?: (ReviewMoveEval | undefined)[];
-    };
+    initialReview?: InitialReviewInput;
     /** 現在局面のスナップショットを通知 */
     onPositionSnapshot?: (snapshot: { sfen: string; moves: string[]; label?: string }) => void;
     /** 現在の解析結果スナップショットを通知 */
@@ -540,8 +722,9 @@ export function ShogiMatch({
     const lastAnalysisSnapshotSignatureRef = useRef<string | null>(null);
 
     useEffect(() => {
-        // JSON.stringify は Infinity を null にする。live 由来の手数なし詰み
-        // (evalMate=±Infinity) を流す場合は stringifyReviewMoveData 相当の変換が必要。
+        // analysisSnapshotDraft はサーバーへ POST するデータ由来で、POST 時点で
+        // Infinity は null に変換済み。ここに ±Infinity は含まれないため、
+        // JSON.stringify による signature 比較は安全。
         const signature = analysisSnapshotDraft ? JSON.stringify(analysisSnapshotDraft) : null;
         if (lastAnalysisSnapshotSignatureRef.current === signature) {
             return;
@@ -1346,87 +1529,16 @@ export function ShogiMatch({
         setIsMatchRunning,
     });
 
-    // initialReview を取り込む。live 観戦では moves が逐次伸びるため、moves が伸びる
-    // たびに importSfen で末尾まで再構築する。`<ShogiMatch>` を remount せず DOM を
-    // 据え置いたまま再構築するので、盤・棋譜が白く飛ばない。
-    // 取込判定は参照ではなく内容 (sfen + moves の連結文字列) で行う。`initialReview`
-    // や moves 配列は呼び出し側で毎レンダー再生成され得るが、内容が同じなら再 import
-    // しない (clock tick 等の無関係な再 render や、同内容を再生成する親に強い)。
-    // importSfen / navigation は毎レンダー再生成されるため ref 経由で参照する。
-    const loadedReviewRef = useRef<{
-        sfen: string;
-        movesKey: string;
-        moveDataKey: string;
-    } | null>(null);
-    const importSfenRef = useRef(importSfen);
-    importSfenRef.current = importSfen;
-    const navigationRef = useRef(navigation);
-    navigationRef.current = navigation;
     const initialAnalysisAppliedRef = useRef<string | null>(null);
-    const reviewSfen = initialReview?.sfen;
-    const reviewMoves = initialReview?.moves;
-    const reviewMoveData = initialReview?.moveData;
-    const reviewMovesKey = reviewMoves?.join(" ");
-    // moveData (評価値・消費時間) だけが変わった場合 (= 指し手の後にコメントが遅れて
-    // 届くライブ観戦) も再取込を発火させるため、内容シグネチャを取込判定に含める。
-    // コメント到着で 1 回だけ安価な再取込が走るが、下の restorePly 復元でカーソルは
-    // 維持され、盤・棋譜も据え置き再構築なのでちらつかない。
-    const reviewMoveDataKey = stringifyReviewMoveData(reviewMoveData);
-    useEffect(() => {
-        if (
-            !positionReady ||
-            reviewSfen === undefined ||
-            reviewMoves === undefined ||
-            reviewMovesKey === undefined
-        ) {
-            return;
-        }
-        const loaded = loadedReviewRef.current;
-        if (
-            loaded &&
-            loaded.sfen === reviewSfen &&
-            loaded.movesKey === reviewMovesKey &&
-            loaded.moveDataKey === reviewMoveDataKey
-        ) {
-            return;
-        }
 
-        // 再構築前のカーソルを捕捉する。末尾追従中 (currentPly === totalPly) なら
-        // 最新手まで進め、途中検討中ならその ply を維持する。
-        const navState = navigationRef.current.state;
-        const wasFollowingTip = navState.currentPly === navState.totalPly;
-        const restorePly = navState.currentPly;
-
-        // await 前に確定して StrictMode の二重実行を冪等化する。連続着手で先行 import が
-        // 後着 import に追い越されたら、isStale で古い import の state 適用を中止する。
-        loadedReviewRef.current = {
-            sfen: reviewSfen,
-            movesKey: reviewMovesKey,
-            moveDataKey: reviewMoveDataKey,
-        };
-        void importSfenRef
-            .current(reviewSfen, reviewMoves, {
-                gotoPly: wasFollowingTip ? undefined : restorePly,
-                moveData: reviewMoveData,
-                isStale: () =>
-                    loadedReviewRef.current?.sfen !== reviewSfen ||
-                    loadedReviewRef.current?.movesKey !== reviewMovesKey ||
-                    loadedReviewRef.current?.moveDataKey !== reviewMoveDataKey,
-            })
-            .catch((err) => {
-                // SFEN 解析失敗などで取り込みが reject したら loaded マークを巻き戻し、
-                // 同一内容の再取り込み (再 snapshot 等) を可能にする。より新しい取り込みが
-                // 先行していれば (参照不一致) リセットしない。
-                if (
-                    loadedReviewRef.current?.sfen === reviewSfen &&
-                    loadedReviewRef.current?.movesKey === reviewMovesKey &&
-                    loadedReviewRef.current?.moveDataKey === reviewMoveDataKey
-                ) {
-                    loadedReviewRef.current = null;
-                }
-                console.error("[rshogi] initialReview の取り込みに失敗しました", err);
-            });
-    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey, reviewMoveData, reviewMoveDataKey]);
+    // initialReview を取り込む。live 観戦では moves が逐次伸びた場合だけ importSfen で
+    // 末尾まで再構築し、コメントだけが遅れて届いた場合は既存ノードへ差分適用する。
+    useInitialReviewSync({
+        positionReady,
+        initialReview,
+        navigation,
+        importSfen,
+    });
 
     useEffect(() => {
         if (!positionReady || !initialAnalysisEntries || initialAnalysisEntries.length === 0) {

--- a/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.test.ts
@@ -55,4 +55,142 @@ describe("useKifuNavigation", () => {
         expect(node?.eval).toMatchObject({ scoreMate: 5, normalized: true });
         expect(node?.multiPvEvals?.[0]).toMatchObject({ scoreMate: 5, normalized: true });
     });
+
+    it("updateMoveEvalAtPly は本譜ノードへ normalized:true の評価値と消費時間を差分適用する", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+        });
+        const nodeId = result.current.tree.currentNodeId;
+
+        act(() => {
+            result.current.updateMoveEvalAtPly(
+                1,
+                {
+                    elapsedMs: 1200,
+                    scoreCp: 234,
+                },
+                {
+                    usiMove: "7g7f",
+                },
+            );
+        });
+
+        const node = result.current.tree.nodes.get(nodeId);
+        expect(node?.elapsedMs).toBe(1200);
+        expect(node?.eval).toMatchObject({ scoreCp: 234, normalized: true });
+        expect(node?.multiPvEvals).toBeUndefined();
+        expect(result.current.kifMoves[0]).toMatchObject({
+            elapsedMs: 1200,
+            evalCp: 234,
+        });
+    });
+
+    it("updateMoveEvalAtPly は手数なし詰みの ±Infinity を先手視点のまま保持する", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+            result.current.addMove("3c3d", createInitialPositionState());
+        });
+
+        act(() => {
+            result.current.updateMoveEvalAtPly(
+                1,
+                { scoreMate: Number.POSITIVE_INFINITY },
+                {
+                    usiMove: "7g7f",
+                },
+            );
+            result.current.updateMoveEvalAtPly(
+                2,
+                { scoreMate: Number.NEGATIVE_INFINITY },
+                {
+                    usiMove: "3c3d",
+                },
+            );
+        });
+
+        expect(result.current.kifMoves[0]?.evalMate).toBe(Number.POSITIVE_INFINITY);
+        expect(result.current.kifMoves[1]?.evalMate).toBe(Number.NEGATIVE_INFINITY);
+        expect(result.current.evalHistory[1]?.evalMate).toBe(Number.POSITIVE_INFINITY);
+        expect(result.current.evalHistory[2]?.evalMate).toBe(Number.NEGATIVE_INFINITY);
+    });
+
+    it("updateMoveEvalAtPly は分岐上の現在位置を動かさず、本譜の同一手だけを更新する", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+            result.current.goBack();
+            result.current.addMove("2g2f", createInitialPositionState());
+        });
+        const branchNodeId = result.current.tree.currentNodeId;
+
+        act(() => {
+            result.current.updateMoveEvalAtPly(1, { scoreCp: 345 }, { usiMove: "7g7f" });
+        });
+
+        expect(result.current.tree.currentNodeId).toBe(branchNodeId);
+        const mainNode = [...result.current.tree.nodes.values()].find(
+            (node) => node.usiMove === "7g7f",
+        );
+        const branchNode = result.current.tree.nodes.get(branchNodeId);
+        expect(mainNode?.eval).toMatchObject({ scoreCp: 345, normalized: true });
+        expect(branchNode?.eval).toBeUndefined();
+    });
+
+    it("updateMoveEvalAtPly は USI 手が一致しない場合に更新しない", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+        });
+
+        act(() => {
+            result.current.updateMoveEvalAtPly(1, { scoreCp: 999 }, { usiMove: "2g2f" });
+        });
+
+        const node = [...result.current.tree.nodes.values()].find((n) => n.ply === 1);
+        expect(node?.eval).toBeUndefined();
+    });
+
+    it("updateMoveEvalAtPly は既存のより深い自前解析をコメントで上書きしない", () => {
+        const { result } = setup();
+
+        act(() => {
+            result.current.addMove("7g7f", createInitialPositionState());
+        });
+
+        act(() => {
+            result.current.recordEvalByPly(1, {
+                type: "info",
+                scoreCp: 900,
+                depth: 20,
+                pv: ["3c3d"],
+                multipv: 1,
+                normalized: true,
+            });
+        });
+
+        act(() => {
+            result.current.updateMoveEvalAtPly(
+                1,
+                {
+                    scoreCp: 100,
+                    depth: 10,
+                },
+                { usiMove: "7g7f" },
+            );
+        });
+
+        const node = [...result.current.tree.nodes.values()].find((n) => n.ply === 1);
+        expect(node?.eval).toMatchObject({
+            scoreCp: 900,
+            depth: 20,
+            pv: ["3c3d"],
+            normalized: true,
+        });
+    });
 });

--- a/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
@@ -42,6 +42,19 @@ import { convertMovesToKif } from "../utils/kifFormat";
 
 export type RecordedEvalInfoEvent = EngineInfoEvent & Pick<KifuEval, "normalized">;
 
+interface MoveEvalUpdate {
+    /** 消費時間（ミリ秒）。undefined の場合は既存値を維持する。 */
+    elapsedMs?: number;
+    /** 評価値（センチポーン、先手視点）。 */
+    scoreCp?: number;
+    /** 詰み手数（先手視点）。手数不明の詰みは ±Infinity。 */
+    scoreMate?: number;
+    /** 探索深さ。 */
+    depth?: number;
+    /** 読み筋（USI形式の指し手配列）。 */
+    pv?: string[];
+}
+
 /** USI形式の指し手からlastMove情報を導出 */
 function deriveLastMoveFromUsi(usiMove: string | null): { from?: string; to: string } | undefined {
     if (!usiMove) return undefined;
@@ -117,6 +130,12 @@ export interface UseKifuNavigationResult {
     truncate: () => void;
     /** 指し手を追加（分岐生成含む） */
     addMove: (usiMove: string, positionAfter: PositionState, options?: AddMoveOptions) => void;
+    /** 本譜の既存ノードへ評価値・消費時間を差分適用（評価値は先手視点で normalized:true） */
+    updateMoveEvalAtPly: (
+        ply: number,
+        update: MoveEvalUpdate | undefined,
+        options?: { usiMove?: string },
+    ) => "applied" | "preserved" | "missing";
     /** 評価値を記録（手数で指定） */
     recordEvalByPly: (ply: number, event: RecordedEvalInfoEvent) => void;
     /** 評価値を記録（ノードIDで指定、分岐内のノード用） */
@@ -342,6 +361,88 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
             onPositionChange?.(positionAfter, lastMove);
             return newTree;
         });
+    };
+
+    /**
+     * live 観戦など、指し手列は同じでコメント（評価値・消費時間）だけが遅れて届く場合に、
+     * 本譜の既存ノードを差分更新する。
+     */
+    const updateMoveEvalAtPly = (
+        ply: number,
+        update: MoveEvalUpdate | undefined,
+        options?: { usiMove?: string },
+    ): "applied" | "preserved" | "missing" => {
+        if (!update) return "preserved";
+
+        const hasEval = update.scoreCp !== undefined || update.scoreMate !== undefined;
+        const hasElapsed = update.elapsedMs !== undefined;
+        if (!hasEval && !hasElapsed) return "preserved";
+
+        const nodeId = findNodeByPlyInMainLine(tree, ply);
+        if (!nodeId) return "missing";
+
+        const currentNode = tree.nodes.get(nodeId);
+        if (!currentNode) return "missing";
+        if (options?.usiMove !== undefined && currentNode.usiMove !== options.usiMove) {
+            return "missing";
+        }
+
+        const existing = currentNode.eval;
+        const existingPvMissing = !existing?.pv || existing.pv.length === 0;
+        const newPvAvailable = !!(update.pv && update.pv.length > 0);
+        const shouldUpdateEval =
+            hasEval &&
+            (!existing ||
+                (update.depth !== undefined && (existing.depth ?? 0) < update.depth) ||
+                (existingPvMissing && newPvAvailable) ||
+                (existing.depth === undefined && update.depth === undefined && existingPvMissing));
+
+        if (!hasElapsed && !shouldUpdateEval) {
+            return "preserved";
+        }
+
+        setTree((prev) => {
+            const nextNodeId = findNodeByPlyInMainLine(prev, ply);
+            if (!nextNodeId) return prev;
+
+            const node = prev.nodes.get(nextNodeId);
+            if (!node) return prev;
+            if (options?.usiMove !== undefined && node.usiMove !== options.usiMove) {
+                return prev;
+            }
+
+            const prevEval = node.eval;
+            const prevEvalPvMissing = !prevEval?.pv || prevEval.pv.length === 0;
+            const nextPvAvailable = !!(update.pv && update.pv.length > 0);
+            const shouldSetEval =
+                hasEval &&
+                (!prevEval ||
+                    (update.depth !== undefined && (prevEval.depth ?? 0) < update.depth) ||
+                    (prevEvalPvMissing && nextPvAvailable) ||
+                    (prevEval.depth === undefined &&
+                        update.depth === undefined &&
+                        prevEvalPvMissing));
+
+            const updatedNode: KifuNode = {
+                ...node,
+                elapsedMs: hasElapsed ? update.elapsedMs : node.elapsedMs,
+                eval: shouldSetEval
+                    ? {
+                          scoreCp: update.scoreCp,
+                          scoreMate: update.scoreMate,
+                          depth: update.depth,
+                          pv: update.pv,
+                          normalized: true,
+                      }
+                    : node.eval,
+            };
+
+            const newNodes = new Map(prev.nodes);
+            newNodes.set(nextNodeId, updatedNode);
+            return { ...prev, nodes: newNodes };
+        });
+
+        return shouldUpdateEval || hasElapsed ? "applied" : "preserved";
     };
 
     /**
@@ -851,6 +952,7 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
         promoteCurrentLine,
         truncate,
         addMove,
+        updateMoveEvalAtPly,
         recordEvalByPly,
         recordEvalByNodeId,
         clearEvalByPly,

--- a/packages/ui/src/components/shogi-match/layouts/MobileLayout.test.ts
+++ b/packages/ui/src/components/shogi-match/layouts/MobileLayout.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { MATE_WITHOUT_PLY } from "../utils/kifFormat";
+import { formatMobileCompactEval } from "./MobileLayout";
+
+describe("formatMobileCompactEval", () => {
+    it("手数不明の詰みは手数を表示しない", () => {
+        expect(formatMobileCompactEval(undefined, MATE_WITHOUT_PLY)).toBe("詰み");
+        expect(formatMobileCompactEval(undefined, -MATE_WITHOUT_PLY)).toBe("詰まされ");
+    });
+
+    it("手数付き詰みと通常評価値は従来表記を維持する", () => {
+        expect(formatMobileCompactEval(undefined, 5)).toBe("詰み5手");
+        expect(formatMobileCompactEval(undefined, -7)).toBe("詰まされ7手");
+        expect(formatMobileCompactEval(150)).toBe("+1.5");
+        expect(formatMobileCompactEval()).toBe("-");
+    });
+});

--- a/packages/ui/src/components/shogi-match/layouts/MobileLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/MobileLayout.tsx
@@ -33,8 +33,18 @@ import { useMatchSettings } from "../contexts/MatchSettingsContext";
 import { useMatchState } from "../contexts/MatchStateContext";
 import { useNavigation } from "../contexts/NavigationContext";
 import type { DisplaySettings } from "../types";
-import type { KifMove as FullKifMove } from "../utils/kifFormat";
+import { type KifMove as FullKifMove, formatEval } from "../utils/kifFormat";
 import type { KifMoveData } from "../utils/kifParser";
+
+export function formatMobileCompactEval(evalCp?: number, evalMate?: number): string {
+    const formatted = formatEval(evalCp, evalMate);
+    if (formatted === "") return "-";
+    if (formatted === "+詰") return "詰み";
+    if (formatted === "-詰") return "詰まされ";
+    if (formatted.startsWith("+詰")) return `詰み${formatted.slice("+詰".length)}手`;
+    if (formatted.startsWith("-詰")) return `詰まされ${formatted.slice("-詰".length)}手`;
+    return formatted;
+}
 
 /**
  * MobileLayout 固有の Props
@@ -490,13 +500,7 @@ export function MobileLayout({
                         <div className="flex items-center justify-center gap-2 text-sm">
                             <span className="text-muted-foreground">評価:</span>
                             <span className="font-mono tabular-nums">
-                                {evalMate !== undefined
-                                    ? evalMate > 0
-                                        ? `詰み${evalMate}手`
-                                        : `詰まされ${Math.abs(evalMate)}手`
-                                    : evalCp !== undefined
-                                      ? `${evalCp > 0 ? "+" : ""}${(evalCp / 100).toFixed(1)}`
-                                      : "-"}
+                                {formatMobileCompactEval(evalCp, evalMate)}
                             </span>
                             {/* 詳細ボタン */}
                             <button

--- a/packages/ui/src/components/shogi-match/utils/branchTreeUtils.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/branchTreeUtils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { normalizeEvalToSentePerspective } from "./branchTreeUtils";
+import { MATE_WITHOUT_PLY } from "./kifFormat";
 
 describe("normalizeEvalToSentePerspective", () => {
     it("保存済みの先手視点 eval は normalized:true で奇数/偶数 ply とも bit 一致で往復する", () => {
@@ -8,6 +9,8 @@ describe("normalizeEvalToSentePerspective", () => {
             { ply: 2, evalCp: -456, evalMate: undefined },
             { ply: 3, evalCp: undefined, evalMate: 7 },
             { ply: 4, evalCp: undefined, evalMate: -9 },
+            { ply: 1, evalCp: undefined, evalMate: MATE_WITHOUT_PLY },
+            { ply: 2, evalCp: undefined, evalMate: -MATE_WITHOUT_PLY },
         ];
 
         for (const { ply, evalCp, evalMate } of cases) {

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
@@ -583,4 +583,35 @@ describe("exportToKifString", () => {
             "開始局面：lnsgkgsnl/1r5b1/ppppppppp/9/9/9/PPPPPPPP1/1B5R1/LNSGKGSNL b - 1",
         );
     });
+
+    it("手数不明の詰みコメントは手数を出力しない", () => {
+        const board = placePiece(createEmptyBoard(), "7g", "sente", "P");
+        const result = exportToKifString(
+            [
+                {
+                    ply: 1,
+                    kifText: "dummy",
+                    displayText: "dummy",
+                    usiMove: "7g7f",
+                    elapsedMs: 0,
+                    evalMate: MATE_WITHOUT_PLY,
+                },
+                {
+                    ply: 2,
+                    kifText: "dummy",
+                    displayText: "dummy",
+                    usiMove: "3c3d",
+                    elapsedMs: 0,
+                    evalMate: -MATE_WITHOUT_PLY,
+                },
+            ],
+            [board, board],
+            { includeEval: true, startSfen: "startpos" },
+        );
+
+        expect(result).toContain("*評価値=詰み");
+        expect(result).toContain("*評価値=被詰み");
+        expect(result).not.toContain("詰Infinity手");
+        expect(result).not.toContain("被詰Infinity手");
+    });
 });


### PR DESCRIPTION
Closes #70

## 変更内容

### #70: 差分適用 API（ユーザー承認済みの方式）
- コメント（評価値）のみの到着では `importSfen`（ツリー reset + 全手再適用）を呼ばず、前回適用分との比較で**変化した ply のみ** `updateMoveEvalAtPly` で差分適用（イベントあたり O(n²) → O(変化数)）
- 観戦者がその場で張ったエンジン解析・分岐・カーソル位置を保持。depth/PV ガードにより深い自前解析を浅い live コメントで上書きしない
- 適用できなかった ply（usiMove 不一致等）がある場合は signature を確定せず再試行可能にし、終局後の eval 恒久喪失経路を解消
- 指し手+コメント同時到着は従来の import 経路（経路は排他、二重適用なし）
- PR #65 レビュー指摘の perf 2件を解消: `useEffectEvent` 化 + WeakMap キャッシュで clock tick ごとの JSON 化・effect 発火を排除

### マージ済み PR #72 レビュー指摘の吸収
- **モバイルのコンパクト評価表示で手数なし詰みが「詰みInfinity手」になるバグを修正**（P2、formatEval 経由に統一 + テスト）
- ±Infinity の normalize 往復テスト（奇数/偶数 ply）、`formatEvalComment` の 詰み/被詰み テスト（公開 API 経由）
- `stringifyReviewMoveData` replacer の NaN ガード、signature 比較の安全性コメント補足
- POST での Infinity 無言消失は #74 で追跡

## 検証
- クリーンコンテキストレビュアー（Opus）2周: REQUEST_CHANGES（Medium 2 / Low 3）→ 全対応後 **APPROVE**（無限再適用ループなし・ガードの過剰ブロックなしを個別検証済み)
- dev サーバー + headless Chromium: デスクトップ幅で「+詰」表示維持、モバイル幅（390px）で本文に `Infinity` が出現せず「詰み」表示であることをテキスト検証
- `turbo lint typecheck test` green（web RoomPage のローカル env 由来失敗のみ既知）、`knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C