### PR TITLE
perf(web): 全ルートを code-split し観戦等の初期 critical JS を削減

### DIFF
--- a/apps/web/src/AppProviders.tsx
+++ b/apps/web/src/AppProviders.tsx
@@ -4,7 +4,7 @@ import {
     detect_nnue_format,
     is_nnue_compatible,
 } from "@shogi/engine-wasm";
-import { NnueProvider } from "@shogi/ui";
+import { NnueProvider } from "@shogi/ui/providers/NnueContext";
 import { Outlet } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { AuthSessionProvider } from "./hooks/useAuthSession";

--- a/apps/web/src/components/HeaderNav.tsx
+++ b/apps/web/src/components/HeaderNav.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@shogi/design-system";
-import { Popover, PopoverContent, PopoverTrigger } from "@shogi/ui";
+import { Popover, PopoverContent, PopoverTrigger } from "@shogi/ui/components/popover";
 import { Link, useLocation } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";

--- a/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiLiveGamesPage.tsx
@@ -1,4 +1,5 @@
-import { RshogiCsaLiveGameList, useRshogiLiveGameList } from "@shogi/ui";
+import { RshogiCsaLiveGameList } from "@shogi/ui/components/rshogi-csa-live-game-list";
+import { useRshogiLiveGameList } from "@shogi/ui/hooks/useRshogiLiveGameList";
 import { Link, useNavigate } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -1,6 +1,6 @@
 import type { RshogiGameSummary } from "@shogi/match-client";
 import { fetchRshogiGameList } from "@shogi/match-client";
-import { RshogiCsaGameList } from "@shogi/ui";
+import { RshogiCsaGameList } from "@shogi/ui/components/rshogi-csa-game-list";
 import { Link, useNavigate } from "@tanstack/react-router";
 import { type ReactElement, useEffect, useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -12,26 +12,11 @@ import {
     createRootRoute,
     createRoute,
     createRouter,
+    lazyRouteComponent,
     redirect,
     useNavigate,
 } from "@tanstack/react-router";
-import App from "./App";
 import { AppProviders } from "./AppProviders";
-import AuthPage from "./pages/auth/AuthPage";
-import GameDetailPage from "./pages/games/GameDetailPage";
-import GameReviewPage from "./pages/games/GameReviewPage";
-import GamesPage from "./pages/games/GamesPage";
-import PublicGamePage from "./pages/games/PublicGamePage";
-import PublicGamesPage from "./pages/games/PublicGamesPage";
-import NnueFilesPage from "./pages/nnue/NnueFilesPage";
-import CreateRoomPage from "./pages/online/CreateRoomPage";
-import OnlinePage from "./pages/online/OnlinePage";
-import RoomPage from "./pages/online/RoomPage";
-import PrivacyPage from "./pages/privacy/PrivacyPage";
-import RshogiLiveGamesPage from "./pages/rshogi-viewer/RshogiLiveGamesPage";
-import RshogiViewerListPage from "./pages/rshogi-viewer/RshogiViewerListPage";
-import RshogiViewerLivePage from "./pages/rshogi-viewer/RshogiViewerLivePage";
-import RshogiViewerPage from "./pages/rshogi-viewer/RshogiViewerPage";
 import { handleLoaderResponse } from "./router-loader-utils";
 
 const rootRoute = createRootRoute({
@@ -41,19 +26,22 @@ const rootRoute = createRootRoute({
 const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/",
-    component: App,
+    // ホーム (`/`) は ShogiMatch を使うため唯一 shogi-match chunk を必要とするページ。
+    // eager にすると entry の静的グラフに shogi-match(~420KB) が入り全ルートで
+    // modulepreload されるため、ここも lazy 化して観戦等の critical path から外す。
+    component: lazyRouteComponent(() => import("./App")),
 });
 
 const onlineRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/online",
-    component: OnlinePage,
+    component: lazyRouteComponent(() => import("./pages/online/OnlinePage")),
 });
 
 const authRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/auth",
-    component: AuthPage,
+    component: lazyRouteComponent(() => import("./pages/auth/AuthPage")),
 });
 
 interface GamesRouteLoaderData {
@@ -88,7 +76,7 @@ async function fetchGamesLoaderData(): Promise<GamesRouteLoaderData> {
 const gamesRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/games",
-    component: GamesPage,
+    component: lazyRouteComponent(() => import("./pages/games/GamesPage")),
     loader: fetchGamesLoaderData,
 });
 
@@ -101,7 +89,7 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 const gameDetailRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/games/$gameId",
-    component: GameDetailPage,
+    component: lazyRouteComponent(() => import("./pages/games/GameDetailPage")),
     loader: async ({ params: { gameId } }) => {
         if (!UUID_RE.test(gameId)) {
             throw redirect({
@@ -127,7 +115,7 @@ const gameDetailRoute = createRoute({
 const gameReviewRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/games/$gameId/review",
-    component: GameReviewPage,
+    component: lazyRouteComponent(() => import("./pages/games/GameReviewPage")),
     loader: async ({ params: { gameId } }) => {
         const [gameResponse, snapshotsResponse] = await Promise.all([
             fetch(`/api/games/${gameId}`, {
@@ -161,7 +149,7 @@ const gameReviewRoute = createRoute({
 const publicGamesRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/public/games",
-    component: PublicGamesPage,
+    component: lazyRouteComponent(() => import("./pages/games/PublicGamesPage")),
     loader: async () => {
         const response = await fetch("/api/public/games");
 
@@ -180,7 +168,7 @@ const publicGamesRoute = createRoute({
 const publicGameRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/public/games/$publicId",
-    component: PublicGamePage,
+    component: lazyRouteComponent(() => import("./pages/games/PublicGamePage")),
     loader: async ({ params: { publicId } }) => {
         const response = await fetch(`/api/public/games/${publicId}`, {
             credentials: "same-origin",
@@ -199,7 +187,7 @@ const publicGameRoute = createRoute({
 const nnueFilesRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/nnue",
-    component: NnueFilesPage,
+    component: lazyRouteComponent(() => import("./pages/nnue/NnueFilesPage")),
     loader: async () => {
         const response = await fetch("/api/nnue/files", {
             credentials: "same-origin",
@@ -227,13 +215,13 @@ const nnueFilesRoute = createRoute({
 const privacyRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/privacy",
-    component: PrivacyPage,
+    component: lazyRouteComponent(() => import("./pages/privacy/PrivacyPage")),
 });
 
 const rshogiViewerListRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer",
-    component: RshogiViewerListPage,
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiViewerListPage")),
 });
 
 // 進行中対局一覧 (静的 path)。単局 `/rshogi-viewer/live/$gameId` とはセグメント数が
@@ -242,7 +230,7 @@ const rshogiViewerListRoute = createRoute({
 const rshogiViewerLiveListRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer/live",
-    component: RshogiLiveGamesPage,
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiLiveGamesPage")),
 });
 
 // `/rshogi-viewer/live/$gameId` は単局 `/rshogi-viewer/$gameId` よりも前に
@@ -250,25 +238,46 @@ const rshogiViewerLiveListRoute = createRoute({
 const rshogiViewerLiveRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer/live/$gameId",
-    component: RshogiViewerLivePage,
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiViewerLivePage")),
 });
 
 const rshogiViewerRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/rshogi-viewer/$gameId",
-    component: RshogiViewerPage,
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiViewerPage")),
 });
 
 const createRoomRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/online/create",
-    component: CreateRoomPage,
+    component: lazyRouteComponent(() => import("./pages/online/CreateRoomPage")),
 });
 
-function RoomPendingComponent() {
+function DefaultPendingComponent() {
     return (
         <div className="mx-auto flex max-w-[480px] flex-col gap-4 px-4 py-10">
             <p className="text-muted-foreground">読み込み中...</p>
+        </div>
+    );
+}
+
+// lazy route の chunk fetch が恒久的に失敗した場合 (stale deploy の reload を
+// 消化し切った後など) の共通フォールバック。未スタイルの既定 error 画面を出さず、
+// 再読み込み導線を持つ最小 UI を出す。
+function DefaultErrorComponent({ error }: { error: Error }) {
+    return (
+        <div className="mx-auto flex max-w-[480px] flex-col gap-4 px-4 py-10">
+            <p className="text-destructive">
+                ページの読み込みに失敗しました。ネットワークを確認して再読み込みしてください。
+            </p>
+            <p className="text-xs text-muted-foreground">{error.message}</p>
+            <button
+                type="button"
+                onClick={() => window.location.reload()}
+                className="self-start text-sm text-muted-foreground hover:text-foreground"
+            >
+                再読み込み
+            </button>
         </div>
     );
 }
@@ -292,7 +301,7 @@ function RoomErrorComponent({ error }: { error: Error }) {
 const roomRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: "/online/$roomId",
-    component: RoomPage,
+    component: lazyRouteComponent(() => import("./pages/online/RoomPage")),
     loader: async ({ params: { roomId } }) => {
         const res = await fetch(`/api/rooms/${roomId}`);
         handleLoaderResponse(res, {
@@ -301,7 +310,7 @@ const roomRoute = createRoute({
         });
         return res.json() as Promise<RoomInfo>;
     },
-    pendingComponent: RoomPendingComponent,
+    pendingComponent: DefaultPendingComponent,
     errorComponent: RoomErrorComponent,
     validateSearch: (search: Record<string, unknown>) => ({
         name: typeof search.name === "string" ? search.name : undefined,
@@ -329,7 +338,11 @@ const routeTree = rootRoute.addChildren([
     rshogiViewerRoute,
 ]);
 
-export const router = createRouter({ routeTree });
+export const router = createRouter({
+    routeTree,
+    defaultPendingComponent: DefaultPendingComponent,
+    defaultErrorComponent: DefaultErrorComponent,
+});
 
 declare module "@tanstack/react-router" {
     interface Register {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -255,7 +255,7 @@ const createRoomRoute = createRoute({
 
 function DefaultPendingComponent() {
     return (
-        <div className="mx-auto flex max-w-[480px] flex-col gap-4 px-4 py-10">
+        <div aria-live="polite" className="mx-auto flex max-w-[480px] flex-col gap-4 px-4 py-10">
             <p className="text-muted-foreground">読み込み中...</p>
         </div>
     );
@@ -264,13 +264,16 @@ function DefaultPendingComponent() {
 // lazy route の chunk fetch が恒久的に失敗した場合 (stale deploy の reload を
 // 消化し切った後など) の共通フォールバック。未スタイルの既定 error 画面を出さず、
 // 再読み込み導線を持つ最小 UI を出す。
-function DefaultErrorComponent({ error }: { error: Error }) {
+function DefaultErrorComponent({ error }: { error: unknown }) {
+    // TanStack Router の error は Error インスタンスとは限らない (throw "string" や
+    // 非 Error の Promise rejection もありうる) ため、安全に文字列化する。
+    const message = error instanceof Error ? error.message : String(error);
     return (
         <div className="mx-auto flex max-w-[480px] flex-col gap-4 px-4 py-10">
             <p className="text-destructive">
                 ページの読み込みに失敗しました。ネットワークを確認して再読み込みしてください。
             </p>
-            <p className="text-xs text-muted-foreground">{error.message}</p>
+            <p className="text-xs text-muted-foreground">{message}</p>
             <button
                 type="button"
                 onClick={() => window.location.reload()}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,6 +17,75 @@ const pkg = JSON.parse(readFileSync(path.join(rootDir, "package.json"), "utf-8")
     version: string;
 };
 
+function manualChunks(id: string): string | undefined {
+    const normalizedId = id.split(path.sep).join("/");
+
+    if (normalizedId.includes("/node_modules/")) {
+        if (
+            normalizedId.includes("/node_modules/react/") ||
+            normalizedId.includes("/node_modules/react-dom/") ||
+            normalizedId.includes("/node_modules/scheduler/")
+        ) {
+            return "vendor-react";
+        }
+
+        if (normalizedId.includes("/node_modules/@tanstack/")) {
+            return "vendor-router";
+        }
+
+        return "vendor";
+    }
+
+    // useLocalStorage は cross-tab 同期 util(react のみ依存の leaf)で、物理的には
+    // shogi-match/hooks 配下にあるが app-shell の useUserSettingsSync(eager)からも
+    // 使われる。shogi-match chunk に含めると eager path が重い shogi-match を丸ごと
+    // 引くため、小さな専用 chunk に切り出す(shogi-match ルールより前に判定する)。
+    if (normalizedId.endsWith("/packages/ui/src/components/shogi-match/hooks/useLocalStorage.ts")) {
+        return "ui-storage";
+    }
+
+    // ShogiMatch は本体ファイル `shogi-match.tsx` と `shogi-match/` 配下(hooks/utils
+    // 等)の両方から成る。trailing slash だけだと本体ファイルを取りこぼし entry 等へ
+    // 落ちるため、ファイル本体も同 chunk に含める。
+    if (
+        normalizedId.includes("/packages/ui/src/components/shogi-match/") ||
+        normalizedId.endsWith("/packages/ui/src/components/shogi-match.tsx")
+    ) {
+        return "shogi-match";
+    }
+
+    if (normalizedId.includes("/packages/app-core/src/")) {
+        return "app-core";
+    }
+
+    if (normalizedId.includes("/packages/match-client/src/")) {
+        return "match-client";
+    }
+
+    // NnueProvider(providers/) と engine-wasm の軽量 nnue glue は、アプリ全体を
+    // 包む AppProviders(eager)が使うため eager path に載る。放置すると rollup 既定が
+    // これらを重い shogi-match chunk に同梱し、全ルートで shogi-match(~440KB) が
+    // modulepreload されてしまう。小さな専用 chunk に分離して eager path を軽く保つ。
+    // (重い wasm/worker は `new Worker(new URL())` で別アセット化され static には載らない)
+    if (normalizedId.includes("/packages/ui/src/providers/")) {
+        return "ui-providers";
+    }
+
+    if (normalizedId.includes("/packages/engine-wasm/src/")) {
+        return "engine-wasm-glue";
+    }
+
+    if (
+        normalizedId.endsWith("/apps/web/src/components/HeaderNav.tsx") ||
+        normalizedId.endsWith("/apps/web/src/components/PageHeader.tsx") ||
+        normalizedId.endsWith("/apps/web/src/hooks/useAuthSession.tsx")
+    ) {
+        return "app-shell";
+    }
+
+    return undefined;
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ command, mode }) => {
     const env = loadEnv(mode, rootDir, "");
@@ -61,6 +130,13 @@ export default defineConfig(({ command, mode }) => {
                 "Cross-Origin-Embedder-Policy": "require-corp",
             },
         },
+        build: {
+            rollupOptions: {
+                output: {
+                    manualChunks,
+                },
+            },
+        },
         plugins: [
             tailwindcss(),
             react({
@@ -92,6 +168,10 @@ export default defineConfig(({ command, mode }) => {
                 {
                     find: /^@shogi\/ui$/,
                     replacement: path.resolve(rootDir, "../../packages/ui/src"),
+                },
+                {
+                    find: /^@shogi\/ui\/(.+)$/,
+                    replacement: path.resolve(rootDir, "../../packages/ui/src/$1"),
                 },
                 {
                     find: /^@shogi\/engine-client$/,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -29,6 +29,9 @@ function manualChunks(id: string): string | undefined {
             return "vendor-react";
         }
 
+        // 現状 @tanstack は react-router のみ。将来 @tanstack/query 等を足すと
+        // この chunk に同梱され肥大化しうるので、その際は router 系に限定するか
+        // chunk を分けること。
         if (normalizedId.includes("/node_modules/@tanstack/")) {
             return "vendor-router";
         }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -44,6 +44,10 @@ export default defineConfig({
                 replacement: path.resolve(rootDir, "../../packages/ui/src"),
             },
             {
+                find: /^@shogi\/ui\/(.+)$/,
+                replacement: path.resolve(rootDir, "../../packages/ui/src/$1"),
+            },
+            {
                 find: /^@shogi\/engine-client$/,
                 replacement: path.resolve(rootDir, "../../packages/engine-client/src"),
             },

--- a/packages/ui/src/components/shogi-match/hooks/useLocalStorage.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useLocalStorage.ts
@@ -1,3 +1,8 @@
+// ⚠️ このファイルのパスは apps/web/vite.config.ts の manualChunks で
+// "ui-storage" chunk へ振り分けるためにハードコードされている。移動・リネームする
+// 場合は vite.config.ts の該当ルールも必ず更新すること。放置すると本 util が
+// shogi-match chunk に取り込まれ、eager path 全体が ~440KB の shogi-match を
+// 引き込む回帰になる (ビルドエラーにはならずサイレントに劣化する)。
 import { useEffect, useRef, useState } from "react";
 
 export const LOCAL_STORAGE_SYNC_EVENT = "shogi-local-storage-sync";


### PR DESCRIPTION
## 背景
観戦ページの「終局後の盤/結果表示が遅い」体感の調査から派生。**サーバ経路・eager NNUE/wasm ロードは主因でない**ことを本番実測で確認済み(終局 push の client レンダリングは実測 11ms、cold-open も warm 1.8s〜throttle 3.7s)。残る唯一の client 律速が **全アプリ単一 `index.js` 1.1MB の parse+React boot**(低速端末で顕著)だったため、これを削る。

## 変更
- **router.tsx**: 全ページ(index `/` 含む)を `lazyRouteComponent(() => import(...))` 化。lazy chunk fetch 中の共通 fallback `defaultPendingComponent` と、恒久 404 用の styled `defaultErrorComponent` を `createRouter` に設定。loader/validateSearch/pendingComponent 等は inline 維持、ルート登録順・path は不変。
- **vite.config.ts**: `manualChunks` で `vendor-react`(react/react-dom/scheduler 同一)・`vendor-router`(@tanstack)・`vendor`・`shogi-match`・`engine-wasm-glue`・`ui-providers`・`ui-storage` を分離。
- **subpath import 化**(AppProviders / HeaderNav / 観戦一覧・live一覧ページ): eager path や一覧 chunk が barrel `@shogi/ui` 経由で重い `shogi-match`(~440KB)を巻き込むのを防ぐ。apps/desktop の既存 subpath import 前例に整合。
- **vitest.config.ts**: `@shogi/ui/(.+)` subpath alias をテスト解決に追加。

## 効果(実 build 実測)
- **eager modulepreload の JS: gzip 324KB → 161KB(約半減)**。entry `index.js` は 1.1MB → 15.7KB(gz 5.6KB)。
- `shogi-match`(438KB)は全ルート eager preload から外れ、**盤を描くページ(`/`・観戦単局/live・room・review)でのみ lazy 取得**。観戦一覧/live一覧は非依存。
- vendor 群が独立 chunk 化されナビゲーション間でキャッシュ可能に。

## 検証
- `typecheck` 緑 / `apps/web` vitest **42/42** / `build` 緑 / biome 緑。
- dist の modulepreload に shogi-match 無し、盤ページのみ lazy import を build 出力で確認。
- 独立 2 レビュー(correctness / effectiveness)を通過。

## 補足(本 PR 対象外・別イシュー)
main(#82 で vitest CI 有効化)時点で monorepo のユニットテストに既存の破綻あり(`app-controller/engine-controller.test.ts` の「dispose で停止と破棄」が red、`api-contract`/`match-protocol` は test 無しで vitest 失敗)。本 PR とは無関係のため触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)