### PR TITLE
ci(web): vitest ユニットテストを CI で実行し RoomPage の env 依存を修正

### DIFF
--- a/.github/workflows/js-format-lint.yml
+++ b/.github/workflows/js-format-lint.yml
@@ -151,16 +151,8 @@ jobs:
         run: pnpm build
       # engine-wasm は Wasm ビルド成果物 (pkg/) を参照するため、ビルド後に typecheck を実行
       - run: pnpm turbo typecheck --filter="@shogi/engine-wasm"
-      # ユニットテスト (vitest) を CI で実行する。build 済みの dist / wasm pkg を
-      # そのまま利用するため build job 内に配置する (別 job にすると tsc/wasm の
-      # 再ビルドが重複するため)。RoomPage 等が必要とする VITE_ 変数は
-      # apps/web/vitest.config.ts の test.env で stub 済み。
-      # 対象外 (本 PR のスコープ外・要フォローアップ):
-      #   - @shogi/app-controller: 既存の失敗テスト
-      #     (src/engine-controller.test.ts「dispose で停止と破棄が呼ばれる」)。無関係の退行のため別途修正。
-      #   - desktop / @shogi/engine-tauri: Tauri(native)前提でこの JS CI では実行しない。
-      #   - @shogi/engine-wasm: wasm ビルド成果物前提。
-      #   - @shogi/api-contract / @shogi/match-protocol: テストファイルが無く vitest が exit 1。
+      # ユニットテスト (vitest): build 済みの dist / wasm pkg を再利用するため build job 内に配置。
+      # 除外パッケージの内訳と app-controller の既存失敗については #84 参照。
       - name: Test (unit)
         run: pnpm turbo test --filter=web --filter=@shogi/match-client --filter=@shogi/app-core --filter=@shogi/design-system --filter=@shogi/engine-client --filter=@shogi/ui -- --run
       - name: sccache stats

--- a/.github/workflows/js-format-lint.yml
+++ b/.github/workflows/js-format-lint.yml
@@ -151,6 +151,18 @@ jobs:
         run: pnpm build
       # engine-wasm は Wasm ビルド成果物 (pkg/) を参照するため、ビルド後に typecheck を実行
       - run: pnpm turbo typecheck --filter="@shogi/engine-wasm"
+      # ユニットテスト (vitest) を CI で実行する。build 済みの dist / wasm pkg を
+      # そのまま利用するため build job 内に配置する (別 job にすると tsc/wasm の
+      # 再ビルドが重複するため)。RoomPage 等が必要とする VITE_ 変数は
+      # apps/web/vitest.config.ts の test.env で stub 済み。
+      # 対象外 (本 PR のスコープ外・要フォローアップ):
+      #   - @shogi/app-controller: 既存の失敗テスト
+      #     (src/engine-controller.test.ts「dispose で停止と破棄が呼ばれる」)。無関係の退行のため別途修正。
+      #   - desktop / @shogi/engine-tauri: Tauri(native)前提でこの JS CI では実行しない。
+      #   - @shogi/engine-wasm: wasm ビルド成果物前提。
+      #   - @shogi/api-contract / @shogi/match-protocol: テストファイルが無く vitest が exit 1。
+      - name: Test (unit)
+        run: pnpm turbo test --filter=web --filter=@shogi/match-client --filter=@shogi/app-core --filter=@shogi/design-system --filter=@shogi/engine-client --filter=@shogi/ui -- --run
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     test: {
         environment: "happy-dom",
         globals: true,
+        env: {
+            VITE_NNUE_MANIFEST_URL: "https://example.test/nnue/manifest.json",
+            VITE_WASM_THREADS: "false",
+            VITE_DEFAULT_NNUE_PRESET: "standard",
+            VITE_RSHOGI_API_BASE: "https://example.test/rshogi",
+        },
         exclude: [
             "**/node_modules/**",
             "**/worker/**", // 統合テストは test:integration スクリプトで実行
@@ -20,6 +26,14 @@ export default defineConfig({
             {
                 find: /^@shogi\/app-core$/,
                 replacement: path.resolve(rootDir, "../../packages/app-core/src"),
+            },
+            {
+                find: /^@shogi\/api-contract$/,
+                replacement: path.resolve(rootDir, "../../packages/api-contract/src"),
+            },
+            {
+                find: /^@shogi\/app-controller$/,
+                replacement: path.resolve(rootDir, "../../packages/app-controller/src"),
             },
             {
                 find: /^@shogi\/design-system$/,
@@ -54,6 +68,10 @@ export default defineConfig({
             {
                 find: /^@shogi\/match-client$/,
                 replacement: path.resolve(rootDir, "../../packages/match-client/src"),
+            },
+            {
+                find: /^@shogi\/match-protocol$/,
+                replacement: path.resolve(rootDir, "../../packages/match-protocol/src"),
             },
         ],
     },


### PR DESCRIPTION
## 概要
これまで JS CI は format/lint/knip/typecheck/build のみで、**vitest が一度も CI 実行されていなかった**(PR #79 レビューで判明)。build job は Rust/wasm toolchain をフル setup し `pnpm build` で全 dist/wasm を生成するため、その **build 後にユニットテスト step を co-locate** し、別 job にせず tsc/wasm 再ビルドの重複を避ける。

## RoomPage の「ローカル既知失敗」修正
`apps/web/src/pages/online/RoomPage.tsx:21-27` は module ロード時に `import.meta.env.VITE_NNUE_MANIFEST_URL` が未定義だと throw する。`RoomPage.test.tsx` は動的 import でこれを踏むため常に失敗していた。`apps/web/vitest.config.ts` の `test.env` に必要な VITE_ 変数を stub して解消(RoomPage 2 tests green)。

## CI 対象(全 green をローカル実測)
`web / @shogi/match-client / @shogi/app-core / @shogi/design-system / @shogi/engine-client / @shogi/ui`

## 対象外(要フォローアップ、workflow コメントに理由記載)
- `@shogi/app-controller`: **既存の失敗テスト**(`src/engine-controller.test.ts`「dispose で停止と破棄が呼ばれる」= mock 未呼び出し)。本 PR と無関係の退行のため別途対応(要 issue 化)。
- `desktop` / `@shogi/engine-tauri`: Tauri(native)前提でこの JS CI では実行しない。
- `@shogi/engine-wasm`: wasm ビルド前提。
- `@shogi/api-contract` / `@shogi/match-protocol`: テストファイルが無く vitest が exit 1。

## 検証
- allowlist の `pnpm turbo test ... -- --run` を build 済み state でローカル実行 → 6 task 全 green(web 7 files 含む RoomPage、ui 29、match-client 3 等)
- `pnpm format:ci` / `pnpm lint` green、workflow YAML パス
- dual review 済(Opus 設計・実装 / Fable approve)