### PR TITLE
style(ui,design-system): arbitrary 色形式のトークン負債を完済

### DIFF
--- a/packages/design-system/src/theme.css
+++ b/packages/design-system/src/theme.css
@@ -80,6 +80,10 @@
         --status-success-fg: 140 40% 95%; /* 成功前景 */
         --status-success-bg: 140 45% 93%; /* 成功背景 */
         --status-success-border: 140 35% 78%; /* 成功ボーダー */
+        --status-warning: 36 80% 38%; /* 警告 - 落ち着いた琥珀。小さい文字でも読める明度 */
+        --status-warning-fg: 40 80% 96%; /* 警告前景 */
+        --status-warning-bg: 40 85% 92%; /* 警告背景 */
+        --status-warning-border: 40 55% 75%; /* 警告ボーダー */
 
         /* レイアウト */
         --panel-width: 400px; /* 右サイドパネルの幅 */
@@ -146,6 +150,10 @@
         --status-success-fg: 140 40% 98%; /* 成功前景 */
         --status-success-bg: 140 30% 12%; /* 成功背景 */
         --status-success-border: 140 25% 22%; /* 成功ボーダー */
+        --status-warning: 38 75% 55%; /* 警告 - 暗地で明るく */
+        --status-warning-fg: 40 80% 97%; /* 警告前景 */
+        --status-warning-bg: 38 40% 12%; /* 警告背景 */
+        --status-warning-border: 38 35% 24%; /* 警告ボーダー */
     }
 
     *,

--- a/packages/design-system/tailwind.preset.ts
+++ b/packages/design-system/tailwind.preset.ts
@@ -73,6 +73,10 @@ const preset: Omit<Config, "content"> = {
                     "success-fg": "hsl(var(--status-success-fg))",
                     "success-bg": "hsl(var(--status-success-bg))",
                     "success-border": "hsl(var(--status-success-border))",
+                    warning: "hsl(var(--status-warning))",
+                    "warning-fg": "hsl(var(--status-warning-fg))",
+                    "warning-bg": "hsl(var(--status-warning-bg))",
+                    "warning-border": "hsl(var(--status-warning-border))",
                 },
                 // 将棋盤配色
                 shogi: {

--- a/packages/ui/src/components/engine-control-panel.tsx
+++ b/packages/ui/src/components/engine-control-panel.tsx
@@ -677,7 +677,7 @@ export function EngineControlPanel({
                                             className={cn(
                                                 "text-base font-semibold",
                                                 threadInfo && threadInfo.activeThreads > 1
-                                                    ? "text-[hsl(var(--success,142_76%_36%))]"
+                                                    ? "text-status-success"
                                                     : "text-foreground",
                                             )}
                                         >
@@ -702,8 +702,8 @@ export function EngineControlPanel({
                                             className={cn(
                                                 "text-sm font-semibold",
                                                 threadInfo?.threadedAvailable
-                                                    ? "text-[hsl(var(--success,142_76%_36%))]"
-                                                    : "text-[hsl(0_72%_51%)]",
+                                                    ? "text-status-success"
+                                                    : "text-destructive",
                                             )}
                                         >
                                             {threadInfo?.threadedAvailable ? "Yes" : "No"}
@@ -722,8 +722,8 @@ export function EngineControlPanel({
                                                 "text-sm font-semibold",
                                                 typeof self.crossOriginIsolated !== "undefined" &&
                                                     self.crossOriginIsolated
-                                                    ? "text-[hsl(var(--success,142_76%_36%))]"
-                                                    : "text-[hsl(0_72%_51%)]",
+                                                    ? "text-status-success"
+                                                    : "text-destructive",
                                             )}
                                         >
                                             {typeof self.crossOriginIsolated !== "undefined"

--- a/packages/ui/src/components/nnue/NnueListItem.tsx
+++ b/packages/ui/src/components/nnue/NnueListItem.tsx
@@ -77,12 +77,12 @@ function getValidationStatus(meta: NnueMeta): { label: string; className: string
     if (meta.format) {
         return {
             label: "形式確認済み",
-            className: "text-[hsl(var(--success,142_76%_36%))]",
+            className: "text-status-success",
         };
     }
     return {
         label: "未確認（動作保証なし）",
-        className: "text-[hsl(var(--warning,38_92%_50%))]",
+        className: "text-status-warning",
     };
 }
 
@@ -256,7 +256,7 @@ export function NnueListItem({
                             className={cn(
                                 "h-5 w-5 shrink-0 rounded-full",
                                 isSelected
-                                    ? "border-[6px] border-[hsl(var(--primary,220_90%_56%))]"
+                                    ? "border-[6px] border-primary"
                                     : "border-2 border-muted-foreground",
                             )}
                         />

--- a/packages/ui/src/components/nnue/NnueManagerDialog.tsx
+++ b/packages/ui/src/components/nnue/NnueManagerDialog.tsx
@@ -243,7 +243,7 @@ export function NnueManagerDialog({
                 <div className="relative flex min-h-[200px] flex-1 flex-col gap-4 overflow-auto">
                     {/* 開いた理由（対局開始時にNNUE未ダウンロードだった場合など） */}
                     {reasonMessage && (
-                        <div className="flex items-start gap-2 rounded-md border border-[hsl(var(--warning,38_92%_50%)/0.3)] bg-[hsl(var(--warning,38_92%_50%)/0.1)] p-3">
+                        <div className="flex items-start gap-2 rounded-md border border-status-warning/30 bg-status-warning/10 p-3">
                             <span className="text-base leading-none">⚠️</span>
                             <div className="flex-1">
                                 <p className="m-0 text-[13px] text-foreground">{reasonMessage}</p>

--- a/packages/ui/src/components/nnue/PresetListItem.tsx
+++ b/packages/ui/src/components/nnue/PresetListItem.tsx
@@ -97,14 +97,14 @@ export function PresetListItem({
     const renderStatusBadge = () => {
         if (status === "latest") {
             return (
-                <span className="rounded bg-[hsl(var(--success,142_76%_36%)/0.1)] px-1.5 py-0.5 text-[11px] text-[hsl(var(--success,142_76%_36%))]">
+                <span className="rounded bg-status-success/10 px-1.5 py-0.5 text-[11px] text-status-success">
                     最新
                 </span>
             );
         }
         if (status === "update-available") {
             return (
-                <span className="rounded bg-[hsl(var(--warning,38_92%_50%)/0.1)] px-1.5 py-0.5 text-[11px] text-[hsl(var(--warning,38_92%_50%))]">
+                <span className="rounded bg-status-warning/10 px-1.5 py-0.5 text-[11px] text-status-warning">
                     更新あり
                 </span>
             );
@@ -145,7 +145,7 @@ export function PresetListItem({
     const downloadSection = (status === "not-downloaded" || status === "update-available") && (
         <div className="flex flex-col items-end gap-1">
             {isLargeFile && !isDownloading && (
-                <span className="whitespace-nowrap rounded bg-[hsl(var(--warning,38_92%_50%)/0.1)] px-1.5 py-0.5 text-[11px] font-medium text-[hsl(var(--warning,38_92%_50%))]">
+                <span className="whitespace-nowrap rounded bg-status-warning/10 px-1.5 py-0.5 text-[11px] font-medium text-status-warning">
                     ⚠ Wi-Fi推奨
                 </span>
             )}
@@ -201,7 +201,7 @@ export function PresetListItem({
                     checked={isSelected}
                     onChange={handleChange}
                     disabled={disabled || isDownloading}
-                    className="m-0 h-5 w-5 shrink-0 accent-[hsl(var(--primary,220_90%_56%))]"
+                    className="m-0 h-5 w-5 shrink-0 accent-primary"
                 />
                 {contentSection}
                 {downloadSection}

--- a/packages/ui/src/components/nnue/RemoteNnueListItem.tsx
+++ b/packages/ui/src/components/nnue/RemoteNnueListItem.tsx
@@ -33,7 +33,7 @@ export function RemoteNnueListItem({
                         <span
                             className={`rounded px-1.5 py-0.5 text-[11px] ${
                                 isImported
-                                    ? "bg-[hsl(var(--success,142_76%_36%)/0.1)] text-[hsl(var(--success,142_76%_36%))]"
+                                    ? "bg-status-success/10 text-status-success"
                                     : "bg-muted text-muted-foreground"
                             }`}
                         >

--- a/packages/ui/src/components/shogi-board.tsx
+++ b/packages/ui/src/components/shogi-board.tsx
@@ -69,11 +69,11 @@ export function ShogiBoard({
     const { files, ranks } = getBoardLabels(flipBoard);
 
     return (
-        <div className="relative inline-block rounded-lg border border-[hsl(var(--shogi-outer-border))] bg-[hsl(var(--shogi-cell-light))] shadow-[0_4px_12px_rgba(0,0,0,0.12)]">
+        <div className="relative inline-block rounded-lg border border-shogi-outer-border bg-shogi-cell-light shadow-[0_4px_12px_rgba(0,0,0,0.12)]">
             {/* 盤外ラベル: 筋（上） */}
             <div
                 className={cn(
-                    "grid grid-cols-9 py-0.5 text-center text-[11px] font-semibold text-[hsl(var(--wafuu-sumi)/0.7)] [text-shadow:0_1px_0_rgba(255,255,255,0.5)] ml-[1.25em] mr-[1.25em]",
+                    "grid grid-cols-9 py-0.5 text-center text-[11px] font-semibold text-wafuu-sumi/70 [text-shadow:0_1px_0_rgba(255,255,255,0.5)] ml-[1.25em] mr-[1.25em]",
                     showBoardLabels ? "visible" : "invisible",
                 )}
             >
@@ -103,8 +103,8 @@ export function ShogiBoard({
                             const isHighlighted = isLastMoveTo || isLastMoveFrom || isSelected;
                             const baseTone =
                                 (rowIndex + columnIndex) % 2 === 0
-                                    ? "bg-[hsl(var(--shogi-cell-light))]"
-                                    : "bg-[hsl(var(--shogi-cell-dark))]";
+                                    ? "bg-shogi-cell-light"
+                                    : "bg-shogi-cell-dark";
 
                             return (
                                 <div
@@ -156,7 +156,7 @@ export function ShogiBoard({
                                                 : `${cell.id} 空マス`
                                         }
                                         className={cn(
-                                            "absolute inset-0 overflow-hidden text-base font-semibold transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-[hsl(var(--wafuu-shu))]/70 focus-visible:ring-offset-transparent",
+                                            "absolute inset-0 overflow-hidden text-base font-semibold transition-all duration-150 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-wafuu-shu/70 focus-visible:ring-offset-transparent",
                                             "hover:ring-2 hover:ring-inset hover:ring-shogi-border",
                                             // タッチ選択・長押しメニュー防止
                                             "select-none [-webkit-touch-callout:none]",
@@ -233,7 +233,7 @@ export function ShogiBoard({
                                                     }
                                                 }}
                                                 aria-label="成る"
-                                                className="flex-1 rounded-t-md bg-gradient-to-b from-[hsl(var(--wafuu-shu))] to-[hsl(var(--wafuu-shu)/0.8)] text-[14px] font-bold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl active:scale-95 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2"
+                                                className="flex-1 rounded-t-md bg-gradient-to-b from-wafuu-shu to-wafuu-shu/80 text-[14px] font-bold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl active:scale-95 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2"
                                             >
                                                 成
                                             </button>
@@ -269,7 +269,7 @@ export function ShogiBoard({
                 {/* 盤外ラベル: 段（右） */}
                 <div
                     className={cn(
-                        "flex flex-col justify-around px-0.5 text-[11px] font-semibold text-[hsl(var(--wafuu-sumi)/0.7)] [text-shadow:0_1px_0_rgba(255,255,255,0.5)]",
+                        "flex flex-col justify-around px-0.5 text-[11px] font-semibold text-wafuu-sumi/70 [text-shadow:0_1px_0_rgba(255,255,255,0.5)]",
                         showBoardLabels ? "visible" : "invisible",
                     )}
                 >

--- a/packages/ui/src/components/shogi-match/components/HandPiecesDisplay.tsx
+++ b/packages/ui/src/components/shogi-match/components/HandPiecesDisplay.tsx
@@ -77,9 +77,7 @@ function PieceToken({
                     "absolute text-center font-bold leading-none",
                     config.badgeSize,
                     shouldRotate ? config.badgePosRotated : config.badgePos,
-                    count > 0
-                        ? "text-[hsl(var(--wafuu-sumi))]"
-                        : "text-[hsl(var(--muted-foreground))]",
+                    count > 0 ? "text-wafuu-sumi" : "text-muted-foreground",
                 )}
             >
                 {count}
@@ -279,11 +277,11 @@ export function HandPiecesDisplay({
                                         canDrag ? "touch-none" : "touch-manipulation",
                                         containerConfig.buttonPadding,
                                         selected
-                                            ? "border-[hsl(var(--wafuu-shu))] bg-[hsl(var(--wafuu-kin)/0.2)]"
+                                            ? "border-wafuu-shu bg-wafuu-kin/20"
                                             : "border-transparent",
                                         count > 0 || isEditMode ? "opacity-100" : "opacity-40",
                                         (canDrag || canSelect) &&
-                                            "cursor-pointer hover:bg-[hsl(var(--wafuu-kin)/0.1)]",
+                                            "cursor-pointer hover:bg-wafuu-kin/10",
                                     )}
                                 >
                                     <PieceToken
@@ -309,11 +307,11 @@ export function HandPiecesDisplay({
                                             disabled={!isEditMode || count >= maxCount}
                                             aria-label={`${PIECE_LABELS[piece]}を増やす`}
                                             className={cn(
-                                                "flex items-center justify-center rounded-t border border-b-0 border-[hsl(var(--border))] text-xs font-bold leading-none",
+                                                "flex items-center justify-center rounded-t border border-b-0 border-border text-xs font-bold leading-none",
                                                 containerConfig.adjusterButton,
                                                 count < maxCount
-                                                    ? "cursor-pointer bg-[hsl(var(--wafuu-washi))] text-[hsl(var(--wafuu-sumi))] opacity-100"
-                                                    : "cursor-not-allowed bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))] opacity-40",
+                                                    ? "cursor-pointer bg-wafuu-washi text-wafuu-sumi opacity-100"
+                                                    : "cursor-not-allowed bg-muted text-muted-foreground opacity-40",
                                             )}
                                         >
                                             +
@@ -324,11 +322,11 @@ export function HandPiecesDisplay({
                                             disabled={!isEditMode || count <= 0}
                                             aria-label={`${PIECE_LABELS[piece]}を減らす`}
                                             className={cn(
-                                                "flex items-center justify-center rounded-b border border-[hsl(var(--border))] text-xs font-bold leading-none",
+                                                "flex items-center justify-center rounded-b border border-border text-xs font-bold leading-none",
                                                 containerConfig.adjusterButton,
                                                 count > 0
-                                                    ? "cursor-pointer bg-[hsl(var(--wafuu-washi))] text-[hsl(var(--wafuu-sumi))] opacity-100"
-                                                    : "cursor-not-allowed bg-[hsl(var(--muted))] text-[hsl(var(--muted-foreground))] opacity-40",
+                                                    ? "cursor-pointer bg-wafuu-washi text-wafuu-sumi opacity-100"
+                                                    : "cursor-not-allowed bg-muted text-muted-foreground opacity-40",
                                             )}
                                         >
                                             −


### PR DESCRIPTION
## 概要

デザイン刷新の整理系 follow-up の最終回。未定義変数のフォールバック頼みだった nnue 系と、arbitrary 色形式の残存 35 箇所をトークンへ統一。残置はすべて理由つきの管理下に。

## 変更

- **`--status-warning` 系4種を新設**（status-success と同構成）。light は旧実効値の白地コントラスト 2.14:1 → 約 4.07:1 に改善
- **未定義変数の解消**: `--success` → `status-success`（意図的な軽微な色変化: システムの落ち着いた緑へ統一）、`--warning` → 新設トークン、`--primary` の dead フォールバック除去（視覚変化ゼロ）
- **機械的等価変換**: HandPiecesDisplay(14) / shogi-board(7) / engine-control-panel(5)。`text-[hsl(0_72%_51%)]` は --destructive と同値のため `text-destructive` へ（dark 追従も改善）
- **正当な残置**（変換不可・理由つき）: SVG stroke 属性 / box-shadow 色 / style={} 内の動的合成 / dev 専用パネルの固定グラデーション

## 検証

- 生成 CSS で新クラス全出力・旧 arbitrary クラスの完全消滅を grep 確認
- `/play` のビジュアル比較で回帰なし（盤・持駒・座標）
- typecheck / lint / test（@shogi/ui 395、web 42）全 pass
- 独立レビュアー APPROVE（色変化の意図的/ゼロの分類・コントラスト実測込み。推奨調整2点は反映済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FuYnNrHccPfMYVkXBwBWHR