### PR TITLE
fix(ui,match-client): stopwatch の秒読みフェーズ表示と時計まわりのレビュー指摘を修正

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -788,7 +788,7 @@ describe("subscribeRshogiLiveGame: モック (apiBaseUrl 未指定 + gameId が 
         expect(events.snapshot.length).toBe(0);
         expect(events.errors.length).toBe(1);
         expect(events.errors[0].message).toContain("apiBaseUrl is required");
-        expect(events.states).toEqual(["closed"]);
+        expect(events.states).toEqual(["connecting", "closed"]);
     });
 });
 
@@ -890,6 +890,22 @@ describe("deriveTimeControl: kind 判定と単位換算 (REST decodeClock 語彙
             byoyomiSeconds: 0,
             byoyomiMilliseconds: undefined,
             incrementSeconds: 10,
+        });
+    });
+    it("Increment:0 は fischer 扱いせず countdown として扱う", () => {
+        expect(
+            __test_internals.deriveTimeControl({
+                timeUnit: "1sec",
+                totalTime: 600,
+                byoyomi: 10,
+                increment: 0,
+            }),
+        ).toEqual({
+            kind: "countdown",
+            mainSeconds: 600,
+            byoyomiSeconds: 10,
+            byoyomiMilliseconds: undefined,
+            incrementSeconds: undefined,
         });
     });
     it("Byoyomi 行あり Time_Unit:1sec → countdown", () => {

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -318,7 +318,7 @@ const parseGameSummaryLines = (summaryLines: string[]): ParsedSummary => {
  * ## kind 判定 (REST `decodeClock` の語彙に合わせる)
  * サーバの clock 方式は `BEGIN Time` セクションの `Time_Unit` + `Increment` /
  * `Byoyomi` の有無で一意に決まる (server `ClockSpec::format_time_section`)。
- * - `Increment` 行あり → `fischer` (Time_Unit は常に 1sec)
+ * - `Increment` 行ありかつ 0 より大きい → `fischer` (Time_Unit は常に 1sec)
  * - `Time_Unit:1min`  → `stopwatch` (Total_Time / Byoyomi は分単位)
  * - `Time_Unit:1msec` → `countdown_msec` (Total_Time / Byoyomi は ms 単位)
  * - それ以外 (`Time_Unit:1sec` / 未指定) → `countdown`。`Byoyomi` が無い/0 の
@@ -346,20 +346,20 @@ const deriveTimeControl = (summary: ParsedSummary): RshogiTimeControl | undefine
         if (unit === "1min") return value * 60;
         return value;
     };
-    const kind: RshogiClockKind =
-        summary.increment !== undefined
-            ? "fischer"
-            : unit === "1min"
-              ? "stopwatch"
-              : unit === "1msec"
-                ? "countdown_msec"
-                : "countdown";
+    const hasPositiveIncrement = summary.increment != null && summary.increment > 0;
+    const kind: RshogiClockKind = hasPositiveIncrement
+        ? "fischer"
+        : unit === "1min"
+          ? "stopwatch"
+          : unit === "1msec"
+            ? "countdown_msec"
+            : "countdown";
     return {
         kind,
         mainSeconds: toSeconds(summary.totalTime),
         byoyomiSeconds: toSeconds(summary.byoyomi),
         byoyomiMilliseconds: unit === "1msec" ? summary.byoyomi : undefined,
-        incrementSeconds: summary.increment,
+        incrementSeconds: hasPositiveIncrement ? summary.increment : undefined,
     };
 };
 
@@ -832,6 +832,11 @@ export function subscribeRshogiLiveGame(
                 clearTimeoutImpl,
                 signal: options.signal,
             });
+        }
+        try {
+            callbacks.onConnectionState("connecting");
+        } catch (handlerErr) {
+            console.error("[rshogi live] onConnectionState handler threw", handlerErr);
         }
         try {
             callbacks.onError(

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -8,6 +8,7 @@ import {
     applyMoveToClocks,
     computeRemaining,
     deriveInByoyomi,
+    formatByoyomiClock,
     formatOwnEval,
     type LiveClocks,
     moveDetailsToEvals,
@@ -325,12 +326,20 @@ describe("formatOwnEval", () => {
     });
 });
 
+describe("formatByoyomiClock", () => {
+    it("秒読み残時間は ceil で m:ss 表示にする", () => {
+        expect(formatByoyomiClock(1)).toBe("0:01");
+        expect(formatByoyomiClock(59_999)).toBe("0:59");
+        expect(formatByoyomiClock(60_000)).toBe("1:00");
+        expect(formatByoyomiClock(0)).toBe("0:00");
+    });
+});
+
 describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラー)", () => {
     it("fischer: mover.main = max(0, main - elapsed) + increment (post-increment)", () => {
         // 先手 65s (=60+5)、10s 消費 → max(0, 65000-10000)+5000 = 60000
         const next = applyMoveToClocks(
             mkClocks({ sente: 65_000, gote: 65_000, sideToMove: "sente" }),
-            "fischer",
             FISCHER,
             "sente",
             10,
@@ -347,7 +356,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
         // (client がドリフトで main を小さく見積もった場合の安全側挙動の確認)。
         const next = applyMoveToClocks(
             mkClocks({ sente: 0, gote: 60_000, sideToMove: "sente" }),
-            "fischer",
             FISCHER,
             "sente",
             3,
@@ -359,7 +367,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
         // 本体 8s の側が 8s 消費 → 本体 0、秒読み (byoyomi 10s>0) へ
         const next = applyMoveToClocks(
             mkClocks({ sente: 8_000, gote: 60_000, sideToMove: "sente" }),
-            "countdown",
             COUNTDOWN,
             "sente",
             8,
@@ -371,7 +378,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
     it("countdown: 本体超過で即秒読みへ (elapsed > main)", () => {
         const next = applyMoveToClocks(
             mkClocks({ sente: 3_000, gote: 60_000, sideToMove: "sente" }),
-            "countdown",
             COUNTDOWN,
             "sente",
             9,
@@ -388,7 +394,7 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
             sideToMove: "sente",
             senteInByoyomi: true,
         });
-        const next = applyMoveToClocks(inByoyomi, "countdown", COUNTDOWN, "sente", 7);
+        const next = applyMoveToClocks(inByoyomi, COUNTDOWN, "sente", 7);
         expect(next.sente).toBe(0);
         expect(next.senteInByoyomi).toBe(true);
     });
@@ -396,7 +402,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
     it("countdown_msec: byoyomiMilliseconds>0 でも本体使い切りで秒読みへ移行する", () => {
         const next = applyMoveToClocks(
             mkClocks({ sente: 500, gote: 10_000, sideToMove: "sente" }),
-            "countdown_msec",
             COUNTDOWN_MSEC,
             "sente",
             1,
@@ -408,7 +413,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
     it("stopwatch: 分単位切り捨て (elapsed 59s → 消費 0)", () => {
         const next = applyMoveToClocks(
             mkClocks({ sente: 900_000, gote: 900_000, sideToMove: "sente" }),
-            "stopwatch",
             STOPWATCH,
             "sente",
             59,
@@ -419,7 +423,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
         // 60 秒ちょうどで 1 分消費
         const after60 = applyMoveToClocks(
             mkClocks({ sente: 900_000, gote: 900_000, sideToMove: "sente" }),
-            "stopwatch",
             STOPWATCH,
             "sente",
             60,
@@ -427,10 +430,34 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
         expect(after60.sente).toBe(840_000);
     });
 
+    it("stopwatch: 本体 0 到達後は分単位 byoyomi を秒読みフェーズとして表示対象にする", () => {
+        const next = applyMoveToClocks(
+            mkClocks({ sente: 60_000, gote: 900_000, sideToMove: "sente" }),
+            STOPWATCH,
+            "sente",
+            60,
+        );
+        expect(next.sente).toBe(0);
+        expect(next.senteInByoyomi).toBe(true);
+
+        const alreadyInByoyomi = applyMoveToClocks(
+            mkClocks({
+                sente: 0,
+                gote: 900_000,
+                sideToMove: "sente",
+                senteInByoyomi: true,
+            }),
+            STOPWATCH,
+            "sente",
+            120,
+        );
+        expect(alreadyInByoyomi.sente).toBe(0);
+        expect(alreadyInByoyomi.senteInByoyomi).toBe(true);
+    });
+
     it("sudden-death (byoyomi 0): 0 でクランプし秒読みには入らない", () => {
         const next = applyMoveToClocks(
             mkClocks({ sente: 3_000, gote: 300_000, sideToMove: "sente" }),
-            "countdown",
             SUDDEN_DEATH,
             "sente",
             9,
@@ -442,7 +469,6 @@ describe("applyMoveToClocks: kind ごとの 1 手適用 (server clock.rs ミラ�
     it("後手番の move は後手側だけを更新し先手を据え置く", () => {
         const next = applyMoveToClocks(
             mkClocks({ sente: 60_000, gote: 40_000, sideToMove: "gote" }),
-            "countdown",
             COUNTDOWN,
             "gote",
             5,
@@ -466,9 +492,11 @@ describe("deriveInByoyomi: snapshot / onClock resync の秒読み派生", () => 
     it("sudden-death (byoyomi 0) → false", () => {
         expect(deriveInByoyomi(0, SUDDEN_DEATH)).toBe(false);
     });
-    it("fischer / stopwatch は countdown 系でないため false", () => {
+    it("fischer は秒読み方式でないため false", () => {
         expect(deriveInByoyomi(0, FISCHER)).toBe(false);
-        expect(deriveInByoyomi(0, STOPWATCH)).toBe(false);
+    });
+    it("stopwatch は byoyomi>0 なら本体 0 で秒読み扱い", () => {
+        expect(deriveInByoyomi(0, STOPWATCH)).toBe(true);
     });
     it("timeControl 未取得なら false", () => {
         expect(deriveInByoyomi(0, undefined)).toBe(false);

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -233,6 +233,8 @@ export function appendMoveEval(
 
 /**
  * onMoveComment 到着時に該当 ply の付随情報へ eval (先手視点) を後追いで書き込む。
+ * live stream の `'` コメント行は直前 move に属し、match-client は onMove 後にだけ
+ * onMoveComment を発火する契約。したがって該当 index は通常 onMove で作成済み。
  * ply は 1 始まり。範囲外・eval 無しコメントは配列を据え置く (消費秒は保持)。
  * 詰みセンチネルは snapshot 経路と同じく手数不明の mate として扱う。
  */
@@ -261,13 +263,16 @@ const formatMs = (ms: number): string => {
  * 秒読み残時間 (ms) を `m:ss` に整形する。
  *
  * 本体時計 (`formatMs`) は floor だが、秒読みは「あと N 秒」という残数表示のため
- * ceil にする (full 10 秒の秒読み開始直後に 9 と出さない)。実際の time-up 判定は
- * server 側で行われ end 行として届くので、client 表示は 0 でクランプするだけ。
+ * 秒部分を ceil にする (full 10 秒の秒読み開始直後に 9 と出さない)。ただし
+ * 59.999 秒を 1:00 とは表示せず、分境界は実ミリ秒が到達したときだけ繰り上げる。
+ * 実際の time-up 判定は server 側で行われ end 行として届くので、client 表示は
+ * 0 でクランプするだけ。
  */
-const formatByoyomiClock = (ms: number): string => {
-    const totalSec = Number.isFinite(ms) ? Math.max(0, Math.ceil(ms / 1000)) : 0;
-    const min = Math.floor(totalSec / 60);
-    const sec = totalSec % 60;
+export const formatByoyomiClock = (ms: number): string => {
+    const clampedMs = Number.isFinite(ms) ? Math.max(0, ms) : 0;
+    const min = Math.floor(clampedMs / 60_000);
+    const secWithinMinute = Math.ceil((clampedMs - min * 60_000) / 1000);
+    const sec = Math.min(59, secWithinMinute);
     return `${min}:${String(sec).padStart(2, "0")}`;
 };
 
@@ -277,23 +282,24 @@ function byoyomiFullMs(timeControl: RshogiTimeControl | undefined): number {
     return timeControl.byoyomiMilliseconds ?? (timeControl.byoyomiSeconds ?? 0) * 1000;
 }
 
-/** countdown 系 (秒読みを持ちうる方式) かどうか。stopwatch / fischer は含めない。 */
-function isCountdownFamily(kind: RshogiClockKind | undefined): boolean {
-    return kind === "countdown" || kind === "countdown_msec";
+/** 秒読みを持ちうる方式かどうか。fischer は含めない。 */
+function supportsByoyomiPhase(kind: RshogiClockKind | undefined): boolean {
+    return kind === "countdown" || kind === "countdown_msec" || kind === "stopwatch";
 }
 
 /**
  * ある側の本体残時間 + timeControl から「秒読みフェーズに入っているか」を導出する。
  *
- * 本体 0 かつ countdown 系かつ byoyomi>0 のときだけ true。snapshot / onClock の
+ * 本体 0 かつ秒読みを持ちうる方式かつ byoyomi>0 のときだけ true。snapshot / onClock の
  * resync 経路で使い、遅れて参加した観戦者が秒読み中の局面を即座に秒読み表示できる
- * ようにする。fischer / stopwatch / sudden-death (byoyomi 0) は常に false。
+ * ようにする。stopwatch はサーバの分単位秒読みを秒へ正規化した値で扱う。
+ * fischer / sudden-death (byoyomi 0) は常に false。
  */
 export function deriveInByoyomi(
     mainMs: number,
     timeControl: RshogiTimeControl | undefined,
 ): boolean {
-    return mainMs <= 0 && isCountdownFamily(timeControl?.kind) && byoyomiFullMs(timeControl) > 0;
+    return mainMs <= 0 && supportsByoyomiPhase(timeControl?.kind) && byoyomiFullMs(timeControl) > 0;
 }
 
 /**
@@ -318,20 +324,19 @@ export function deriveInByoyomi(
  *             ms 粒度の秒読み移行判定に最大 1 秒未満の誤差が出る (snapshot resync
  *             でのみ補正)。
  * - stopwatch: floor(elapsedSec/60)*60000 を減算 (分単位切り捨て。elapsed 59s → 消費 0)。
- *             既知の制約: stopwatch の秒読み (分単位) フェーズ表示は未対応
- *             (本番プリセットは fischer / countdown のみで stopwatch 配信が無いため)。
- *             本体 0 到達後は 00:00 のまま。対応する場合は countdown 系と同様に
- *             `inByoyomi` を分粒度で扱うこと。
+ *             本体を使い切ったら byoyomi>0 のときだけ秒読みフェーズへ移行する。
+ *             サーバの StopWatchClock は byoyomi_minutes を持つため、client 側では
+ *             timeControl.byoyomiSeconds (分→秒へ正規化済み) を full 量として扱う。
  * - sudden-death (byoyomi 0 / increment 無し) / kind 不明: 0 でクランプするだけ
  *   (`inByoyomi` は立てない)。
  */
 export function applyMoveToClocks(
     clocks: LiveClocks,
-    kind: RshogiClockKind | undefined,
     timeControl: RshogiTimeControl | undefined,
     moverSide: "sente" | "gote",
     elapsedSec: number,
 ): LiveClocks {
+    const kind = timeControl?.kind;
     const elapsedMs = Math.max(0, elapsedSec) * 1000;
     const main = moverSide === "sente" ? clocks.sente : clocks.gote;
     const alreadyInByoyomi = moverSide === "sente" ? clocks.senteInByoyomi : clocks.goteInByoyomi;
@@ -344,8 +349,8 @@ export function applyMoveToClocks(
         nextInByoyomi = false;
     } else if (kind === "stopwatch") {
         const consumedMs = Math.floor(Math.max(0, elapsedSec) / 60) * 60_000;
-        nextMain = Math.max(0, main - consumedMs);
-        nextInByoyomi = false;
+        nextMain = alreadyInByoyomi ? 0 : Math.max(0, main - consumedMs);
+        nextInByoyomi = nextMain <= 0 && byoyomiFullMs(timeControl) > 0;
     } else {
         // countdown / countdown_msec / sudden-death / kind 不明。
         // 既に秒読みなら本体は 0 のまま (秒読みは毎手 full リセットで持続量を保持しない)、
@@ -786,7 +791,7 @@ export function RshogiCsaLiveViewer({
                     moveEvals: moveDetailsToEvals(snapshot.moveDetails),
                     result: snapshot.finalResult ?? prev.result,
                     snapshotEpoch: prev.snapshotEpoch + 1,
-                    // 本体残 0 かつ countdown 系秒読み局面なら、遅れて参加した観戦者にも
+                    // 本体残 0 かつ秒読み方式なら、遅れて参加した観戦者にも
                     // 秒読み表示を即座に出せるよう inByoyomi を派生する。
                     clocks: {
                         sente: snapshot.clocks.sente,
@@ -819,7 +824,6 @@ export function RshogiCsaLiveViewer({
                         clocks: prev.clocks
                             ? applyMoveToClocks(
                                   prev.clocks,
-                                  timeControl?.kind,
                                   timeControl,
                                   prev.clocks.sideToMove,
                                   elapsedSec,
@@ -842,7 +846,9 @@ export function RshogiCsaLiveViewer({
                 setState((prev) => {
                     // onClock は snapshot 完了直後 (onSnapshot の後) にのみ発火するため、
                     // prev.snapshot は既に最新へ更新済み。そこから timeControl を引き、
-                    // 本体残 0 の countdown 系秒読み局面を即座に秒読み表示へ乗せる。
+                    // 本体残 0 の秒読み局面を即座に秒読み表示へ乗せる。
+                    // もし契約外に snapshot なしで届いた場合は timeControl undefined とし、
+                    // 秒読み判定をスキップする (安全側で本体時計表示に寄せる)。
                     const timeControl = prev.snapshot?.meta.timeControl;
                     return {
                         ...prev,


### PR DESCRIPTION
Closes #68

## 変更内容

### #68: stopwatch の秒読み（分単位）フェーズ表示
- stopwatch でも本体残 0 到達後に `byoyomi_minutes>0` なら秒読みフェーズへ入るよう `deriveInByoyomi` / `applyMoveToClocks` を countdown 系と統一（snapshot 経路・onClock 経路とも整合）
- `byoyomi_minutes=0` の純切れ負け stopwatch は従来どおり（サーバー挙動と一致）
- 表示は countdown 系と同じ秒粒度カウントダウン（time-up 判定はサーバー権威。分粒度残時間との瞬間値差異は観戦表示向けの意図的な近似）

### マージ済み PR #66 / #65 レビュー指摘の吸収
- `increment: 0` を Fischer と誤判定しない（`!= null && > 0`）+ 回帰テスト
- `applyMoveToClocks` の kind/timeControl 二重渡し解消（`timeControl` のみ受け取り）
- `formatByoyomiClock` の丸めバグ修正（59999ms が "1:00" → "0:59"）+ 境界値テスト（1ms/59999/60000/0）
- `onClock`「onSnapshot 完了後にのみ発火」契約・`setMoveEvalAtPly`「onMoveComment は onMove 後」契約のコメント明示
- live.ts 非 mock エラーパスの接続状態遷移を mock パスと同じ `connecting`→`closed` に統一 + テスト更新

## 検証
- クリーンコンテキストレビュアー（Opus): **APPROVE**（fischer/countdown への回帰なし、シグネチャ変更の追随漏れなしを確認。指摘は info 1件のみ＝秒粒度表示は意図的近似である旨、本文に記載済み）
- `turbo lint typecheck test` green（web RoomPage のローカル env 由来失敗のみ既知）、`knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C