### PR TITLE
fix(ui,match-client): live viewer レビューフォローアップ (PR #73/#75/#76 指摘対応)

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -667,6 +667,31 @@ describe("subscribeRshogiLiveGame: room full", () => {
         }
     });
 
+    it("room full 以外の満席らしい文言は契約外として扱わない", () => {
+        vi.useFakeTimers();
+        try {
+            const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+            subscribeRshogiLiveGame(
+                "game-1",
+                { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+                callbacks,
+            );
+            const ws = wsInstances[0];
+            ws.fireOpen();
+            ws.fireLines([
+                "##[MONITOR2] ERROR too many spectators",
+                "##[MONITOR2] ERROR spectator full",
+                "##[MONITOR2] ERROR 満席",
+            ]);
+
+            expect(ws.closeArgs).toBeUndefined();
+            expect(events.errors).toEqual([]);
+            expect(events.states.at(-1)).toBe("connected");
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
     it("room full ではない MONITOR2 ERROR 行は接続を維持する", () => {
         vi.useFakeTimers();
         try {

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -616,13 +616,9 @@ const parseLiveComment = (line: string): RshogiLiveComment => {
 
 const isRoomFullText = (value: string): boolean => {
     const normalized = value.toLowerCase();
-    return (
-        normalized.includes("room full") ||
-        (normalized.includes("spectator") && normalized.includes("full")) ||
-        normalized.includes("too many spectators") ||
-        (normalized.includes("観戦") && normalized.includes("上限")) ||
-        normalized.includes("満席")
-    );
+    // サーバ契約は close(1013, "room full") と MONITOR2 ERROR の "room full" のみ。
+    // 将来マッチ範囲を広げる場合は、誤検知を避けるため根拠をコメントで明記する。
+    return normalized.includes("room full");
 };
 
 const maybeRoomFullLineError = (line: string): RshogiLiveRoomFullError | null =>
@@ -1109,6 +1105,8 @@ export function subscribeRshogiLiveGame(
             if (roomFullError) {
                 closeAsRoomFull(roomFullError);
             }
+            // room full 以外の MONITOR2 ERROR は一時的な警告として扱う。
+            // snapshot / live line は継続して届く可能性があるため、ここでは接続を維持する。
             return;
         }
         if (inSnapshot) {

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -145,6 +145,30 @@ const createStaticGameFetch = () =>
             ),
     ) as unknown as typeof fetch;
 
+const createStaticGameNotFoundFetch = () =>
+    vi.fn(async () => new Response("not found", { status: 404 })) as unknown as typeof fetch;
+
+const createStaticGameFailureFetch = (message = "fallback exploded") =>
+    vi.fn(async () => {
+        throw new Error(message);
+    }) as unknown as typeof fetch;
+
+const createInvalidStaticGameFetch = () =>
+    vi.fn(
+        async () =>
+            new Response(
+                JSON.stringify({
+                    game_id: "game-1",
+                    black_handle: "alice",
+                    white_handle: "bob",
+                    result_kind: "WIN_WHITE",
+                    end_reason: "RESIGN",
+                    csa: "not csa",
+                }),
+                { status: 200, headers: { "content-type": "application/json" } },
+            ),
+    ) as unknown as typeof fetch;
+
 describe("RshogiCsaLiveViewer: static fallback", () => {
     beforeEach(() => {
         MockWebSocket.instances = [];
@@ -189,6 +213,75 @@ describe("RshogiCsaLiveViewer: static fallback", () => {
         expect(screen.getByText("後手 (bob) 勝ち (投了)")).toBeTruthy();
     });
 
+    it("静的 fallback が RshogiGameNotFoundError になったら not-found 表示にする", async () => {
+        const fetchOverride = createStaticGameNotFoundFetch();
+
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+                fetchOverride={fetchOverride}
+            />,
+        );
+
+        act(() => {
+            MockWebSocket.instances[0].fireOpen();
+            MockWebSocket.instances[0].fireLines(["##[MONITOR2] NOT_FOUND game-1"]);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText(/終局済み棋譜がまだ見つかりませんでした/)).toBeTruthy();
+        });
+    });
+
+    it("静的 fallback が汎用エラーになったら errorMessage を表示する", async () => {
+        const fetchOverride = createStaticGameFailureFetch("fallback exploded");
+
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+                fetchOverride={fetchOverride}
+            />,
+        );
+
+        act(() => {
+            MockWebSocket.instances[0].fireOpen();
+            MockWebSocket.instances[0].fireLines(["##[MONITOR2] NOT_FOUND game-1"]);
+        });
+
+        await waitFor(() => {
+            expect(screen.getByText("fallback exploded")).toBeTruthy();
+        });
+    });
+
+    it("terminal snapshot 後の parseCsaMoves 例外は snapshot を保持して抑制する", async () => {
+        const fetchOverride = createInvalidStaticGameFetch();
+
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+                fetchOverride={fetchOverride}
+            />,
+        );
+
+        act(() => {
+            MockWebSocket.instances[0].fireOpen();
+            MockWebSocket.instances[0].fireLines(buildLiveSnapshot(["+7776FU,T8"], "#RESIGN"));
+        });
+
+        await waitFor(() => expect(fetchOverride).toHaveBeenCalled());
+        expect(screen.queryByText(/終局済み棋譜の解析に失敗しました/)).toBeNull();
+        expect(screen.getByTestId("shogi-match")).toBeTruthy();
+    });
+
     it("reconnect 上限到達時に静的終局表示へ切り替え、上限エラーを二重表示しない", async () => {
         vi.useFakeTimers();
         try {
@@ -225,6 +318,45 @@ describe("RshogiCsaLiveViewer: static fallback", () => {
                 screen.getByText("ライブ接続は終了済みのため、保存済み棋譜を表示しています。"),
             ).toBeTruthy();
             expect(screen.queryByText(/再接続の上限/)).toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("snapshot 保持中でも reconnect 上限の fallback 失敗は理由と errorMessage を表示する", async () => {
+        vi.useFakeTimers();
+        try {
+            const fetchOverride = createStaticGameFailureFetch("fallback exploded");
+            render(
+                <RshogiCsaLiveViewer
+                    gameId="game-1"
+                    engineOptions={[]}
+                    manifestUrl="/nnue/manifest.json"
+                    apiBaseUrl="https://example.com/api/v1"
+                    fetchOverride={fetchOverride}
+                />,
+            );
+
+            const backoff = [1000, 2000, 4000, 8000, 16000, 30000];
+            act(() => {
+                MockWebSocket.instances[0].fireOpen();
+                MockWebSocket.instances[0].fireLines(buildLiveSnapshot(["+7776FU,T8"]));
+                MockWebSocket.instances[0].fireClose(1006, "flap");
+            });
+            for (let i = 0; i < backoff.length; i++) {
+                await act(async () => {
+                    vi.advanceTimersByTime(backoff[i]);
+                });
+                act(() => {
+                    MockWebSocket.instances[i + 1].fireOpen();
+                    MockWebSocket.instances[i + 1].fireClose(1006, "flap");
+                });
+            }
+
+            await act(async () => {});
+            await act(async () => {});
+            expect(screen.getByText(/再接続の上限/)).toBeTruthy();
+            expect(screen.getByText("fallback exploded")).toBeTruthy();
         } finally {
             vi.useRealTimers();
         }
@@ -331,6 +463,8 @@ describe("formatByoyomiClock", () => {
         expect(formatByoyomiClock(1)).toBe("0:01");
         expect(formatByoyomiClock(59_999)).toBe("0:59");
         expect(formatByoyomiClock(60_000)).toBe("1:00");
+        expect(formatByoyomiClock(119_999)).toBe("1:59");
+        expect(formatByoyomiClock(120_000)).toBe("2:00");
         expect(formatByoyomiClock(0)).toBe("0:00");
     });
 });

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -272,6 +272,8 @@ export const formatByoyomiClock = (ms: number): string => {
     const clampedMs = Number.isFinite(ms) ? Math.max(0, ms) : 0;
     const min = Math.floor(clampedMs / 60_000);
     const secWithinMinute = Math.ceil((clampedMs - min * 60_000) / 1000);
+    // 分は実ミリ秒の境界でだけ繰り上げるため、59.999 秒の ceil が 60 になっても
+    // 1:00 とは表示せず 0:59 に留める。
     const sec = Math.min(59, secWithinMinute);
     return `${min}:${String(sec).padStart(2, "0")}`;
 };
@@ -738,13 +740,14 @@ export function RshogiCsaLiveViewer({
                     } catch (parseError) {
                         setState((prev) => ({
                             ...prev,
-                            staticFallback: prev.snapshot
-                                ? undefined
-                                : {
-                                      status: "error",
-                                      reason,
-                                      errorMessage: `終局済み棋譜の解析に失敗しました: ${String(parseError)}`,
-                                  },
+                            staticFallback:
+                                prev.snapshot && reason === "terminal-snapshot"
+                                    ? undefined
+                                    : {
+                                          status: "error",
+                                          reason,
+                                          errorMessage: `終局済み棋譜の解析に失敗しました: ${String(parseError)}`,
+                                      },
                         }));
                         return;
                     }
@@ -757,24 +760,26 @@ export function RshogiCsaLiveViewer({
                     if (error instanceof RshogiGameNotFoundError) {
                         setState((prev) => ({
                             ...prev,
-                            staticFallback: prev.snapshot
-                                ? undefined
-                                : { status: "not-found", reason },
+                            staticFallback:
+                                prev.snapshot && reason === "terminal-snapshot"
+                                    ? undefined
+                                    : { status: "not-found", reason },
                         }));
                         return;
                     }
                     setState((prev) => ({
                         ...prev,
-                        staticFallback: prev.snapshot
-                            ? undefined
-                            : {
-                                  status: "error",
-                                  reason,
-                                  errorMessage:
-                                      error instanceof Error
-                                          ? error.message
-                                          : `終局済み棋譜の読み込みに失敗しました: ${String(error)}`,
-                              },
+                        staticFallback:
+                            prev.snapshot && reason === "terminal-snapshot"
+                                ? undefined
+                                : {
+                                      status: "error",
+                                      reason,
+                                      errorMessage:
+                                          error instanceof Error
+                                              ? error.message
+                                              : `終局済み棋譜の読み込みに失敗しました: ${String(error)}`,
+                                  },
                     }));
                 }
             })();
@@ -872,7 +877,8 @@ export function RshogiCsaLiveViewer({
             onError(err) {
                 setState((prev) => ({
                     ...prev,
-                    ...(prev.staticFallback?.status === "loading"
+                    ...(prev.staticFallback?.status === "loading" &&
+                    prev.staticFallback.reason === "terminal-snapshot"
                         ? {}
                         : {
                               lastError:

--- a/packages/ui/src/components/shogi-match.test.ts
+++ b/packages/ui/src/components/shogi-match.test.ts
@@ -111,11 +111,14 @@ describe("initialReview sync", () => {
     });
 });
 
-const setupInitialReviewSyncHarness = (initialReview: {
-    sfen: string;
-    moves: string[];
-    moveData?: (ReviewMoveEval | undefined)[];
-}) => {
+const setupInitialReviewSyncHarness = (
+    initialReview: {
+        sfen: string;
+        moves: string[];
+        moveData?: (ReviewMoveEval | undefined)[];
+    },
+    harnessOptions?: { beforeImportApply?: () => Promise<void> },
+) => {
     const importCalls: Array<{
         sfen: string;
         moves: string[];
@@ -139,6 +142,7 @@ const setupInitialReviewSyncHarness = (initialReview: {
                 },
             ) => {
                 importCalls.push({ sfen, moves: [...moves], moveData: options?.moveData });
+                await harnessOptions?.beforeImportApply?.();
                 if (options?.isStale?.()) return;
 
                 navigation.reset(createInitialPositionState(), sfen);
@@ -180,6 +184,42 @@ const setupInitialReviewSyncHarness = (initialReview: {
 };
 
 describe("useInitialReviewSync", () => {
+    it("import 未完了中に到着したコメント評価値を import 完了後に再適用する", async () => {
+        let resolveImport: (() => void) | undefined;
+        const importGate = new Promise<void>((resolve) => {
+            resolveImport = resolve;
+        });
+        const { result, rerender, importCalls } = setupInitialReviewSyncHarness(
+            {
+                sfen: "startpos",
+                moves: ["7g7f"],
+            },
+            { beforeImportApply: () => importGate },
+        );
+
+        await waitFor(() => expect(importCalls).toHaveLength(1));
+
+        await act(async () => {
+            rerender({
+                review: {
+                    sfen: "startpos",
+                    moves: ["7g7f"],
+                    moveData: [{ evalCp: 321, elapsedMs: 1500 }],
+                },
+            });
+        });
+
+        expect(result.current.kifMoves).toHaveLength(0);
+        await act(async () => {
+            resolveImport?.();
+            await importGate;
+        });
+
+        await waitFor(() => expect(result.current.kifMoves[0]?.evalCp).toBe(321));
+        expect(result.current.kifMoves[0]?.elapsedMs).toBe(1500);
+        expect(importCalls).toHaveLength(1);
+    });
+
     it("コメントのみが到着した場合は import せず diff 経路で実ナビゲーションへ反映する", async () => {
         const { result, rerender, importCalls } = setupInitialReviewSyncHarness({
             sfen: "startpos",

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -170,6 +170,8 @@ export const applyReviewMoveDataDiff = (
         if (isSameReviewMoveEval(previousMoveData?.[index], data)) continue;
 
         result.changed++;
+        // 評価値のクリアは diff 経路では非対応。moves 変化時の import 経路で
+        // 棋譜ツリーを再構築し、その際に古い評価値もリセットされる。
         if (!data) continue;
         const updateResult = navigation.updateMoveEvalAtPly(
             index + 1,
@@ -231,11 +233,10 @@ export function useInitialReviewSync({
     const reviewSfen = initialReview?.sfen;
     const reviewMoves = initialReview?.moves;
     const reviewMoveData = initialReview?.moveData;
-    const reviewMovesKey = reviewMoves?.join(" ");
     const reviewMoveDataKey = stringifyReviewMoveData(reviewMoveData);
-    const getLatestReviewMoveData = useEffectEvent(() => initialReview?.moveData);
+    const getLatestReview = useEffectEvent(() => initialReview);
     const applyLatestReviewMoveDataDiff = useEffectEvent((moves: string[]) => {
-        const nextMoveData = getLatestReviewMoveData();
+        const nextMoveData = getLatestReview()?.moveData;
         const result = applyReviewMoveDataDiff(
             navigationRef.current,
             moves,
@@ -249,18 +250,14 @@ export function useInitialReviewSync({
     });
 
     useEffect(() => {
-        if (
-            !positionReady ||
-            reviewSfen === undefined ||
-            reviewMoves === undefined ||
-            reviewMovesKey === undefined
-        ) {
+        if (!positionReady || reviewSfen === undefined || reviewMoves === undefined) {
             return;
         }
+        const movesKey = reviewMoves.join(" ");
         const loaded = loadedReviewRef.current;
         const nextSignature = {
             sfen: reviewSfen,
-            movesKey: reviewMovesKey,
+            movesKey,
             moveDataKey: reviewMoveDataKey,
         };
         const syncMode = getInitialReviewSyncMode(loaded, nextSignature);
@@ -284,15 +281,48 @@ export function useInitialReviewSync({
         // await 前に確定して StrictMode の二重実行を冪等化する。連続着手で先行 import が
         // 後着 import に追い越されたら、isStale で古い import の state 適用を中止する。
         loadedReviewRef.current = nextSignature;
-        loadedReviewMoveDataRef.current = getLatestReviewMoveData();
+        const importMoveData = getLatestReview()?.moveData;
+        loadedReviewMoveDataRef.current = importMoveData;
         void importSfenRef
             .current(reviewSfen, reviewMoves, {
                 gotoPly: wasFollowingTip ? undefined : restorePly,
-                moveData: getLatestReviewMoveData(),
+                moveData: importMoveData,
                 isStale: () =>
                     loadedReviewRef.current?.sfen !== reviewSfen ||
-                    loadedReviewRef.current?.movesKey !== reviewMovesKey ||
+                    loadedReviewRef.current?.movesKey !== movesKey ||
                     loadedReviewRef.current?.moveDataKey !== reviewMoveDataKey,
+            })
+            .then(() => {
+                setTimeout(() => {
+                    if (
+                        loadedReviewRef.current?.sfen !== reviewSfen ||
+                        loadedReviewRef.current?.movesKey !== movesKey
+                    ) {
+                        return;
+                    }
+                    const latestReview = getLatestReview();
+                    if (
+                        latestReview?.sfen !== reviewSfen ||
+                        latestReview.moves.join(" ") !== movesKey
+                    ) {
+                        return;
+                    }
+                    const latestMoveData = latestReview.moveData;
+                    const result = applyReviewMoveDataDiff(
+                        navigationRef.current,
+                        reviewMoves,
+                        loadedReviewMoveDataRef.current,
+                        latestMoveData,
+                    );
+                    if (result.skipped === 0) {
+                        loadedReviewMoveDataRef.current = latestMoveData;
+                        loadedReviewRef.current = {
+                            sfen: reviewSfen,
+                            movesKey,
+                            moveDataKey: stringifyReviewMoveData(latestMoveData),
+                        };
+                    }
+                }, 0);
             })
             .catch((err) => {
                 // SFEN 解析失敗などで取り込みが reject したら loaded マークを巻き戻し、
@@ -300,7 +330,7 @@ export function useInitialReviewSync({
                 // 先行していれば (参照不一致) リセットしない。
                 if (
                     loadedReviewRef.current?.sfen === reviewSfen &&
-                    loadedReviewRef.current?.movesKey === reviewMovesKey &&
+                    loadedReviewRef.current?.movesKey === movesKey &&
                     loadedReviewRef.current?.moveDataKey === reviewMoveDataKey
                 ) {
                     loadedReviewRef.current = null;
@@ -308,7 +338,7 @@ export function useInitialReviewSync({
                 }
                 console.error("[rshogi] initialReview の取り込みに失敗しました", err);
             });
-    }, [positionReady, reviewSfen, reviewMoves, reviewMovesKey, reviewMoveDataKey]);
+    }, [positionReady, reviewSfen, reviewMoves, reviewMoveDataKey]);
 }
 
 interface ShogiMatchProps {

--- a/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useKifuNavigation.ts
@@ -402,6 +402,9 @@ export function useKifuNavigation(options: UseKifuNavigationOptions): UseKifuNav
         }
 
         setTree((prev) => {
+            // Concurrent Mode ではこの関数が "applied" を返したあとに state 更新が
+            // 古い render 由来として破棄される可能性がある。呼び出し側の applied 数は
+            // UI 反映の厳密な件数ではなく、適用を試みた件数として扱う。
             const nextNodeId = findNodeByPlyInMainLine(prev, ply);
             if (!nextNodeId) return prev;
 


### PR DESCRIPTION
マージ済み PR #73 / #75 / #76 のレビューコメント対応のフォローアップ。

## P2 修正

1. **初回 importSfen 完了前に届いたコメント評価値の恒久欠落**（PR #75 指摘）: import 完了後（React commit 後）に最新 `moveData` の diff を再適用。後着 import との競合は `loadedReviewRef` の sfen/movesKey と `getLatestReview()` の二重ガードで防止。回帰テスト（import 保留中にコメント到着 → 完了後に反映、再 import なし）追加
2. **reconnect 上限フォールバックの取得失敗時に理由表示が消える**（PR #73 指摘）: snapshot 保持時の失敗表示抑制を `terminal-snapshot` 起因のみに限定。reconnect-limit 起因では「再接続の上限」+ フォールバック失敗を表示。回帰テスト追加

## 軽微対応

- `isRoomFullText` をサーバー契約（close(1013, "room full") / MONITOR2 ERROR の room full）どおりの `"room full"` マッチのみに縮小 + 契約外文言の否定テスト（サーバー実装 rshogi#866 で reason "room full" 固定を確認済み）
- フォールバック失敗パスのテスト3種（not-found / 汎用エラー / parse 例外 + snapshot 保持時の抑制）
- 冗長ガード削除・`getLatestReviewMoveData()` 二重呼び出しの変数化
- 意図コメント: 非 room-full MONITOR2 ERROR の無視 / diff 経路の eval クリア非対応 / Concurrent Mode の applied 過剰カウント / `formatByoyomiClock` の 59 クランプ
- `formatByoyomiClock` 複数分境界テスト（119999ms→"1:59" / 120000ms→"2:00"）
- `increment: 0` の `incrementSeconds: undefined` は参照側（`&& > 0` / `?? 0`）で 0 と同等に扱われることを確認、修正不要

## 検証
- クリーンコンテキストレビュアー（Opus): **APPROVE**（P2-1 の stale 競合・moves 伸長時の誤適用なし、P2-2 の満席経路への副作用なしを個別検証。ビルド成果物の混入なしも確認）
- UI 58 + match-client 47 テスト green、`turbo lint typecheck test` green（web RoomPage のローカル env 由来失敗のみ既知）、`knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C