### PR TITLE
fix(web): 検討 snapshot の手数なし詰みを有限センチネルで往復し無言のデータ損失を修正 (#74)

### DIFF
--- a/apps/web/src/pages/games/GameReviewPage.tsx
+++ b/apps/web/src/pages/games/GameReviewPage.tsx
@@ -9,7 +9,11 @@ import type {
 } from "@shogi/api-contract";
 import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { AnalysisSettings, AnalysisSnapshotDraft, EngineOption } from "@shogi/ui";
-import { ShogiMatch } from "@shogi/ui";
+import {
+    decodeSnapshotEvalMateReviver,
+    encodeSnapshotEvalMateReplacer,
+    ShogiMatch,
+} from "@shogi/ui";
 import { getRouteApi, useParams } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
@@ -55,9 +59,9 @@ async function createAnalysisSnapshot(
             "Content-Type": "application/json",
         },
         credentials: "same-origin",
-        // JSON.stringify は Infinity を null にする。live 由来の手数なし詰み
-        // (evalMate=±Infinity) を流す場合は stringifyReviewMoveData 相当の変換が必要。
-        body: JSON.stringify(requestBody),
+        // 素の JSON.stringify は Infinity を null に落とし手数なし詰み (evalMate=±Infinity) を
+        // 無言で失う。replacer で entry / multiPv の全 evalMate を有限センチネルへ符号化する。
+        body: JSON.stringify(requestBody, encodeSnapshotEvalMateReplacer),
     });
 
     if (!response.ok) {
@@ -78,7 +82,11 @@ async function getAnalysisSnapshot(
         throw new Error(await parseApiError(response));
     }
 
-    return (await response.json()) as GetAnalysisSnapshotResponse;
+    // reviver で entry / multiPv の全 evalMate センチネルを内部表現 (±Infinity) へ復元する。
+    return JSON.parse(
+        await response.text(),
+        decodeSnapshotEvalMateReviver,
+    ) as GetAnalysisSnapshotResponse;
 }
 
 export default function GameReviewPage(): ReactElement {

--- a/packages/api-contract/src/generated/openapi.json
+++ b/packages/api-contract/src/generated/openapi.json
@@ -403,7 +403,8 @@
                         "type": ["integer", "null"]
                     },
                     "evalMate": {
-                        "type": ["integer", "null"]
+                        "type": ["integer", "null"],
+                        "description": "詰み手数 (先手視点、+ が先手勝ち)。手数不明の詰みは予約センチネル ±100000 で表す。"
                     },
                     "depth": {
                         "type": ["integer", "null"],

--- a/packages/api-contract/src/generated/schema.ts
+++ b/packages/api-contract/src/generated/schema.ts
@@ -444,6 +444,7 @@ export interface components {
         AnalysisSnapshotEntry: {
             ply: number;
             evalCp: number | null;
+            /** @description 詰み手数 (先手視点、+ が先手勝ち)。手数不明の詰みは予約センチネル ±100000 で表す。 */
             evalMate: number | null;
             depth: number | null;
             pv: string[] | null;

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -104,6 +104,17 @@ const SPECTATE_DISPLAY_SETTINGS: DisplaySettings = {
 
 const reviewMoveDataKeyCache = new WeakMap<(ReviewMoveEval | undefined)[], string>();
 
+/**
+ * JSON.stringify 用 replacer。素の stringify は ±Infinity をどちらも null に潰して符号を失うため、
+ * signature/cache key では手数なし詰み (evalMate=±Infinity) を符号付き文字列として残す。
+ */
+const infinitySafeReplacer = (_key: string, value: unknown): unknown =>
+    typeof value === "number" && !Number.isNaN(value) && !Number.isFinite(value)
+        ? value > 0
+            ? "Infinity"
+            : "-Infinity"
+        : value;
+
 export const stringifyReviewMoveData = (
     moveData: (ReviewMoveEval | undefined)[] | undefined,
 ): string => {
@@ -111,13 +122,7 @@ export const stringifyReviewMoveData = (
     const cached = reviewMoveDataKeyCache.get(moveData);
     if (cached !== undefined) return cached;
 
-    const key = JSON.stringify(moveData, (_key, value: unknown) =>
-        typeof value === "number" && !Number.isNaN(value) && !Number.isFinite(value)
-            ? value > 0
-                ? "Infinity"
-                : "-Infinity"
-            : value,
-    );
+    const key = JSON.stringify(moveData, infinitySafeReplacer);
     reviewMoveDataKeyCache.set(moveData, key);
     return key;
 };
@@ -761,10 +766,12 @@ export function ShogiMatch({
     const lastAnalysisSnapshotSignatureRef = useRef<string | null>(null);
 
     useEffect(() => {
-        // analysisSnapshotDraft はサーバーへ POST するデータ由来で、POST 時点で
-        // Infinity は null に変換済み。ここに ±Infinity は含まれないため、
-        // JSON.stringify による signature 比較は安全。
-        const signature = analysisSnapshotDraft ? JSON.stringify(analysisSnapshotDraft) : null;
+        // analysisSnapshotDraft は live 由来の手数なし詰み (evalMate=±Infinity) を含みうる。
+        // 素の JSON.stringify は ±Infinity をどちらも null にして符号を潰すため、
+        // signature 比較では符号を保持する infinitySafeReplacer を使う。
+        const signature = analysisSnapshotDraft
+            ? JSON.stringify(analysisSnapshotDraft, infinitySafeReplacer)
+            : null;
         if (lastAnalysisSnapshotSignatureRef.current === signature) {
             return;
         }

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1591,7 +1591,10 @@ export function ShogiMatch({
             return;
         }
 
-        const signature = JSON.stringify(initialAnalysisEntries);
+        // 復元済み snapshot は evalMate=±Infinity (手数なし詰み) を含みうる。素の
+        // JSON.stringify は ±Infinity をどちらも null に潰し符号違いの snapshot 切替を
+        // 取りこぼすため、符号を保持する infinitySafeReplacer で署名する。
+        const signature = JSON.stringify(initialAnalysisEntries, infinitySafeReplacer);
         if (initialAnalysisAppliedRef.current === signature) {
             return;
         }

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
@@ -709,4 +709,9 @@ describe("snapshot evalMate wire replacer/reviver", () => {
             MATE_WITHOUT_PLY_WIRE,
         );
     });
+
+    it("evalMate が null のときは typeof ガードでそのままパススルーする", () => {
+        expect(encodeSnapshotEvalMateReplacer("evalMate", null)).toBeNull();
+        expect(decodeSnapshotEvalMateReviver("evalMate", null)).toBeNull();
+    });
 });

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
@@ -634,6 +634,18 @@ describe("evalMate wire encode/decode", () => {
         expect(encodeEvalMateForWire(null)).toBeNull();
     });
 
+    it("予約センチネルと同値の有限入力は 1 手内側へ丸め復元時に詰みと誤認されない", () => {
+        expect(encodeEvalMateForWire(MATE_WITHOUT_PLY_WIRE)).toBe(MATE_WITHOUT_PLY_WIRE - 1);
+        expect(encodeEvalMateForWire(-MATE_WITHOUT_PLY_WIRE)).toBe(-(MATE_WITHOUT_PLY_WIRE - 1));
+        // 丸めた値は有限のまま復元され ±Infinity にならない
+        expect(decodeEvalMateFromWire(encodeEvalMateForWire(MATE_WITHOUT_PLY_WIRE))).toBe(
+            MATE_WITHOUT_PLY_WIRE - 1,
+        );
+        expect(
+            Number.isFinite(decodeEvalMateFromWire(encodeEvalMateForWire(MATE_WITHOUT_PLY_WIRE))),
+        ).toBe(true);
+    });
+
     it("ワイヤのセンチネルを ±Infinity に復元する", () => {
         expect(decodeEvalMateFromWire(MATE_WITHOUT_PLY_WIRE)).toBe(MATE_WITHOUT_PLY);
         expect(decodeEvalMateFromWire(-MATE_WITHOUT_PLY_WIRE)).toBe(-MATE_WITHOUT_PLY);

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.test.ts
@@ -2,6 +2,10 @@ import type { BoardState, Piece, PieceType, Square } from "@shogi/app-core";
 import { describe, expect, it } from "vitest";
 import {
     convertMovesToKif,
+    decodeEvalMateFromWire,
+    decodeSnapshotEvalMateReviver,
+    encodeEvalMateForWire,
+    encodeSnapshotEvalMateReplacer,
     evalToY,
     exportToKifString,
     formatEval,
@@ -10,6 +14,7 @@ import {
     getEvalTooltipInfo,
     getPieceName,
     MATE_WITHOUT_PLY,
+    MATE_WITHOUT_PLY_WIRE,
     parseToSquare,
     squareToKanji,
 } from "./kifFormat";
@@ -613,5 +618,83 @@ describe("exportToKifString", () => {
         expect(result).toContain("*評価値=被詰み");
         expect(result).not.toContain("詰Infinity手");
         expect(result).not.toContain("被詰Infinity手");
+    });
+});
+
+describe("evalMate wire encode/decode", () => {
+    it("手数なし詰み ±Infinity を有限センチネル ±MATE_WITHOUT_PLY_WIRE に符号化する", () => {
+        expect(encodeEvalMateForWire(MATE_WITHOUT_PLY)).toBe(MATE_WITHOUT_PLY_WIRE);
+        expect(encodeEvalMateForWire(-MATE_WITHOUT_PLY)).toBe(-MATE_WITHOUT_PLY_WIRE);
+    });
+
+    it("有限の詰み手数と null はそのまま通す", () => {
+        expect(encodeEvalMateForWire(3)).toBe(3);
+        expect(encodeEvalMateForWire(-5)).toBe(-5);
+        expect(encodeEvalMateForWire(0)).toBe(0);
+        expect(encodeEvalMateForWire(null)).toBeNull();
+    });
+
+    it("ワイヤのセンチネルを ±Infinity に復元する", () => {
+        expect(decodeEvalMateFromWire(MATE_WITHOUT_PLY_WIRE)).toBe(MATE_WITHOUT_PLY);
+        expect(decodeEvalMateFromWire(-MATE_WITHOUT_PLY_WIRE)).toBe(-MATE_WITHOUT_PLY);
+    });
+
+    it("センチネル以外の有限値と null はそのまま復元する", () => {
+        expect(decodeEvalMateFromWire(3)).toBe(3);
+        expect(decodeEvalMateFromWire(-5)).toBe(-5);
+        expect(decodeEvalMateFromWire(null)).toBeNull();
+    });
+
+    it("符号を保ったまま往復する (encode → decode)", () => {
+        for (const value of [MATE_WITHOUT_PLY, -MATE_WITHOUT_PLY, 7, -7, 0, null]) {
+            expect(decodeEvalMateFromWire(encodeEvalMateForWire(value))).toBe(value);
+        }
+    });
+});
+
+describe("snapshot evalMate wire replacer/reviver", () => {
+    // entry 直下と multiPv 配下の両方に手数なし詰みを含む payload
+    const draft = {
+        entries: [
+            {
+                ply: 1,
+                evalCp: null,
+                evalMate: MATE_WITHOUT_PLY,
+                multiPv: [
+                    { multipv: 1, evalMate: MATE_WITHOUT_PLY },
+                    { multipv: 2, evalMate: -MATE_WITHOUT_PLY },
+                    { multipv: 3, evalCp: 120 },
+                ],
+            },
+            { ply: 2, evalCp: 50, evalMate: 3, multiPv: null },
+        ],
+    };
+
+    it("符号化した payload には Infinity ではなくセンチネルが載る", () => {
+        const wire = JSON.parse(JSON.stringify(draft, encodeSnapshotEvalMateReplacer));
+        expect(wire.entries[0].evalMate).toBe(MATE_WITHOUT_PLY_WIRE);
+        expect(wire.entries[0].multiPv[0].evalMate).toBe(MATE_WITHOUT_PLY_WIRE);
+        expect(wire.entries[0].multiPv[1].evalMate).toBe(-MATE_WITHOUT_PLY_WIRE);
+        // 有限の evalMate と evalCp はそのまま
+        expect(wire.entries[1].evalMate).toBe(3);
+        expect(wire.entries[0].multiPv[2].evalCp).toBe(120);
+    });
+
+    it("entry / multiPv の全 evalMate が符号を保って往復する", () => {
+        const encoded = JSON.stringify(draft, encodeSnapshotEvalMateReplacer);
+        const decoded = JSON.parse(encoded, decodeSnapshotEvalMateReviver);
+        expect(decoded.entries[0].evalMate).toBe(MATE_WITHOUT_PLY);
+        expect(decoded.entries[0].multiPv[0].evalMate).toBe(MATE_WITHOUT_PLY);
+        expect(decoded.entries[0].multiPv[1].evalMate).toBe(-MATE_WITHOUT_PLY);
+        expect(decoded.entries[1].evalMate).toBe(3);
+    });
+
+    it("evalCp など evalMate 以外のフィールドには触れない", () => {
+        expect(encodeSnapshotEvalMateReplacer("evalCp", MATE_WITHOUT_PLY_WIRE)).toBe(
+            MATE_WITHOUT_PLY_WIRE,
+        );
+        expect(decodeSnapshotEvalMateReviver("evalCp", MATE_WITHOUT_PLY_WIRE)).toBe(
+            MATE_WITHOUT_PLY_WIRE,
+        );
     });
 });

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.ts
@@ -11,7 +11,42 @@ import { parseSfen } from "./kifParser";
 /** 手数不明の詰みを表す evalMate センチネル。符号は勝つ側を先手視点で表す。 */
 export const MATE_WITHOUT_PLY = Number.POSITIVE_INFINITY;
 
+/**
+ * 手数不明の詰みのワイヤ表現。JSON は Infinity を送れないため、解析 snapshot の
+ * POST / GET では内部表現の ±Infinity をこの有限センチネルに符号化する。
+ * バックエンド (ramu-shogi-backend) の MATE_WITHOUT_PLY_SENTINEL と一致させること。
+ * この値は evalMate 空間の予約値であり、現実の詰み手数 (高々数百) とは衝突しない。
+ * (rshogi-csa-live-viewer.tsx の MATE_EVAL_SENTINEL は evalCp 空間の別物で偶然同値)
+ */
+export const MATE_WITHOUT_PLY_WIRE = 100_000;
+
 const isMateWithoutPly = (evalMate: number): boolean => !Number.isFinite(evalMate);
+
+/** 内部表現の evalMate (±Infinity=手数不明の詰み) をワイヤ用の有限センチネルへ符号化する。 */
+export const encodeEvalMateForWire = (evalMate: number | null): number | null => {
+    if (evalMate === MATE_WITHOUT_PLY) return MATE_WITHOUT_PLY_WIRE;
+    if (evalMate === -MATE_WITHOUT_PLY) return -MATE_WITHOUT_PLY_WIRE;
+    return evalMate;
+};
+
+/** ワイヤのセンチネルを内部表現 (±Infinity) へ復元する。 */
+export const decodeEvalMateFromWire = (evalMate: number | null): number | null => {
+    if (evalMate === MATE_WITHOUT_PLY_WIRE) return MATE_WITHOUT_PLY;
+    if (evalMate === -MATE_WITHOUT_PLY_WIRE) return -MATE_WITHOUT_PLY;
+    return evalMate;
+};
+
+/**
+ * JSON.stringify 用 replacer。snapshot payload 内の全 `evalMate` フィールド (entry 直下と
+ * multiPv 配下の両方) の ±Infinity を有限センチネルへ符号化する。フィールド追加時の
+ * 符号化漏れを構造的に防ぐため、個別マッピングではなく境界の replacer で一括処理する。
+ */
+export const encodeSnapshotEvalMateReplacer = (key: string, value: unknown): unknown =>
+    key === "evalMate" && typeof value === "number" ? encodeEvalMateForWire(value) : value;
+
+/** JSON.parse 用 reviver。全 `evalMate` フィールドのセンチネルを ±Infinity へ復元する。 */
+export const decodeSnapshotEvalMateReviver = (key: string, value: unknown): unknown =>
+    key === "evalMate" && typeof value === "number" ? decodeEvalMateFromWire(value) : value;
 
 /** 単一PVの評価値情報 */
 export interface PvEvalInfo {

--- a/packages/ui/src/components/shogi-match/utils/kifFormat.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifFormat.ts
@@ -26,6 +26,10 @@ const isMateWithoutPly = (evalMate: number): boolean => !Number.isFinite(evalMat
 export const encodeEvalMateForWire = (evalMate: number | null): number | null => {
     if (evalMate === MATE_WITHOUT_PLY) return MATE_WITHOUT_PLY_WIRE;
     if (evalMate === -MATE_WITHOUT_PLY) return -MATE_WITHOUT_PLY_WIRE;
+    // 予約センチネルと同値の有限詰み手数 (KIF import の「詰100000手」等の異常入力) は
+    // 1 手内側へ丸め、復元時に mate-without-ply と誤認されないようにする。
+    if (evalMate === MATE_WITHOUT_PLY_WIRE) return MATE_WITHOUT_PLY_WIRE - 1;
+    if (evalMate === -MATE_WITHOUT_PLY_WIRE) return -(MATE_WITHOUT_PLY_WIRE - 1);
     return evalMate;
 };
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -44,6 +44,10 @@ export { ShogiBoard } from "./components/shogi-board";
 export { BottomSheet } from "./components/shogi-match/components/BottomSheet";
 export { HandPiecesDisplay } from "./components/shogi-match/components/HandPiecesDisplay";
 export { KifuNavigationToolbar } from "./components/shogi-match/components/KifuNavigationToolbar";
+export {
+    decodeSnapshotEvalMateReviver,
+    encodeSnapshotEvalMateReplacer,
+} from "./components/shogi-match/utils/kifFormat";
 export { boardToGrid } from "./components/shogi-match/utils/positionUtils";
 
 // progress


### PR DESCRIPTION
## Summary

- 検討モードの解析 snapshot POST は素の `JSON.stringify` を使うため、live 由来の手数なし詰み(`evalMate = ±Infinity`)が `Infinity → null` に潰れ、サーバー側で「評価値なし」として記録される**無言のデータ損失**があった(#74)。
- `evalMate` の内部表現 `±Infinity` を、予約センチネル `±100000` に符号化して往復させる。**wire 境界の replacer/reviver** で `entry` 直下だけでなく `multiPv` 配下も含めた**全 `evalMate` フィールドを構造的にカバー**し、フィールド追加時の符号化漏れを防ぐ。
  - `createAnalysisSnapshot`(POST): `JSON.stringify(body, encodeSnapshotEvalMateReplacer)`
  - `getAnalysisSnapshot`(GET): `JSON.parse(text, decodeSnapshotEvalMateReviver)`
- あわせて `analysisSnapshotDraft` の signature 生成が `±Infinity` を素の `JSON.stringify` でどちらも `null` に潰し**符号衝突**していたのを、符号を保持する `infinitySafeReplacer` に統一(既存 `stringifyReviewMoveData` の replacer を抽出・共用)。誤ったコメントも訂正。
- 予約センチネルと同値の**有限** `evalMate`(KIF import の「詰100000手」等の異常入力)が decode で誤って `±Infinity` へ昇格しないよう、encode 境界で `±99999` へ 1 手丸めるガードを追加。

## 契約(バックエンド連携)

- バックエンド [ramu-shogi-backend#16](https://github.com/SH11235/ramu-shogi-backend/pull/16)(merged)で `evalMate` の予約センチネル `±100000` を `MATE_WITHOUT_PLY_SENTINEL` + zod `.describe()` として契約明記 + 往復 guard test を追加済み。型は `evalMate: number | null` のまま**不変**。
- 本 PR の `packages/api-contract/src/generated/{openapi.json,schema.ts}` は `pnpm generate:api-contract` による再生成物(description 追記のみ、型不変)。

## 設計判断

| 案 | 採否 | 理由 |
|---|---|---|
| 有限センチネル ±100000(採用) | ✅ | 契約型不変・DB マイグレーション不要。フロント CSA 経路が既に `±100000 = mate-without-ply` を使用しており貫通一貫。現実の詰み手数と非衝突 |
| 契約を string/union に拡張 | ✕ | 型変更が広範に波及、blast radius 大 |
| wire 境界 replacer/reviver(採用) | ✅ | `evalMate` キーを一括処理し `multiPv` ネストまで構造的にカバー。個別フィールド指定の漏れを排除 |

## 既知の限界(本 PR スコープ外)

- 保存済み snapshot を棋譜ツリーへ**再適用**する `analysisSnapshotEntryToRecordedEvalInfoEvent`(`shogi-match.tsx`)は `entry.multiPv` を捨て `multipv: 1` の単一 event に変換する**既存挙動**(本 PR 非変更)。これは `±Infinity` に限らず有限 multiPV でも同様の UI レンダリング欠落であり、#74 の「サーバー側データ損失」とは別レイヤの課題。本 PR は wire/サーバー上の無損失保存・取得を保証する(データ整合性は達成)。UI 再適用での multiPV surface は別 issue 化を推奨。

## Test plan

- [x] `@shogi/ui` vitest 76 pass(encode/decode 往復・符号保持、multiPv ネスト往復、センチネル衝突ガード、`evalCp` 不干渉)
- [x] `pnpm format:ci` / `pnpm lint` / `pnpm knip` green、`web`+`ui`+`api-contract` typecheck green
- [x] local reviewer #1 (Codex) APPROVE(REQUEST CHANGES → 対応 → APPROVE)
- [x] local reviewer #2 (汎用) APPROVE

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)