### PR TITLE
fix(match-client,ui): #ABNORMAL 終局コード未対応による再接続ループを修正

### DIFF
--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -38,6 +38,20 @@ export default defineConfig({
                 replacement: path.resolve(rootDir, "../../packages/engine-wasm/src"),
             },
             {
+                find: "../pkg/engine_wasm.js",
+                replacement: path.resolve(
+                    rootDir,
+                    "../../packages/engine-wasm/src/__mocks__/engine-wasm-pkg.ts",
+                ),
+            },
+            {
+                find: "../pkg-threaded/engine_wasm.js",
+                replacement: path.resolve(
+                    rootDir,
+                    "../../packages/engine-wasm/src/__mocks__/engine-wasm-pkg.ts",
+                ),
+            },
+            {
                 find: /^@shogi\/match-client$/,
                 replacement: path.resolve(rootDir, "../../packages/match-client/src"),
             },

--- a/packages/engine-tauri/src/preview-session-service.test.ts
+++ b/packages/engine-tauri/src/preview-session-service.test.ts
@@ -70,7 +70,7 @@ describe("createPreviewSessionService", () => {
 
     describe("孤児セッション防止", () => {
         it("起動中に再 start すると古い結果を孤児として quit する", async () => {
-            let resolveFirst: (v: string) => void;
+            let resolveFirst: ((v: string) => void) | undefined;
             const firstStart = new Promise<string>((r) => {
                 resolveFirst = r;
             });
@@ -88,7 +88,8 @@ describe("createPreviewSessionService", () => {
             expect(sid2).toBe("session-2");
 
             // 最初の起動が完了 → 孤児としてquitされるはず
-            resolveFirst!("session-orphan");
+            if (!resolveFirst) throw new Error("first start resolver was not initialized");
+            resolveFirst("session-orphan");
             await expect(p1).rejects.toThrow("Start request superseded");
 
             expect(mockInvoke).toHaveBeenCalledWith("usi_engine_quit", {
@@ -97,7 +98,7 @@ describe("createPreviewSessionService", () => {
         });
 
         it("起動中に dispose すると完了後の結果を孤児として quit する", async () => {
-            let resolveStart: (v: string) => void;
+            let resolveStart: ((v: string) => void) | undefined;
             const startPromise = new Promise<string>((r) => {
                 resolveStart = r;
             });
@@ -118,7 +119,8 @@ describe("createPreviewSessionService", () => {
             expect(svc.getStatus()).toEqual({ state: "idle" });
 
             // 起動が完了 → 孤児としてquitされるはず
-            resolveStart!("session-orphan");
+            if (!resolveStart) throw new Error("start resolver was not initialized");
+            resolveStart("session-orphan");
             await expect(p).rejects.toThrow("Start request superseded");
 
             expect(mockInvoke).toHaveBeenCalledWith("usi_engine_quit", {

--- a/packages/engine-wasm/src/__mocks__/engine-wasm-pkg.ts
+++ b/packages/engine-wasm/src/__mocks__/engine-wasm-pkg.ts
@@ -17,3 +17,13 @@ export const wasm_replay_moves_strict = vi.fn().mockReturnValue({
     last_ply: 0,
     board: {},
 });
+export const initThreadPool = vi.fn().mockResolvedValue(undefined);
+export const init = vi.fn();
+export const dispose = vi.fn();
+export const load_model = vi.fn();
+export const load_position = vi.fn();
+export const apply_moves = vi.fn();
+export const search = vi.fn();
+export const stop = vi.fn();
+export const set_event_handler = vi.fn();
+export const set_option = vi.fn();

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -255,6 +255,47 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         expect(events.ends.length).toBe(1);
         expect(events.staticFallbacks).toEqual(["terminal-snapshot"]);
     });
+
+    it("snapshot 末尾に #ABNORMAL があると abnormal/ABNORMAL で終局扱いにして reconnect しない", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([], "#ABNORMAL"));
+        expect(events.ends).toEqual([{ kind: "abnormal", endReason: "ABNORMAL" }]);
+        expect(events.snapshot[0].finalResult).toEqual({
+            kind: "abnormal",
+            endReason: "ABNORMAL",
+        });
+        expect(events.staticFallbacks).toEqual(["terminal-snapshot"]);
+
+        ws.fireClose(1000, "spectate finished");
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(1);
+        expect(events.states).toContain("closed");
+    });
+
+    it("未知の snapshot result_code でも終局扱いにして reconnect しない", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([], "#FUTURE_CODE"));
+        expect(events.ends).toEqual([{ kind: "abort", endReason: "FUTURE_CODE" }]);
+        expect(events.staticFallbacks).toEqual(["terminal-snapshot"]);
+
+        ws.fireClose(1000, "spectate finished");
+        vi.advanceTimersByTime(60000);
+        expect(wsInstances.length).toBe(1);
+    });
 });
 
 describe("subscribeRshogiLiveGame: Floodgate コメント (eval / PV)", () => {

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -456,7 +456,9 @@ const decodeSnapshotBlock = (
             gote: summary.whiteRemainingMs ?? 0,
             sideToMove,
         },
-        finalResult: resultCodeLine ? decodeResultCode(resultCodeLine, state.turn) : undefined,
+        finalResult: resultCodeLine
+            ? decodeSnapshotResultCode(resultCodeLine, state.turn)
+            : undefined,
     };
 
     return { snapshot, finalResultLine: resultCodeLine };
@@ -464,6 +466,10 @@ const decodeSnapshotBlock = (
 
 /**
  * `#RESIGN` / `#TIME_UP` 等の result_code 行から `RshogiGameResult` を導出する。
+ *
+ * サーバーの result_code は rshogi の primary_result_code と一致し、
+ * `#RESIGN` / `#TIME_UP` / `#ILLEGAL_MOVE` / `#JISHOGI` /
+ * `#OUTE_SENNICHITE` / `#SENNICHITE` / `#MAX_MOVES` / `#ABNORMAL` の集合。
  *
  * snapshot 末尾の result_code は「敗者視点」の理由として届く。
  * - `#RESIGN`: 手番側が投了 → 敗者 = `currentTurn`、勝者 = 反対側
@@ -521,6 +527,11 @@ const decodeResultCode = (
             endReason = "ILLEGAL";
             winnerSide = "draw";
             break;
+        case "#ABNORMAL":
+            kind = "abnormal";
+            endReason = "ABNORMAL";
+            winnerSide = "draw";
+            break;
         default:
             return undefined;
     }
@@ -533,6 +544,17 @@ const decodeResultCode = (
         winner = currentTurn;
     }
     return { kind, winner, endReason };
+};
+
+const decodeSnapshotResultCode = (
+    line: string,
+    currentTurn: "sente" | "gote",
+): RshogiGameResult | undefined => {
+    const result = decodeResultCode(line, currentTurn);
+    if (result) return result;
+    const code = line.trim();
+    if (!code.startsWith("#")) return undefined;
+    return { kind: "abort", endReason: code.slice(1) || "UNKNOWN_RESULT_CODE" };
 };
 
 /**

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -236,6 +236,33 @@ describe("RshogiCsaLiveViewer: static fallback", () => {
         });
     });
 
+    it("terminal snapshot 0手後の fallback 404 は再読み込み誘導ではなく未保存表示にする", async () => {
+        const fetchOverride = createStaticGameNotFoundFetch();
+
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+                fetchOverride={fetchOverride}
+            />,
+        );
+
+        act(() => {
+            MockWebSocket.instances[0].fireOpen();
+            MockWebSocket.instances[0].fireLines(buildLiveSnapshot([], "#ABNORMAL"));
+        });
+
+        await waitFor(() => expect(fetchOverride).toHaveBeenCalled());
+        await waitFor(() => {
+            expect(screen.getByText(/この対局の棋譜データは保存されていません/)).toBeTruthy();
+        });
+        expect(screen.queryByText(/少し時間をおいて再読み込みしてください/)).toBeNull();
+        expect(screen.getByText(/この対局は終局 \(異常終了\)として終了済みです/)).toBeTruthy();
+        expect(screen.getByTestId("shogi-match").getAttribute("data-move-count")).toBe("0");
+    });
+
     it("静的 fallback が汎用エラーになったら errorMessage を表示する", async () => {
         const fetchOverride = createStaticGameFailureFetch("fallback exploded");
 
@@ -863,5 +890,15 @@ describe("RshogiLiveMetaPanel: 読み筋の表示", () => {
     it("PV が無いときは読み筋を表示しない", () => {
         render(<RshogiLiveMetaPanel meta={META} />);
         expect(screen.queryByText("読み筋")).toBeNull();
+    });
+
+    it("#MAX_MOVES は勝者不明でも引き分けとして表示する", () => {
+        render(
+            <RshogiLiveMetaPanel
+                meta={META}
+                result={{ kind: "max_moves", endReason: "MAX_MOVES" }}
+            />,
+        );
+        expect(screen.getByText("引き分け (最大手数)")).toBeDefined();
     });
 });

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -399,14 +399,29 @@ const RESULT_KIND_LABEL: Record<RshogiGameResult["kind"], string> = {
 };
 
 const formatResultText = (meta: RshogiGameMeta | undefined, result: RshogiGameResult): string => {
+    const isDrawishResult = result.kind === "draw" || result.kind === "max_moves";
     const winnerLabel =
         result.winner === "sente"
             ? `先手${meta?.senteName ? ` (${meta.senteName})` : ""} 勝ち`
             : result.winner === "gote"
               ? `後手${meta?.goteName ? ` (${meta.goteName})` : ""} 勝ち`
-              : "引き分け";
+              : isDrawishResult
+                ? "引き分け"
+                : "終局";
     const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
     return `${winnerLabel} (${reason})`;
+};
+
+const formatTerminalSnapshotNotFoundText = (
+    reason: RshogiLiveStaticFallbackReason,
+    snapshot: RshogiLiveSnapshot | null,
+    result: RshogiGameResult | undefined,
+): string => {
+    if (reason !== "terminal-snapshot" || !snapshot || snapshot.moves.length > 0) {
+        return "終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。";
+    }
+    const resultText = result ? formatResultText(snapshot.meta, result) : "終局";
+    return `この対局は${resultText}として終了済みです。この対局の棋譜データは保存されていません。`;
 };
 
 /** スコアボード片側分の表示用残時間 (本体 or 秒読み)。 */
@@ -762,7 +777,9 @@ export function RshogiCsaLiveViewer({
                             ...prev,
                             staticFallback:
                                 prev.snapshot && reason === "terminal-snapshot"
-                                    ? undefined
+                                    ? prev.snapshot.moves.length > 0
+                                        ? undefined
+                                        : { status: "not-found", reason }
                                     : { status: "not-found", reason },
                         }));
                         return;
@@ -982,7 +999,11 @@ export function RshogiCsaLiveViewer({
                 {state.staticFallback?.status === "loading" && <p>終局済み棋譜を読み込み中...</p>}
                 {state.staticFallback?.status === "not-found" && (
                     <p className="text-destructive">
-                        終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。
+                        {formatTerminalSnapshotNotFoundText(
+                            state.staticFallback.reason,
+                            state.snapshot,
+                            state.result,
+                        )}
                     </p>
                 )}
                 {state.staticFallback?.status === "error" && (
@@ -1013,7 +1034,11 @@ export function RshogiCsaLiveViewer({
             )}
             {state.staticFallback?.status === "not-found" && (
                 <div className="px-4 pt-2 text-xs text-destructive">
-                    終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。
+                    {formatTerminalSnapshotNotFoundText(
+                        state.staticFallback.reason,
+                        state.snapshot,
+                        state.result,
+                    )}
                 </div>
             )}
             {state.staticFallback?.status === "error" && (


### PR DESCRIPTION
## 実障害（本番で再現確認済み）

終局済み対局 `be-A1-1783183305-1783183314456` の live ページで再接続ループ →「再接続の上限」+「終局済み棋譜がまだ見つかりませんでした。少し時間をおいて再読み込みしてください。」が表示される。

原因:
1. サーバーは正しく終局即 push（`Game_Summary` + `#ABNORMAL` + close(1000)）している
2. クライアントの `decodeResultCode` に `#ABNORMAL` の case が無く、終局 snapshot と認識されず再接続ループに入っていた
3. この対局は棋譜が R2 にも無く（REST 404・0手 snapshot）、上限後のフォールバックが誤誘導文言を出していた

## 修正

- `decodeResultCode` に `#ABNORMAL`（kind `"abnormal"`、表示「異常終了」）を追加。サーバーの `primary_result_code` 全集合（#RESIGN/#TIME_UP/#ILLEGAL_MOVE/#JISHOGI/#OUTE_SENNICHITE/#SENNICHITE/#MAX_MOVES/#ABNORMAL）との対応コメントを付記
- **未知コード防御**: snapshot 内に `#` 結果コード行があれば decode 不能でも terminal 扱いにして再接続を停止（snapshot パース内に限定、進行中対局への誤検知経路なしをレビューで確認済み）
- 棋譜未保存の終局対局（0手 + 404）は「棋譜データは保存されていません」表示に変更。棋譜あり終局 + 一時的 404 は従来どおり snapshot 表示維持
- `#MAX_MOVES` の「引き分け」表示維持の回帰テスト付き

## 検証

- クリーンコンテキストレビュアー（Opus）: **APPROVE**（#ABNORMAL/#FUTURE_CODE で再接続しないこと、0手+404 の表示、既存コード経路の回帰なし、付随の vitest mock alias が CI/build に影響しないことを個別検証）
- live.test 49 + viewer.test 52 green、`turbo lint typecheck test` / `knip:ci` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C