### PR TITLE
test(app-controller): dispose の stale テストを実装挙動に合わせ修正 (Issue #84)

### DIFF
--- a/.github/workflows/js-format-lint.yml
+++ b/.github/workflows/js-format-lint.yml
@@ -152,9 +152,9 @@ jobs:
       # engine-wasm は Wasm ビルド成果物 (pkg/) を参照するため、ビルド後に typecheck を実行
       - run: pnpm turbo typecheck --filter="@shogi/engine-wasm"
       # ユニットテスト (vitest): build 済みの dist / wasm pkg を再利用するため build job 内に配置。
-      # 除外パッケージの内訳と app-controller の既存失敗については #84 参照。
+      # tauri/wasm 前提や test 無しのパッケージは対象外。
       - name: Test (unit)
-        run: pnpm turbo test --filter=web --filter=@shogi/match-client --filter=@shogi/app-core --filter=@shogi/design-system --filter=@shogi/engine-client --filter=@shogi/ui -- --run
+        run: pnpm turbo test --filter=web --filter=@shogi/match-client --filter=@shogi/app-core --filter=@shogi/app-controller --filter=@shogi/design-system --filter=@shogi/engine-client --filter=@shogi/ui -- --run
       - name: sccache stats
         if: always()
         run: sccache --show-stats || true

--- a/packages/app-controller/src/engine-controller.test.ts
+++ b/packages/app-controller/src/engine-controller.test.ts
@@ -393,7 +393,7 @@ describe("createEngineController", () => {
         expect(controller.getState().isAnalyzing).toBe(false);
     });
 
-    it("dispose で停止と破棄が呼ばれる", async () => {
+    it("dispose で破棄が呼ばれ stop は呼ばれない", async () => {
         const mockClient = createMockEngineClient();
         const controller = createEngineController({
             createClient: (_engineId) => mockClient.client,
@@ -422,7 +422,9 @@ describe("createEngineController", () => {
 
         await controller.command.dispose("sente");
 
-        expect(mockClient.stop).toHaveBeenCalled();
+        // dispose は Worker を terminate するため stop() を呼ばない設計
+        // (理由は engine-controller.ts の disposeEngineForSide 実装コメント参照)
+        expect(mockClient.stop).not.toHaveBeenCalled();
         expect(mockClient.dispose).toHaveBeenCalled();
         expect(controller.getState().engineReady.sente).toBe(false);
     });


### PR DESCRIPTION
## Summary

- `@shogi/app-controller` の `engine-controller.test.ts`「dispose で停止と破棄が呼ばれる」が **既存で失敗**していた(vitest が CI 未実行だったため潜在化。PR #82 で判明)。
- 原因は **テストの陳腐化**。commit `596ba3de`「fix: dispose前のstop()呼び出しを削除しスレッド再初期化の競合を修正」で `disposeEngineForSide` が `dispose()` 前の `stop()` 呼び出しを意図的に削除したが、テストだけ旧挙動(`stop` 呼び出し)を期待したまま取り残されていた。
- テストを実装の意図した設計(dispose は `stop()` を呼ばない)をガードする形へ修正し、名称も実態に合わせた。`dispose` 呼び出し・`engineReady=false` は引き続き positive assert しており、空虚なテストにはならない。
- あわせて CI の Test (unit) allowlist に `@shogi/app-controller` を追加(Issue #84 の対応要件)。

## 変更

- `packages/app-controller/src/engine-controller.test.ts`: テスト名変更 + `expect(mockClient.stop).toHaveBeenCalled()` → `.not.toHaveBeenCalled()`(契約を説明するコメント付き、機序は実装コメントを参照)
- `.github/workflows/js-format-lint.yml`: Test (unit) の turbo filter に `@shogi/app-controller` を追加

## 既知の限界(本 PR スコープ外)

- 本テストは engine client を mock する層のため、`terminateAndRecover()` の再初期化レース(`cancel()`/`stop()` が共通経路)そのものは再現しない。レース本体の回帰防止は実 WASM worker を要し、`engine-wasm` の統合テスト層の責務。必要なら別途 Issue 化を推奨。

## 関連

- Closes #84
- 前提: PR #82(vitest CI 導入、本テストを一時除外)

## Test plan

- [x] `pnpm --filter @shogi/app-controller exec vitest run` → 19/19 pass
- [x] `pnpm format:ci` / `pnpm lint` green、workflow YAML パース OK
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (汎用) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)