### PR TITLE
refactor(ui,match-client): PR #77-#79 レビュー指摘の可読性改善

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -546,6 +546,9 @@ const decodeResultCode = (
     return { kind, winner, endReason };
 };
 
+// snapshot 限定の防御: 既知コード以外でも `#` 行なら terminal 扱いにして
+// 再接続ループを防ぐ (将来サーバーに結果コードが増えた場合の再発防止)。
+// broadcast 行は decodeResultCode を直接通るため、この緩い判定は適用されない。
 const decodeSnapshotResultCode = (
     line: string,
     currentTurn: "sente" | "gote",

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -775,11 +775,14 @@ export function RshogiCsaLiveViewer({
                     if (error instanceof RshogiGameNotFoundError) {
                         setState((prev) => ({
                             ...prev,
+                            // 棋譜つき terminal snapshot を表示中の一時的 404 のみ非表示
+                            // (snapshot 表示を維持)。0手 snapshot や reconnect 上限起因の
+                            // 404 は not-found を表示する。
                             staticFallback:
-                                prev.snapshot && reason === "terminal-snapshot"
-                                    ? prev.snapshot.moves.length > 0
-                                        ? undefined
-                                        : { status: "not-found", reason }
+                                prev.snapshot &&
+                                reason === "terminal-snapshot" &&
+                                prev.snapshot.moves.length > 0
+                                    ? undefined
                                     : { status: "not-found", reason },
                         }));
                         return;
@@ -980,6 +983,17 @@ export function RshogiCsaLiveViewer({
         );
     }
 
+    // not-found 文言は「初期 snapshot 待機中」と「snapshot 取得済み」の両ブランチで
+    // 表示するため、一度だけ組み立てて使い回す。
+    const staticFallbackNotFoundText =
+        state.staticFallback?.status === "not-found"
+            ? formatTerminalSnapshotNotFoundText(
+                  state.staticFallback.reason,
+                  state.snapshot,
+                  state.result,
+              )
+            : undefined;
+
     if (!state.snapshot) {
         // 初回 snapshot 受信前のローディング表示。
         // `packages/ui/AGENTS.md` の規約に従い、コンポーネント自身は margin
@@ -997,14 +1011,8 @@ export function RshogiCsaLiveViewer({
                 </div>
                 <p>初期 snapshot を待機中...</p>
                 {state.staticFallback?.status === "loading" && <p>終局済み棋譜を読み込み中...</p>}
-                {state.staticFallback?.status === "not-found" && (
-                    <p className="text-destructive">
-                        {formatTerminalSnapshotNotFoundText(
-                            state.staticFallback.reason,
-                            state.snapshot,
-                            state.result,
-                        )}
-                    </p>
+                {staticFallbackNotFoundText !== undefined && (
+                    <p className="text-destructive">{staticFallbackNotFoundText}</p>
                 )}
                 {state.staticFallback?.status === "error" && (
                     <p className="text-destructive">{state.staticFallback.errorMessage}</p>
@@ -1032,13 +1040,9 @@ export function RshogiCsaLiveViewer({
                     終局済み棋譜を読み込み中...
                 </div>
             )}
-            {state.staticFallback?.status === "not-found" && (
+            {staticFallbackNotFoundText !== undefined && (
                 <div className="px-4 pt-2 text-xs text-destructive">
-                    {formatTerminalSnapshotNotFoundText(
-                        state.staticFallback.reason,
-                        state.snapshot,
-                        state.result,
-                    )}
+                    {staticFallbackNotFoundText}
                 </div>
             )}
             {state.staticFallback?.status === "error" && (

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -297,6 +297,8 @@ export function useInitialReviewSync({
                 // macrotask (setTimeout 0) に後退させ、commit 後の navigationRef
                 // (updateMoveEvalAtPly の missing 判定が参照するツリー) に対して
                 // import 中に届いたコメント評価値の diff を再適用する。
+                // (.then() 時点では既に非同期コンテキストのため flushSync による
+                // 同期 commit の強制は使えない)
                 setTimeout(() => {
                     if (
                         loadedReviewRef.current?.sfen !== reviewSfen ||


### PR DESCRIPTION
PR #77〜#79 のレビューコメントのうち妥当なものへの対応（挙動変更なし）。

- `decodeSnapshotResultCode`: snapshot 限定の防御的フォールバックである意図コメントを追加（PR#79 指摘）
- 終局フォールバック 404 の二重三項演算子を単一条件へ整理（両 else 枝が同一値のため挙動不変）+ 意図コメント（PR#79 指摘）
- `formatTerminalSnapshotNotFoundText` の同一引数二重呼び出しを変数へ集約（PR#79 指摘）
- `setTimeout(0)` コメントに「.then() 時点では非同期コンテキストのため flushSync は使えない」旨を補足（PR#78 指摘）

見送り: `winnerSide: "none"` への改名（PR#79 レビュー自身がスコープ外と明記）。PR#77 の提案2件は PR#78 で対応済み。

検証: ui 365 / match-client 92 テスト green、lint / typecheck / knip:ci green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPTHFUwXRuZHuzCeZQsY9C