### PR TITLE
fix(web): トップ対局画面のレイアウト崩れ修正とヘッダー導線の再設計

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -59,7 +59,11 @@ function App() {
     return (
         <>
             <PageHeader items={[{ label: "ラム将棋" }]} right={<HeaderNav />} />
-            <main className="mx-auto flex max-w-[1100px] flex-col gap-3 pt-3 md:px-5">
+            {/* 対局レイアウトは 3 カラム (サイドバー+盤+棋譜 ≈ 1260px) で幅が広い。
+                中央寄せ・横スクロールの管理は PCLayout 側 (overflow-x-auto + mx-auto
+                w-max) が担うため、ここでは max-width を課さず全幅で渡す。max-width で
+                挟むと中央寄せが効かず常時横スクロールになる。 */}
+            <main className="flex w-full flex-col gap-3 pt-3">
                 <ShogiMatch
                     key={initialReview ? "review" : "normal"}
                     engineOptions={engineOptions}

--- a/apps/web/src/components/HeaderNav.tsx
+++ b/apps/web/src/components/HeaderNav.tsx
@@ -1,43 +1,108 @@
+import { cn } from "@shogi/design-system";
 import { Link, useLocation } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useAuthSession } from "../hooks/useAuthSession";
 
-const linkClass =
-    "rounded-md border border-border px-3 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground";
-const linkAccentClass =
-    "rounded-md border border-wafuu-shu px-3 py-0.5 text-xs text-wafuu-shu transition-colors hover:bg-wafuu-shu/10";
+// リンクの見た目は「現在ページかどうか」で表示/非表示を切り替えず、常に全導線を
+// 出したまま aria-current + 配色で現在地を示す。項目数が遷移で増減しないため
+// ヘッダーのレイアウトシフトが起きない。geometry (border/padding) は variant/active
+// 間で共通にし、色だけを変えて幅の揺れも防ぐ。
+const baseLinkClass =
+    "rounded-md border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-colors";
+const variantClass = {
+    // 主導線 (対局・オンライン): 朱アクセントで優先度を示す
+    primary: "border-wafuu-shu/40 text-wafuu-shu hover:bg-wafuu-shu/10",
+    // 副導線 (棋譜・NNUE・観戦系・ログイン): 落ち着いた muted 系
+    default: "border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground",
+} as const;
+// 現在ページ: variant に関わらず塗りアクセントで現在地を強調
+const activeClass = "border-wafuu-shu bg-wafuu-shu/10 text-wafuu-shu";
+
+type NavVariant = keyof typeof variantClass;
+
+// Link の `to` は登録ルートで型付けされる。ヘッダーで使う遷移先はいずれも
+// params/search を要求しない静的パスなので、その literal union に限定する。
+type NavTo =
+    | "/"
+    | "/online"
+    | "/games"
+    | "/nnue"
+    | "/rshogi-viewer/live"
+    | "/rshogi-viewer"
+    | "/public/games"
+    | "/auth";
+
+function NavLink({
+    to,
+    label,
+    active,
+    variant = "default",
+}: {
+    to: NavTo;
+    label: string;
+    active: boolean;
+    variant?: NavVariant;
+}): ReactElement {
+    return (
+        <Link
+            to={to}
+            aria-current={active ? "page" : undefined}
+            className={cn(baseLinkClass, active ? activeClass : variantClass[variant])}
+        >
+            {label}
+        </Link>
+    );
+}
+
+/** グループ区切りの縦罫 */
+function Divider(): ReactElement {
+    return <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />;
+}
 
 export function HeaderNav(): ReactElement {
     const { session } = useAuthSession();
     const { pathname } = useLocation();
 
+    // 現在地判定。CSA 観戦系は live 一覧/観戦 と単局ビューアが prefix を共有する。
+    // 単局ビューアの動的 param (/rshogi-viewer/$gameId) が "live..." で始まる gameId を
+    // ライブと誤判定しないよう、live はセグメント境界で判定する (一覧 `/live` と観戦
+    // `/live/<id>` のみ)。ビューアは残りの /rshogi-viewer 配下 (一覧・単局)。
+    const isPlay = pathname === "/";
+    const isOnline = pathname.startsWith("/online");
     const isGames = pathname.startsWith("/games");
     const isNnue = pathname === "/nnue";
-    const isOnline = pathname.startsWith("/online");
+    const isLive =
+        pathname === "/rshogi-viewer/live" || pathname.startsWith("/rshogi-viewer/live/");
+    const isViewer = pathname.startsWith("/rshogi-viewer") && !isLive;
+    const isPublicGames = pathname.startsWith("/public/games");
     const isAuth = pathname === "/auth";
 
     return (
-        <div className="flex items-center gap-2">
-            {!isGames && (
-                <Link to="/games" className={linkClass}>
-                    棋譜一覧
-                </Link>
-            )}
-            {!isNnue && (
-                <Link to="/nnue" className={linkClass}>
-                    NNUE
-                </Link>
-            )}
-            {!isOnline && (
-                <Link to="/online" className={linkAccentClass}>
-                    オンライン対局 →
-                </Link>
-            )}
-            {!isAuth && (
-                <Link to="/auth" className={linkClass}>
-                    {session?.authenticated ? session.user.displayName : "ログイン"}
-                </Link>
-            )}
-        </div>
+        <nav aria-label="サイト内ナビゲーション" className="flex items-center gap-1.5">
+            {/* アプリ本体機能 */}
+            <NavLink to="/" label="対局" active={isPlay} variant="primary" />
+            <NavLink to="/online" label="オンライン" active={isOnline} variant="primary" />
+            <NavLink to="/games" label="棋譜" active={isGames} />
+            <NavLink to="/nnue" label="NNUE" active={isNnue} />
+
+            <Divider />
+
+            {/* CSA サーバー連携 (観戦・棋譜) */}
+            <span className="hidden select-none text-[10px] text-muted-foreground sm:inline">
+                観戦
+            </span>
+            <NavLink to="/rshogi-viewer/live" label="ライブ" active={isLive} />
+            <NavLink to="/rshogi-viewer" label="棋譜ビューア" active={isViewer} />
+            <NavLink to="/public/games" label="公開棋譜" active={isPublicGames} />
+
+            <Divider />
+
+            {/* アカウント */}
+            <NavLink
+                to="/auth"
+                label={session?.authenticated ? session.user.displayName : "ログイン"}
+                active={isAuth}
+            />
+        </nav>
     );
 }

--- a/apps/web/src/components/HeaderNav.tsx
+++ b/apps/web/src/components/HeaderNav.tsx
@@ -1,14 +1,14 @@
 import { cn } from "@shogi/design-system";
+import { Popover, PopoverContent, PopoverTrigger } from "@shogi/ui";
 import { Link, useLocation } from "@tanstack/react-router";
 import type { ReactElement } from "react";
+import { useState } from "react";
 import { useAuthSession } from "../hooks/useAuthSession";
 
 // リンクの見た目は「現在ページかどうか」で表示/非表示を切り替えず、常に全導線を
 // 出したまま aria-current + 配色で現在地を示す。項目数が遷移で増減しないため
 // ヘッダーのレイアウトシフトが起きない。geometry (border/padding) は variant/active
 // 間で共通にし、色だけを変えて幅の揺れも防ぐ。
-const baseLinkClass =
-    "rounded-md border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap transition-colors";
 const variantClass = {
     // 主導線 (対局・オンライン): 朱アクセントで優先度を示す
     primary: "border-wafuu-shu/40 text-wafuu-shu hover:bg-wafuu-shu/10",
@@ -17,6 +17,10 @@ const variantClass = {
 } as const;
 // 現在ページ: variant に関わらず塗りアクセントで現在地を強調
 const activeClass = "border-wafuu-shu bg-wafuu-shu/10 text-wafuu-shu";
+// PC ヘッダーの横並びピル / モバイルドロワーの縦積み行。geometry のみ差し替え、
+// 配色 (variantClass/activeClass) は共通で再利用する。
+const pillClass = "rounded-md border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap";
+const rowClass = "block w-full rounded-md border px-3 py-1.5 text-sm font-medium";
 
 type NavVariant = keyof typeof variantClass;
 
@@ -32,77 +36,143 @@ type NavTo =
     | "/public/games"
     | "/auth";
 
-function NavLink({
-    to,
-    label,
-    active,
-    variant = "default",
-}: {
+interface NavItem {
     to: NavTo;
     label: string;
     active: boolean;
     variant?: NavVariant;
-}): ReactElement {
-    return (
-        <Link
-            to={to}
-            aria-current={active ? "page" : undefined}
-            className={cn(baseLinkClass, active ? activeClass : variantClass[variant])}
-        >
-            {label}
-        </Link>
-    );
 }
 
-/** グループ区切りの縦罫 */
-function Divider(): ReactElement {
-    return <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />;
+function NavLink({
+    item,
+    layout,
+    onNavigate,
+}: {
+    item: NavItem;
+    layout: "pill" | "row";
+    onNavigate?: () => void;
+}): ReactElement {
+    const geometry = layout === "pill" ? pillClass : rowClass;
+    return (
+        <Link
+            to={item.to}
+            aria-current={item.active ? "page" : undefined}
+            onClick={onNavigate}
+            className={cn(
+                geometry,
+                "transition-colors",
+                item.active ? activeClass : variantClass[item.variant ?? "default"],
+            )}
+        >
+            {item.label}
+        </Link>
+    );
 }
 
 export function HeaderNav(): ReactElement {
     const { session } = useAuthSession();
     const { pathname } = useLocation();
+    const [menuOpen, setMenuOpen] = useState(false);
 
     // 現在地判定。CSA 観戦系は live 一覧/観戦 と単局ビューアが prefix を共有する。
     // 単局ビューアの動的 param (/rshogi-viewer/$gameId) が "live..." で始まる gameId を
     // ライブと誤判定しないよう、live はセグメント境界で判定する (一覧 `/live` と観戦
     // `/live/<id>` のみ)。ビューアは残りの /rshogi-viewer 配下 (一覧・単局)。
-    const isPlay = pathname === "/";
-    const isOnline = pathname.startsWith("/online");
-    const isGames = pathname.startsWith("/games");
-    const isNnue = pathname === "/nnue";
     const isLive =
         pathname === "/rshogi-viewer/live" || pathname.startsWith("/rshogi-viewer/live/");
-    const isViewer = pathname.startsWith("/rshogi-viewer") && !isLive;
-    const isPublicGames = pathname.startsWith("/public/games");
-    const isAuth = pathname === "/auth";
+
+    const appItems: NavItem[] = [
+        { to: "/", label: "対局", active: pathname === "/", variant: "primary" },
+        {
+            to: "/online",
+            label: "オンライン",
+            active: pathname.startsWith("/online"),
+            variant: "primary",
+        },
+        { to: "/games", label: "棋譜", active: pathname.startsWith("/games") },
+        { to: "/nnue", label: "NNUE", active: pathname === "/nnue" },
+    ];
+    const csaItems: NavItem[] = [
+        { to: "/rshogi-viewer/live", label: "ライブ", active: isLive },
+        {
+            to: "/rshogi-viewer",
+            label: "棋譜ビューア",
+            active: pathname.startsWith("/rshogi-viewer") && !isLive,
+        },
+        { to: "/public/games", label: "公開棋譜", active: pathname.startsWith("/public/games") },
+    ];
+    const authItem: NavItem = {
+        to: "/auth",
+        label: session?.authenticated ? session.user.displayName : "ログイン",
+        active: pathname === "/auth",
+    };
 
     return (
-        <nav aria-label="サイト内ナビゲーション" className="flex items-center gap-1.5">
-            {/* アプリ本体機能 */}
-            <NavLink to="/" label="対局" active={isPlay} variant="primary" />
-            <NavLink to="/online" label="オンライン" active={isOnline} variant="primary" />
-            <NavLink to="/games" label="棋譜" active={isGames} />
-            <NavLink to="/nnue" label="NNUE" active={isNnue} />
+        <>
+            {/* PC: 全導線を横並びピルで常時表示。狭幅では溢れるので min-[880px] 以上のみ。 */}
+            <nav
+                aria-label="サイト内ナビゲーション"
+                className="hidden items-center gap-1.5 min-[880px]:flex"
+            >
+                {appItems.map((item) => (
+                    <NavLink key={item.to} item={item} layout="pill" />
+                ))}
+                <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />
+                {/* CSA サーバー連携 (観戦・棋譜) */}
+                <span className="select-none text-[10px] text-muted-foreground">観戦</span>
+                {csaItems.map((item) => (
+                    <NavLink key={item.to} item={item} layout="pill" />
+                ))}
+                <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />
+                <NavLink item={authItem} layout="pill" />
+            </nav>
 
-            <Divider />
-
-            {/* CSA サーバー連携 (観戦・棋譜) */}
-            <span className="hidden select-none text-[10px] text-muted-foreground sm:inline">
-                観戦
-            </span>
-            <NavLink to="/rshogi-viewer/live" label="ライブ" active={isLive} />
-            <NavLink to="/rshogi-viewer" label="棋譜ビューア" active={isViewer} />
-            <NavLink to="/public/games" label="公開棋譜" active={isPublicGames} />
-
-            <Divider />
-
-            {/* アカウント */}
-            <NavLink
-                to="/auth"
-                label={session?.authenticated ? session.user.displayName : "ログイン"}
-                active={isAuth}
-            />
-        </nav>
+            {/* モバイル: 全導線をドロワーに畳む。トリガーは固定幅なのでヘッダーが
+                溢れず、ページ全体の横スクロールも起きない。 */}
+            <div className="min-[880px]:hidden">
+                <Popover open={menuOpen} onOpenChange={setMenuOpen}>
+                    <PopoverTrigger asChild>
+                        <button
+                            type="button"
+                            aria-label="メニュー"
+                            aria-expanded={menuOpen}
+                            className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-base leading-none text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+                        >
+                            <span aria-hidden>☰</span>
+                        </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="end" className="w-56 p-2">
+                        <nav aria-label="サイト内ナビゲーション" className="flex flex-col gap-1">
+                            {appItems.map((item) => (
+                                <NavLink
+                                    key={item.to}
+                                    item={item}
+                                    layout="row"
+                                    onNavigate={() => setMenuOpen(false)}
+                                />
+                            ))}
+                            <div className="my-1 flex items-center gap-2 px-1">
+                                <span className="text-[10px] text-muted-foreground">観戦</span>
+                                <span className="h-px flex-1 bg-wafuu-border" />
+                            </div>
+                            {csaItems.map((item) => (
+                                <NavLink
+                                    key={item.to}
+                                    item={item}
+                                    layout="row"
+                                    onNavigate={() => setMenuOpen(false)}
+                                />
+                            ))}
+                            <span aria-hidden className="my-1 h-px bg-wafuu-border" />
+                            <NavLink
+                                item={authItem}
+                                layout="row"
+                                onNavigate={() => setMenuOpen(false)}
+                            />
+                        </nav>
+                    </PopoverContent>
+                </Popover>
+            </div>
+        </>
     );
 }

--- a/apps/web/src/pages/online/OnlinePage.test.tsx
+++ b/apps/web/src/pages/online/OnlinePage.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../../hooks/useAuthSession", () => ({
     }),
 }));
 
-// @shogi/ui のモック（PositionPresetSelector を使用）
+// @shogi/ui のモック（PositionPresetSelector と、HeaderNav が使う Popover 系）
 vi.mock("@shogi/ui", () => ({
     PositionPresetSelector: ({
         value,
@@ -36,6 +36,9 @@ vi.mock("@shogi/ui", () => ({
             <option value="startpos">平手</option>
         </select>
     ),
+    Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+    PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 // import はモック設定後

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // popover
 // position-preset-selector
 export { POSITION_PRESETS, PositionPresetSelector } from "./components/PositionPresetSelector";
+export { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
 export type { ShogiBoardCell, ShogiBoardPiece } from "./components/shogi-board";
 // shogi-board (online game 用)
 export { ShogiBoard } from "./components/shogi-board";


### PR DESCRIPTION
## Summary

- **レイアウト崩れ修正**: トップ対局画面が「中央に寄って常時横スクロール」になっていた不具合を修正。`App.tsx` の `main` から `max-w-[1100px]` を撤廃し全幅化。対局モード3カラム(サイドバー+盤+棋譜 ≈1260px)の中央寄せ/横スクロール管理は `PCLayout`(`overflow-x-auto` + `mx-auto w-max`)が担っているが、外側 `main` の 1100px 上限がそれより狭く中央寄せを潰していたのが原因(PR #56 のレイアウト刷新が起点)。
- **ヘッダー導線の再設計**: 現在ページのリンクを非表示にする方式(遷移でレイアウトシフト)をやめ、全導線を常時表示し `aria-current` + 配色で現在地を示す。アプリ本体機能(対局/オンライン/棋譜/NNUE)と CSA サーバー連携の観戦系(ライブ/棋譜ビューア/公開棋譜)を区切り線で2グループに分離し、これまで導線が無かった CSA ライブ/棋譜系への入口を追加。

## 設計判断

- `main` の幅制約は match レイアウト固有の中央寄せと競合するため撤廃し、幅制御を `PCLayout` に一元化(reviewMode branch は内部で `max-w-[1240px]` を保持するため影響なし)。
- ナビは active/inactive で geometry(border/padding)を共通化し色のみ変更 → 幅揺れ・レイアウトシフトを排除。
- CSA 観戦系の `isLive` はセグメント境界で判定し、単局ビューア `/rshogi-viewer/$gameId` の gameId が `live` で始まっても誤ハイライトしないようにした。

## 未確定 (deploy 後に目視で確定予定)

- ヘッダーの観戦系グループを「全表示(本PR採用)」のままにするか「ドロップダウンに畳む」かは本番 deploy 後に目視で確定。

## Test plan

- [x] biome format (--check) / lint clean
- [x] web typecheck (tsc) pass
- [x] web vitest 42 tests 全 pass
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (汎用) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3kKDyuR2qWmypzWowSi9x