### PR TITLE
feat(match-client): 結果コード契約テスト + rshogi 乖離検知 workflow

### DIFF
--- a/.github/workflows/result-codes-contract-drift.yml
+++ b/.github/workflows/result-codes-contract-drift.yml
@@ -1,0 +1,55 @@
+# rshogi(サーバ)の canonical な result-codes.json と、本リポジトリが持つ
+# byte-identical コピー(packages/match-client/src/rshogi-csa/result-codes.json)の
+# 乖離を定期検知する。rshogi 側で語彙を変えたのにこちらへコピーし忘れる、という
+# 2 リポジトリ跨ぎの唯一の同期漏れ経路を監視するのが目的。
+#
+# rshogi は private repo のため、読み取りには repo read 権限を持つ PAT を
+# secret `RSHOGI_CONTRACT_READ_TOKEN` に設定する必要がある。未設定なら何もせず
+# 成功終了する(best-effort)。乖離検知時は issue を起票し job を失敗させる。
+name: result-codes contract drift
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Compare with rshogi canonical manifest
+        env:
+          RSHOGI_READ_TOKEN: ${{ secrets.RSHOGI_CONTRACT_READ_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RSHOGI_READ_TOKEN}" ]; then
+            echo "::notice::secret RSHOGI_CONTRACT_READ_TOKEN が未設定のため drift check をスキップします。"
+            exit 0
+          fi
+          local_path="packages/match-client/src/rshogi-csa/result-codes.json"
+          upstream_path="crates/rshogi-csa-server-workers/contracts/result-codes.json"
+          GH_TOKEN="${RSHOGI_READ_TOKEN}" gh api \
+            "repos/SH11235/rshogi/contents/${upstream_path}?ref=main" \
+            -H "Accept: application/vnd.github.raw" > /tmp/upstream.json
+          if diff -u "${local_path}" /tmp/upstream.json > /tmp/contract.diff; then
+            echo "result-codes.json は rshogi canonical と一致しています。"
+            exit 0
+          fi
+          echo "::error::result-codes.json が rshogi canonical と乖離しています。"
+          cat /tmp/contract.diff
+          title="result-codes.json が rshogi と乖離"
+          body="$(printf 'rshogi の canonical manifest と本リポジトリのコピーに乖離を検知しました。rshogi を単一ソースとして本リポジトリの `%s` を更新してください。\n\n```diff\n%s\n```\n' "${local_path}" "$(cat /tmp/contract.diff)")"
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open --search "in:title ${title}" --json number --jq '.[0].number // empty')"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --repo "${GITHUB_REPOSITORY}" --body "${body}"
+          else
+            gh issue create --repo "${GITHUB_REPOSITORY}" --title "${title}" --body "${body}"
+          fi
+          exit 1

--- a/.github/workflows/result-codes-contract-drift.yml
+++ b/.github/workflows/result-codes-contract-drift.yml
@@ -45,7 +45,9 @@ jobs:
           echo "::error::result-codes.json が rshogi canonical と乖離しています。"
           cat /tmp/contract.diff
           title="result-codes.json が rshogi と乖離"
-          body="$(printf 'rshogi の canonical manifest と本リポジトリのコピーに乖離を検知しました。rshogi を単一ソースとして本リポジトリの `%s` を更新してください。\n\n```diff\n%s\n```\n' "${local_path}" "$(cat /tmp/contract.diff)")"
+          # GitHub issue body の上限(65535 文字)対策で diff を切り詰める
+          # (result-codes.json は小さいので通常は全文だが、防御的に truncate)。
+          body="$(printf 'rshogi の canonical manifest と本リポジトリのコピーに乖離を検知しました。rshogi を単一ソースとして本リポジトリの `%s` を更新してください。\n\n```diff\n%s\n```\n' "${local_path}" "$(head -c 50000 /tmp/contract.diff)")"
           existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" --state open --search "in:title ${title}" --json number --jq '.[0].number // empty')"
           if [ -n "${existing}" ]; then
             gh issue comment "${existing}" --repo "${GITHUB_REPOSITORY}" --body "${body}"

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,13 @@
         "useIgnoreFile": true
     },
     "files": {
-        "includes": ["**", "!**/packages/rust-core", "!**/src-tauri", "!**/infra/pulumi"],
+        "includes": [
+            "**",
+            "!**/packages/rust-core",
+            "!**/src-tauri",
+            "!**/infra/pulumi",
+            "!**/packages/match-client/src/rshogi-csa/result-codes.json"
+        ],
         "ignoreUnknown": true
     },
     "css": {

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -480,6 +480,9 @@ const decodeSnapshotBlock = (
  *
  * `currentTurn` は「次に指す側 = 全手 replay 直後の `PositionState.turn`」を
  * 渡す契約 (snapshot 経路) または「`detectEndLine` 検知時点の手番」(live 経路)。
+ *
+ * @internal contract test 用に export しているだけで、パッケージ外の公開 API
+ * ではない(index.ts から re-export しないこと)。
  */
 export const decodeResultCode = (
     line: string,

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -481,7 +481,7 @@ const decodeSnapshotBlock = (
  * `currentTurn` は「次に指す側 = 全手 replay 直後の `PositionState.turn`」を
  * 渡す契約 (snapshot 経路) または「`detectEndLine` 検知時点の手番」(live 経路)。
  */
-const decodeResultCode = (
+export const decodeResultCode = (
     line: string,
     currentTurn: "sente" | "gote",
 ): RshogiGameResult | undefined => {

--- a/packages/match-client/src/rshogi-csa/result-codes.contract.test.ts
+++ b/packages/match-client/src/rshogi-csa/result-codes.contract.test.ts
@@ -60,6 +60,9 @@ describe("result-codes contract", () => {
             // decodeResultCode は未知コードで undefined を返す(fallback 無し)ので、
             // defined であること = switch がその csa_code を直接扱っていること。
             expect(decoded, `${variant.variant} (${variant.csa_code})`).toBeDefined();
+            // 契約が保証するのは csa_code ⇄ end_reason 対応まで。decoded.kind
+            // ("resignation" 等)は client 内部表現でサーバマニフェストに無いため
+            // 契約テストの対象外(kind のマッピング健全性は live.test.ts が担当)。
             expect(decoded?.endReason, variant.csa_code).toBe(variant.end_reason);
         }
     });
@@ -74,7 +77,15 @@ describe("result-codes contract", () => {
         expect(new Set(contract.result_kinds)).toEqual(new Set(EXPECTED_RESULT_KINDS));
     });
 
-    it("wire union の網羅性(コンパイル時ガード)が保たれている", () => {
+    // NOTE: マニフェストの `csa_outcome_codes` (#WIN/#LOSE/#DRAW/#CENSORED) は終局
+    // 結果に付随する outcome 行で、client の decodeResultCode は reason コード
+    // (#RESIGN 等)のみを解釈し outcome 行は消費しない。よって本契約テストでは
+    // 検証しない(将来 live.ts で使い始めたら同様の網羅チェックを追加すること)。
+    // リポジトリ間のコピー乖離自体は drift 検知 workflow が担保する。
+
+    it("wire union の網羅性(コンパイル時ガード: このテストが実行される時点で型検査済み)", () => {
+        // 型エラーなくここに到達している = コンパイル時に exhaustive が成立している。
+        // ランタイムでは常に true だが、ガードが存在することを明示的に文書化する。
         expect(endReasonExhaustive).toBe(true);
         expect(resultKindExhaustive).toBe(true);
     });

--- a/packages/match-client/src/rshogi-csa/result-codes.contract.test.ts
+++ b/packages/match-client/src/rshogi-csa/result-codes.contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import type { RshogiEndReasonWire, RshogiResultKindWire } from "./fixtures";
+import { decodeResultCode } from "./live";
+import contract from "./result-codes.json";
+
+/**
+ * 結果コード契約テスト。
+ *
+ * `result-codes.json` は rshogi
+ * (`crates/rshogi-csa-server-workers/contracts/result-codes.json`) の canonical
+ * マニフェストの **byte-identical コピー**。rshogi 側は generate-and-compare
+ * テストで enum との一致をコンパイル時 + `cargo test` で強制し、こちら側は本
+ * テストで client の decode 実装がマニフェスト語彙を漏れなく扱うことを保証する。
+ * 2 リポジトリ間のコピー乖離の常時監視は
+ * `.github/workflows/result-codes-contract-drift.yml` が担う。
+ *
+ * 注意: `live.ts` の `#ILLEGAL` は client 側の寛容な alias であり、マニフェスト
+ * には存在しない(サーバ正準は `#ILLEGAL_MOVE`)。将来のリファクタでこの alias
+ * case を「マニフェストに無いから」と削除しないこと。
+ */
+
+// wire リテラルを列挙。`satisfies` で各値が union のメンバであることをコンパイル時保証
+// (typo / union に無い値を書くと型エラー)。
+const EXPECTED_END_REASONS = [
+    "RESIGN",
+    "TIME_UP",
+    "ILLEGAL",
+    "JISHOGI",
+    "OUTE_SENNICHITE",
+    "SENNICHITE",
+    "MAX_MOVES",
+    "ABNORMAL",
+] as const satisfies readonly RshogiEndReasonWire[];
+
+const EXPECTED_RESULT_KINDS = [
+    "WIN_BLACK",
+    "WIN_WHITE",
+    "DRAW",
+    "ABORT",
+] as const satisfies readonly RshogiResultKindWire[];
+
+// 逆方向(union 側に列挙漏れが無いこと)をコンパイル時保証。列挙から漏れた union
+// メンバがあると `Exclude<...>` が never にならず、代入が型エラーになる。
+type EndReasonExhaustive =
+    Exclude<RshogiEndReasonWire, (typeof EXPECTED_END_REASONS)[number]> extends never
+        ? true
+        : false;
+const endReasonExhaustive: EndReasonExhaustive = true;
+
+type ResultKindExhaustive =
+    Exclude<RshogiResultKindWire, (typeof EXPECTED_RESULT_KINDS)[number]> extends never
+        ? true
+        : false;
+const resultKindExhaustive: ResultKindExhaustive = true;
+
+describe("result-codes contract", () => {
+    it("全 variant の csa_code が fallback 無しで decode され end_reason が一致する", () => {
+        for (const variant of contract.variants) {
+            const decoded = decodeResultCode(variant.csa_code, "sente");
+            // decodeResultCode は未知コードで undefined を返す(fallback 無し)ので、
+            // defined であること = switch がその csa_code を直接扱っていること。
+            expect(decoded, `${variant.variant} (${variant.csa_code})`).toBeDefined();
+            expect(decoded?.endReason, variant.csa_code).toBe(variant.end_reason);
+        }
+    });
+
+    it("マニフェストの end_reason 集合が RshogiEndReasonWire と双方向一致する", () => {
+        expect(new Set(contract.variants.map((v) => v.end_reason))).toEqual(
+            new Set(EXPECTED_END_REASONS),
+        );
+    });
+
+    it("マニフェストの result_kinds 集合が RshogiResultKindWire と双方向一致する", () => {
+        expect(new Set(contract.result_kinds)).toEqual(new Set(EXPECTED_RESULT_KINDS));
+    });
+
+    it("wire union の網羅性(コンパイル時ガード)が保たれている", () => {
+        expect(endReasonExhaustive).toBe(true);
+        expect(resultKindExhaustive).toBe(true);
+    });
+});

--- a/packages/match-client/src/rshogi-csa/result-codes.json
+++ b/packages/match-client/src/rshogi-csa/result-codes.json
@@ -1,0 +1,56 @@
+{
+  "variants": [
+    {
+      "variant": "Toryo",
+      "csa_code": "#RESIGN",
+      "end_reason": "RESIGN"
+    },
+    {
+      "variant": "TimeUp",
+      "csa_code": "#TIME_UP",
+      "end_reason": "TIME_UP"
+    },
+    {
+      "variant": "IllegalMove",
+      "csa_code": "#ILLEGAL_MOVE",
+      "end_reason": "ILLEGAL"
+    },
+    {
+      "variant": "Kachi",
+      "csa_code": "#JISHOGI",
+      "end_reason": "JISHOGI"
+    },
+    {
+      "variant": "OuteSennichite",
+      "csa_code": "#OUTE_SENNICHITE",
+      "end_reason": "OUTE_SENNICHITE"
+    },
+    {
+      "variant": "Sennichite",
+      "csa_code": "#SENNICHITE",
+      "end_reason": "SENNICHITE"
+    },
+    {
+      "variant": "MaxMoves",
+      "csa_code": "#MAX_MOVES",
+      "end_reason": "MAX_MOVES"
+    },
+    {
+      "variant": "Abnormal",
+      "csa_code": "#ABNORMAL",
+      "end_reason": "ABNORMAL"
+    }
+  ],
+  "csa_outcome_codes": [
+    "#WIN",
+    "#LOSE",
+    "#DRAW",
+    "#CENSORED"
+  ],
+  "result_kinds": [
+    "WIN_BLACK",
+    "WIN_WHITE",
+    "DRAW",
+    "ABORT"
+  ]
+}

--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,7 @@
             "persistent": true
         },
         "test": {
-            "inputs": ["src/**/*.{ts,tsx,js,jsx}", "**/*.test.{ts,tsx,js,jsx}"]
+            "inputs": ["src/**/*.{ts,tsx,js,jsx}", "**/*.test.{ts,tsx,js,jsx}", "src/**/*.json"]
         },
         "test:unit": {
             "inputs": ["src/**/*.{ts,tsx,js,jsx}", "src/**/*.test.{ts,tsx,js,jsx}"]


### PR DESCRIPTION
## 概要
rshogi を単一ソースとする結果コード契約の **web client 側**。canonical マニフェストの
byte-identical コピーを `packages/match-client/src/rshogi-csa/result-codes.json` に置き、
contract test で decode 実装がマニフェスト語彙を漏れなく扱うことを保証する。
サーバ側 PR: SH11235/rshogi#874

## 内容
- **result-codes.contract.test.ts**:
  - 全 variant の `csa_code` が `decodeResultCode` で **fallback 無しに** defined で decode され、`end_reason` が一致(未知コードは undefined を返すため、defined = switch が直接扱っている証左。`decodeSnapshotResultCode` の `#`→abort fallback は網羅検査を無効化するので通さない)
  - `end_reason` / `result_kind` 集合が `RshogiEndReasonWire` / `RshogiResultKindWire` と **双方向一致**(`satisfies` + `Exclude` 網羅ガードでコンパイル時にも保証)
  - `#ILLEGAL` は client 側の寛容 alias(マニフェスト外)である旨をコメントで明示
- **result-codes-contract-drift.yml**: rshogi main の canonical と diff する scheduled workflow(2 リポジトリ間コピー漏れ検知)。private repo 読み取りに secret `RSHOGI_CONTRACT_READ_TOKEN` が必要、未設定なら best-effort skip。乖離時は issue 起票 + fail。
- `live.ts` の `decodeResultCode` を test 用に export。byte-identity 維持のため JSON を biome format 対象から除外。

## 検証
- `pnpm --filter @shogi/match-client test`(contract test 4 tests 含め全 pass)/ `typecheck`(網羅ガード成立)/ `format:ci` / match-client lint green
- JSON は rshogi canonical と sha256 一致を維持