### PR TITLE
docs(ui): live 差分適用の setTimeout(0) とリトライ設計の意図コメントを追加

### DIFF
--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -293,6 +293,10 @@ export function useInitialReviewSync({
                     loadedReviewRef.current?.moveDataKey !== reviewMoveDataKey,
             })
             .then(() => {
+                // importSfen の resolve 時点では React の commit が未完了のことがあるため、
+                // macrotask (setTimeout 0) に後退させ、commit 後の navigationRef
+                // (updateMoveEvalAtPly の missing 判定が参照するツリー) に対して
+                // import 中に届いたコメント評価値の diff を再適用する。
                 setTimeout(() => {
                     if (
                         loadedReviewRef.current?.sfen !== reviewSfen ||
@@ -314,6 +318,9 @@ export function useInitialReviewSync({
                         loadedReviewMoveDataRef.current,
                         latestMoveData,
                     );
+                    // skipped > 0 (ply 未登録等) の場合は ref を確定せず、
+                    // 次の reviewMoveData 変化時に同じ差分の再適用を試みる (リトライ)。
+                    // 差分適用は冪等なので重複適用の害はない。
                     if (result.skipped === 0) {
                         loadedReviewMoveDataRef.current = latestMoveData;
                         loadedReviewRef.current = {


### PR DESCRIPTION
PR #77 のレビューコメント対応（コメント追記のみ、ロジック変更なし）。

- `setTimeout(0)` を使う理由（importSfen resolve 時点では React commit 未完了のため、commit 後の navigationRef に対して diff を再適用する）を明記
- `skipped > 0` 時に ref を確定しない設計が「次の reviewMoveData 変化時のリトライ」を意図していること、差分適用が冪等であることを明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C