### PR TITLE
style(ui): PR レビュー残指摘の arbitrary トークン形式を正規化

### DIFF
--- a/packages/ui/src/components/shogi-board.tsx
+++ b/packages/ui/src/components/shogi-board.tsx
@@ -90,7 +90,7 @@ export function ShogiBoard({
                         </span>
                     ))}
                 </div>
-                <div className="grid flex-1 grid-cols-9 overflow-hidden rounded-xl border-l border-t border-[hsl(var(--shogi-border))]">
+                <div className="grid flex-1 grid-cols-9 overflow-hidden rounded-xl border-l border-t border-shogi-border">
                     {grid.map((row, rowIndex) =>
                         row.map((cell, columnIndex) => {
                             const isSelected = selectedSquare === cell.id;
@@ -109,7 +109,7 @@ export function ShogiBoard({
                             return (
                                 <div
                                     key={cell.id}
-                                    className="relative aspect-square w-[var(--shogi-cell-size,48px)] border-b border-r border-[hsl(var(--shogi-border))]"
+                                    className="relative aspect-square w-[var(--shogi-cell-size,48px)] border-b border-r border-shogi-border"
                                 >
                                     <button
                                         type="button"

--- a/packages/ui/src/components/shogi-match/components/GameResultDialog.tsx
+++ b/packages/ui/src/components/shogi-match/components/GameResultDialog.tsx
@@ -37,9 +37,7 @@ export function GameResultDialog({
                 </DialogHeader>
 
                 <div className="flex flex-col items-center gap-4 py-4">
-                    <div className="text-2xl font-bold text-[hsl(var(--wafuu-kin,42_85%_50%))]">
-                        {winnerLabel}
-                    </div>
+                    <div className="text-2xl font-bold text-wafuu-kin">{winnerLabel}</div>
 
                     <div className="h-px w-full bg-border" />
 

--- a/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
+++ b/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
@@ -135,7 +135,7 @@ function PvCandidateItem({
         <div
             className="
                 border border-border rounded-lg p-2
-                bg-wafuu-washi/30 dark:bg-[hsl(var(--muted)/0.3)]
+                bg-wafuu-washi/30 dark:bg-muted/30
             "
         >
             {/* ヘッダー: 候補番号 + 評価値 */}
@@ -435,7 +435,7 @@ export function MoveDetailWindow({
             {/* コンテンツ */}
             <div className="flex-1 overflow-auto p-3">
                 {/* 評価値サマリー */}
-                <div className="flex items-center gap-2 mb-3 p-2 bg-wafuu-washi dark:bg-[hsl(var(--muted)/0.5)] rounded-lg">
+                <div className="flex items-center gap-2 mb-3 p-2 bg-wafuu-washi dark:bg-muted/50 rounded-lg">
                     <span
                         className={`font-medium text-[14px] ${
                             evalInfo.advantage === "sente"

--- a/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
@@ -125,7 +125,7 @@ export function PCBoardSection({ candidateNote, hideClock }: PCBoardSectionProps
                             type="button"
                             onClick={() => onFlipBoardChange(!flipBoard)}
                             className={`flex items-center gap-1 px-2 py-1 rounded-md border border-wafuu-border cursor-pointer text-[13px] whitespace-nowrap ${
-                                flipBoard ? "bg-[hsl(var(--wafuu-kin)/0.2)]" : "bg-card"
+                                flipBoard ? "bg-wafuu-kin/20" : "bg-card"
                             }`}
                             title="盤面を反転"
                         >

--- a/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCBoardSection.tsx
@@ -124,7 +124,7 @@ export function PCBoardSection({ candidateNote, hideClock }: PCBoardSectionProps
                         <button
                             type="button"
                             onClick={() => onFlipBoardChange(!flipBoard)}
-                            className={`flex items-center gap-1 px-2 py-1 rounded-md border border-[hsl(var(--wafuu-border))] cursor-pointer text-[13px] whitespace-nowrap ${
+                            className={`flex items-center gap-1 px-2 py-1 rounded-md border border-wafuu-border cursor-pointer text-[13px] whitespace-nowrap ${
                                 flipBoard ? "bg-[hsl(var(--wafuu-kin)/0.2)]" : "bg-card"
                             }`}
                             title="盤面を反転"

--- a/packages/ui/src/components/shogi-match/components/SkillLevelSelector.tsx
+++ b/packages/ui/src/components/shogi-match/components/SkillLevelSelector.tsx
@@ -32,9 +32,7 @@ export function SkillLevelSelector({
         <label className={labelClassName}>
             <span className="flex justify-between">
                 <span>エンジンの強さ</span>
-                <span className="font-mono text-[hsl(var(--wafuu-kincha))]">
-                    レベル {currentLevel}
-                </span>
+                <span className="font-mono text-wafuu-kincha">レベル {currentLevel}</span>
             </span>
             <input
                 type="range"
@@ -43,9 +41,9 @@ export function SkillLevelSelector({
                 value={currentLevel}
                 onChange={(e) => handleLevelChange(Number(e.target.value))}
                 disabled={disabled}
-                className="w-full accent-[hsl(var(--wafuu-shu))]"
+                className="w-full accent-wafuu-shu"
             />
-            <span className="flex justify-between text-[11px] text-[hsl(var(--muted-foreground))]">
+            <span className="flex justify-between text-[11px] text-muted-foreground">
                 <span>弱い</span>
                 <span>強い</span>
             </span>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -49,8 +49,8 @@ export {
     encodeSnapshotEvalMateReplacer,
 } from "./components/shogi-match/utils/kifFormat";
 export { boardToGrid } from "./components/shogi-match/utils/positionUtils";
-export type { SurfaceTheme } from "./components/surface-theme";
 // surface-theme (Portal 脱出 UI への局所テーマ伝搬)
+export type { SurfaceTheme } from "./components/surface-theme";
 export { SurfaceThemeProvider, useSurfaceTheme } from "./components/surface-theme";
 
 // progress


### PR DESCRIPTION
## 背景

#89 / #91 のレビューコメント棚卸しで未対応が判明した分の対応:
- **#89 指摘**: MoveDetailWindow の `dark:bg-[hsl(var(--muted)/0.3)]` / `/0.5`（KifuPanel 分は対応済みだったが MoveDetailWindow 分が漏れていた）
- **#91 指摘**: index.ts の surface-theme export のコメント位置

あわせて S3a レビューで follow-up 指定されていた同型の残存（shogi-board / SkillLevelSelector / PCBoardSection / GameResultDialog）を一掃。

## 対象外（理由つき）

nnue 系コンポーネントの `--success` / `--warning` 参照は**トークン自体が theme.css に存在せず**、arbitrary 形式のフォールバック値で動作している別問題。機械的変換不可のため、トークン新設を伴う follow-up として別途。

## 検証

- 全て className 文字列の機械的置換のみ（ロジック変更なし）
- production build の生成 CSS で全トークンクラスの出力と opacity modifier の color-mix 展開を確認
- typecheck / lint / test（@shogi/ui 395、web 42）全 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuYnNrHccPfMYVkXBwBWHR