### PR TITLE
fix(ui): Portal 系 UI が墨の検討室でライト表示される問題を修正

### DIFF
--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -3,6 +3,7 @@ import { cn } from "@shogi/design-system";
 import type { ComponentPropsWithoutRef, ComponentRef, ReactElement } from "react";
 import { forwardRef } from "react";
 import { buttonVariants } from "./button";
+import { useSurfaceTheme } from "./surface-theme";
 
 export const AlertDialog = AlertDialogPrimitive.Root;
 export const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
@@ -28,11 +29,14 @@ export const AlertDialogContent = forwardRef<
     ComponentRef<typeof AlertDialogPrimitive.Content>,
     ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
 >(function AlertDialogContent({ className, children, ...props }, ref): ReactElement {
+    // Portal で body 直下へ出るため、開いた場所の局所テーマを引き継ぐ
+    const surfaceTheme = useSurfaceTheme();
     return (
         <AlertDialogPortal>
             <AlertDialogOverlay />
             <AlertDialogPrimitive.Content
                 className={cn(
+                    surfaceTheme,
                     "fixed left-1/2 top-1/2 z-[51] grid w-[min(420px,calc(100%-32px))] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl border border-border bg-card p-6 text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.35)] duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
                     className,
                 )}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -2,6 +2,7 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { cn } from "@shogi/design-system";
 import type { ComponentPropsWithoutRef, ComponentRef, CSSProperties, ReactElement } from "react";
 import { forwardRef } from "react";
+import { useSurfaceTheme } from "./surface-theme";
 
 export const Dialog = DialogPrimitive.Root;
 export const DialogTrigger = DialogPrimitive.Trigger;
@@ -35,6 +36,9 @@ export const DialogContent = forwardRef<
     { className, children, overlayClassName, overlayStyle, style, ...props },
     ref,
 ): ReactElement {
+    // Portal で body 直下へ出るため、開いた場所の局所テーマ(検討室の墨地等)を
+    // context 経由で引き継ぎ、Content ルートにクラスとして付け直す
+    const surfaceTheme = useSurfaceTheme();
     return (
         <DialogPortal>
             <DialogOverlay className={overlayClassName} style={overlayStyle} />
@@ -42,6 +46,7 @@ export const DialogContent = forwardRef<
                 aria-describedby={undefined}
                 style={style}
                 className={cn(
+                    surfaceTheme,
                     "fixed left-1/2 top-1/2 z-[51] w-[min(960px,calc(100%-24px))] -translate-x-1/2 -translate-y-1/2 overflow-auto rounded-xl border border-border bg-card p-6 text-foreground shadow-[0_24px_70px_rgba(0,0,0,0.35)] max-h-[85vh] gap-4 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
                     className,
                 )}

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -2,6 +2,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover";
 import { cn } from "@shogi/design-system";
 import type { ComponentPropsWithoutRef, ComponentRef, ReactElement } from "react";
 import { forwardRef } from "react";
+import { useSurfaceTheme } from "./surface-theme";
 
 export const Popover = PopoverPrimitive.Root;
 export const PopoverTrigger = PopoverPrimitive.Trigger;
@@ -13,10 +14,13 @@ export const PopoverContent = forwardRef<
     { className, align = "center", sideOffset = 6, ...props },
     ref,
 ): ReactElement {
+    // Portal で body 直下へ出るため、開いた場所の局所テーマを引き継ぐ
+    const surfaceTheme = useSurfaceTheme();
     return (
         <PopoverPrimitive.Portal>
             <PopoverPrimitive.Content
                 className={cn(
+                    surfaceTheme,
                     "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2",
                     className,
                 )}

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -8,6 +8,7 @@ import * as SelectPrimitive from "@radix-ui/react-select";
 import { cn } from "@shogi/design-system";
 import type { ComponentPropsWithoutRef, ComponentRef, ReactElement } from "react";
 import { forwardRef } from "react";
+import { useSurfaceTheme } from "./surface-theme";
 
 const Select = SelectPrimitive.Root;
 const SelectValue = SelectPrimitive.Value;
@@ -56,10 +57,13 @@ const SelectContent = forwardRef<
     { className, children, position = "popper", ...props },
     ref,
 ): ReactElement {
+    // Portal で body 直下へ出るため、開いた場所の局所テーマを引き継ぐ
+    const surfaceTheme = useSurfaceTheme();
     return (
         <SelectPrimitive.Portal>
             <SelectPrimitive.Content
                 className={cn(
+                    surfaceTheme,
                     "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-lg border border-wafuu-border bg-wafuu-washi shadow-md",
                     "data-[state=open]:animate-in data-[state=closed]:animate-out",
                     "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",

--- a/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
+++ b/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
@@ -13,8 +13,10 @@ import type {
     PositionState,
     PresetConfig,
 } from "@shogi/app-core";
+import { cn } from "@shogi/design-system";
 import type { ReactElement } from "react";
 import { useEffect } from "react";
+import { useSurfaceTheme } from "../../surface-theme";
 import { useDraggableWindow } from "../hooks/useDraggableWindow";
 import {
     comparePvWithMainLine,
@@ -322,6 +324,7 @@ export function MoveDetailWindow({
     onClose,
     isOnMainLine = true,
 }: MoveDetailWindowProps): ReactElement {
+    const surfaceTheme = useSurfaceTheme();
     const { geometry, handlers } = useDraggableWindow(
         {
             x:
@@ -394,7 +397,12 @@ export function MoveDetailWindow({
 
     return (
         <div
-            className="fixed flex flex-col overflow-hidden bg-card border border-border rounded-xl shadow-2xl z-[1000]"
+            // fixed 配置で reviewMode の dark div の外(ShogiMatchLayout 階層)に出るため、
+            // Portal 系と同様に局所テーマを引き継ぐ
+            className={cn(
+                surfaceTheme,
+                "fixed flex flex-col overflow-hidden bg-card border border-border rounded-xl shadow-2xl z-[1000]",
+            )}
             style={{
                 left: windowPosition.x,
                 top: windowPosition.y,

--- a/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
@@ -11,6 +11,7 @@ import type { ReactElement } from "react";
 import { AboutDialog } from "../../AboutDialog";
 import { EngineRestartingOverlay } from "../../nnue/EngineRestartingOverlay";
 import { NnueManagerDialog } from "../../nnue/NnueManagerDialog";
+import { SurfaceThemeProvider } from "../../surface-theme";
 import { GameResultDialog } from "../components/GameResultDialog";
 import { MoveDetailWindow } from "../components/MoveDetailWindow";
 import { PvPreviewDialog } from "../components/PvPreviewDialog";
@@ -254,7 +255,12 @@ export function ShogiMatchLayout({
     } = mobileSpecificProps;
 
     return (
-        <>
+        // 検討/観戦では、Radix Portal で body 直下へ脱出する Dialog/Popover(この階層の
+        // PvPreviewDialog 等も含む)へ墨地テーマを context で配る。dark クラスの DOM
+        // スコープは Portal に届かないため、Portal 先で付け直す仕組み(surface-theme)。
+        // reviewMode は pc 用グループの値だが、mobileReviewMode と同一の外部 prop 由来
+        // (shogi-match.tsx で同じ reviewMode から両グループへ配られる)ため両デバイスで有効。
+        <SurfaceThemeProvider theme={reviewMode ? "dark" : undefined}>
             {/* DnD ゴースト */}
             <DragGhost
                 ref={dndController.ghostRef as React.RefObject<HTMLDivElement>}
@@ -634,6 +640,6 @@ export function ShogiMatchLayout({
             )}
 
             <AboutDialog open={isAboutOpen} onOpenChange={setIsAboutOpen} />
-        </>
+        </SurfaceThemeProvider>
     );
 }

--- a/packages/ui/src/components/surface-theme.test.tsx
+++ b/packages/ui/src/components/surface-theme.test.tsx
@@ -32,6 +32,17 @@ describe("SurfaceThemeProvider / useSurfaceTheme", () => {
         );
         expect(screen.getByTestId("probe").textContent).toBe("(none)");
     });
+
+    it("theme=undefined をネストしても親の dark を消さない", () => {
+        render(
+            <SurfaceThemeProvider theme="dark">
+                <SurfaceThemeProvider theme={undefined}>
+                    <ThemeProbe />
+                </SurfaceThemeProvider>
+            </SurfaceThemeProvider>,
+        );
+        expect(screen.getByTestId("probe").textContent).toBe("dark");
+    });
 });
 
 describe("Portal 系 Content へのテーマ伝搬", () => {

--- a/packages/ui/src/components/surface-theme.test.tsx
+++ b/packages/ui/src/components/surface-theme.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { Dialog, DialogContent, DialogTitle } from "./dialog";
+import { SurfaceThemeProvider, useSurfaceTheme } from "./surface-theme";
+
+function ThemeProbe(): ReactElement {
+    const theme = useSurfaceTheme();
+    return <span data-testid="probe">{theme ?? "(none)"}</span>;
+}
+
+describe("SurfaceThemeProvider / useSurfaceTheme", () => {
+    it("Provider 外では undefined", () => {
+        render(<ThemeProbe />);
+        expect(screen.getByTestId("probe").textContent).toBe("(none)");
+    });
+
+    it("Provider 内では dark が伝搬する", () => {
+        render(
+            <SurfaceThemeProvider theme="dark">
+                <ThemeProbe />
+            </SurfaceThemeProvider>,
+        );
+        expect(screen.getByTestId("probe").textContent).toBe("dark");
+    });
+
+    it("theme=undefined の Provider は何も上書きしない", () => {
+        render(
+            <SurfaceThemeProvider theme={undefined}>
+                <ThemeProbe />
+            </SurfaceThemeProvider>,
+        );
+        expect(screen.getByTestId("probe").textContent).toBe("(none)");
+    });
+});
+
+describe("Portal 系 Content へのテーマ伝搬", () => {
+    it("dark サーフェス内から開いた Dialog は Portal 先でも dark クラスを持つ", () => {
+        render(
+            <SurfaceThemeProvider theme="dark">
+                <Dialog open>
+                    <DialogContent>
+                        <DialogTitle>設定</DialogTitle>
+                    </DialogContent>
+                </Dialog>
+            </SurfaceThemeProvider>,
+        );
+        const content = screen.getByRole("dialog");
+        expect(content.className.split(" ")).toContain("dark");
+    });
+
+    it("Provider 外の Dialog に dark は付かない", () => {
+        render(
+            <Dialog open>
+                <DialogContent>
+                    <DialogTitle>設定</DialogTitle>
+                </DialogContent>
+            </Dialog>,
+        );
+        const content = screen.getByRole("dialog");
+        expect(content.className.split(" ")).not.toContain("dark");
+    });
+});

--- a/packages/ui/src/components/surface-theme.tsx
+++ b/packages/ui/src/components/surface-theme.tsx
@@ -1,0 +1,26 @@
+import { createContext, type ReactElement, type ReactNode, useContext } from "react";
+
+// 局所サーフェステーマ(検討室の墨地など)を Portal 脱出組へ伝えるための context。
+// theme.css の `.dark` 変数スコープは DOM の祖先にしか効かないため、Radix Portal で
+// body 直下へ脱出する Dialog/Popover には届かない。React ツリーは Portal を跨いで
+// 繋がっているので、context 経由でテーマ名を渡し、Portal 先のルート要素に同じ
+// クラスを付け直すことで配下の CSS 変数を揃える。
+
+export type SurfaceTheme = "dark";
+
+const SurfaceThemeContext = createContext<SurfaceTheme | undefined>(undefined);
+
+interface SurfaceThemeProviderProps {
+    /** 局所テーマ。undefined ならページ既定のまま(何も上書きしない) */
+    theme: SurfaceTheme | undefined;
+    children: ReactNode;
+}
+
+export function SurfaceThemeProvider({ theme, children }: SurfaceThemeProviderProps): ReactElement {
+    return <SurfaceThemeContext.Provider value={theme}>{children}</SurfaceThemeContext.Provider>;
+}
+
+/** Portal で body 直下へ出る UI が、開かれた場所の局所テーマを引き継ぐための hook */
+export function useSurfaceTheme(): SurfaceTheme | undefined {
+    return useContext(SurfaceThemeContext);
+}

--- a/packages/ui/src/components/surface-theme.tsx
+++ b/packages/ui/src/components/surface-theme.tsx
@@ -17,6 +17,11 @@ interface SurfaceThemeProviderProps {
 }
 
 export function SurfaceThemeProvider({ theme, children }: SurfaceThemeProviderProps): ReactElement {
+    // undefined は「何も上書きしない」契約なので Provider を挟まない。
+    // 挟むと value=undefined がネストした親の値を消してしまう。
+    if (theme === undefined) {
+        return <>{children}</>;
+    }
     return <SurfaceThemeContext.Provider value={theme}>{children}</SurfaceThemeContext.Provider>;
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,6 +49,9 @@ export {
     encodeSnapshotEvalMateReplacer,
 } from "./components/shogi-match/utils/kifFormat";
 export { boardToGrid } from "./components/shogi-match/utils/positionUtils";
+export type { SurfaceTheme } from "./components/surface-theme";
+// surface-theme (Portal 脱出 UI への局所テーマ伝搬)
+export { SurfaceThemeProvider, useSurfaceTheme } from "./components/surface-theme";
 
 // progress
 // shogi-board


### PR DESCRIPTION
## 問題

#89 の「墨の検討室」（reviewMode の局所 `dark` クラス）は DOM スコープのため、Radix Portal で body 直下へ脱出する UI に届かない。検討/観戦中に設定ダイアログ・一括解析 Popover 等を開くと、墨地の上に突然ライトの紙色で表示されていた（#89 の既知 follow-up）。

## 修正

**サーフェステーマの React Context** で解決。context は Portal を跨いで流れるため、開いた場所の局所テーマ名を Portal 先へ配れる:

- `surface-theme.tsx` 新設（`SurfaceThemeProvider` / `useSurfaceTheme`）
- ShogiMatchLayout ルートで `reviewMode ? "dark" : undefined` を供給（PC/モバイル + この階層のダイアログ群を一括カバー）
- Dialog / Popover / AlertDialog / Select の Content が context を読み Portal 先に `dark` を合成
- MoveDetailWindow も対応（Portal ではないが fixed 配置で dark div の外に出る同族問題）
- Provider 外（対局ページ・HeaderNav 等）は `undefined` → no-op でライト維持

## 検証

- typecheck / lint / test（@shogi/ui 394 = +新規5、web 42）全 pass
- クリック操作つき playwright で実測: 検討室の 一括解析 Popover / SettingsModal / NNUE 管理 / **ネストした AlertDialog**（Dialog 内から発火）すべて墨地、`/play` 側は全てライト維持
- `html.dark`（グローバルダーク）との二重適用が冪等であることを実測確認
- 独立2レビュアー（正しさ/アーキ + QA攻め）APPROVE。レビュー指摘の select.tsx の latent gap と MoveDetailWindow も本PRで対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuYnNrHccPfMYVkXBwBWHR