### PR TITLE
fix(web): vendor-react chunk 分離による本番ビルド起動不能を修正 (#86 リグレッション)

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -21,13 +21,10 @@ function manualChunks(id: string): string | undefined {
     const normalizedId = id.split(path.sep).join("/");
 
     if (normalizedId.includes("/node_modules/")) {
-        if (
-            normalizedId.includes("/node_modules/react/") ||
-            normalizedId.includes("/node_modules/react-dom/") ||
-            normalizedId.includes("/node_modules/scheduler/")
-        ) {
-            return "vendor-react";
-        }
+        // 注意: react / react-dom / scheduler を専用 chunk (vendor-react) に分離すると
+        // vendor 側の react 依存 CJS interop と初期化順の循環が生じ、本番ビルドが
+        // `Cannot set properties of undefined (setting 'Activity')` で起動不能になる
+        // (#86 のリグレッション)。react 系は vendor に同梱したままにすること。
 
         // 現状 @tanstack は react-router のみ。将来 @tanstack/query 等を足すと
         // この chunk に同梱され肥大化しうるので、その際は router 系に限定するか

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -21,10 +21,9 @@ function manualChunks(id: string): string | undefined {
     const normalizedId = id.split(path.sep).join("/");
 
     if (normalizedId.includes("/node_modules/")) {
-        // 注意: react / react-dom / scheduler を専用 chunk (vendor-react) に分離すると
-        // vendor 側の react 依存 CJS interop と初期化順の循環が生じ、本番ビルドが
-        // `Cannot set properties of undefined (setting 'Activity')` で起動不能になる
-        // (#86 のリグレッション)。react 系は vendor に同梱したままにすること。
+        // react / react-dom / scheduler を専用 chunk に分離してはいけない。vendor 側の
+        // react 依存 CJS interop と chunk 初期化順の循環が生じ、本番ビルドのみ
+        // `Cannot set properties of undefined (setting 'Activity')` で起動不能になる。
 
         // 現状 @tanstack は react-router のみ。将来 @tanstack/query 等を足すと
         // この chunk に同梱され肥大化しうるので、その際は router 系に限定するか

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,6 +24,8 @@ function manualChunks(id: string): string | undefined {
         // react / react-dom / scheduler を専用 chunk に分離してはいけない。vendor 側の
         // react 依存 CJS interop と chunk 初期化順の循環が生じ、本番ビルドのみ
         // `Cannot set properties of undefined (setting 'Activity')` で起動不能になる。
+        // (resolve.dedupe の react 指定は複数インスタンス重複を防ぐ別の保護で、
+        //  この chunk 分割の制約とは独立)
 
         // 現状 @tanstack は react-router のみ。将来 @tanstack/query 等を足すと
         // この chunk に同梱され肥大化しうるので、その際は router 系に限定するか


### PR DESCRIPTION
## 問題

#86 の manualChunks で react / react-dom / scheduler を専用 chunk (`vendor-react`) に分離した結果、**本番ビルドが起動不能**（`Cannot set properties of undefined (setting 'Activity')` で React がマウントしない）。

- vendor chunk 内の react 依存 CJS interop と vendor-react chunk の間で初期化順の循環が発生
- デプロイが手動運用のため未検出だった（staging へ #89 のブランチをデプロイした際に発覚。**origin/main 単体のビルドでも再現することを確認済み**）
- 本番は旧デプロイのまま稼働中のため影響なし。ただし本修正が入るまで main からのデプロイは全て起動不能

## 修正

react 系を vendor chunk へ戻す（#86 のルート code-split 自体は維持）。再発防止コメントを manualChunks に追記。

## 検証

- `vite preview` + headless Chromium で `/`・`/rshogi-viewer`・`/online` の起動確認（root マウント、console エラーなし）
- 修正前は同環境で pageerror を再現

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuYnNrHccPfMYVkXBwBWHR