### PR TITLE
fix(ui): 保存済み snapshot 再適用時に multiPV 評価を UI へ復元する (#88)

### DIFF
--- a/packages/ui/src/components/shogi-match.test.ts
+++ b/packages/ui/src/components/shogi-match.test.ts
@@ -56,6 +56,12 @@ describe("analysisSnapshotMultiPvToRecordedEvalInfoEvent", () => {
             normalized: true,
         });
     });
+
+    it("省略された evalCp / evalMate は undefined へフォールバックする", () => {
+        const event = analysisSnapshotMultiPvToRecordedEvalInfoEvent({ multipv: 1, depth: 5 });
+        expect(event.scoreCp).toBeUndefined();
+        expect(event.scoreMate).toBeUndefined();
+    });
 });
 
 describe("applyAnalysisSnapshotEntryEvals", () => {
@@ -112,6 +118,23 @@ describe("applyAnalysisSnapshotEntryEvals", () => {
         expect(recordEvalByPly).toHaveBeenCalledWith(
             1,
             expect.objectContaining({ multipv: 1, scoreCp: 10 }),
+        );
+    });
+
+    it("multiPv が空配列のときも主評価のみ再適用する", () => {
+        const clearEvalByPly = vi.fn();
+        const recordEvalByPly = vi.fn();
+
+        applyAnalysisSnapshotEntryEvals(
+            { ply: 2, evalCp: 50, evalMate: null, depth: 10, pv: ["3g3f"], multiPv: [] },
+            { clearEvalByPly, recordEvalByPly },
+        );
+
+        expect(clearEvalByPly).toHaveBeenCalledExactlyOnceWith(2);
+        expect(recordEvalByPly).toHaveBeenCalledTimes(1);
+        expect(recordEvalByPly).toHaveBeenCalledWith(
+            2,
+            expect.objectContaining({ multipv: 1, scoreCp: 50 }),
         );
     });
 });

--- a/packages/ui/src/components/shogi-match.test.ts
+++ b/packages/ui/src/components/shogi-match.test.ts
@@ -1,8 +1,10 @@
 import { applyMoveWithState, createInitialPositionState } from "@shogi/app-core";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
     analysisSnapshotEntryToRecordedEvalInfoEvent,
+    analysisSnapshotMultiPvToRecordedEvalInfoEvent,
+    applyAnalysisSnapshotEntryEvals,
     applyReviewMoveDataDiff,
     getInitialReviewSyncMode,
     stringifyReviewMoveData,
@@ -31,6 +33,86 @@ describe("analysisSnapshotEntryToRecordedEvalInfoEvent", () => {
             multipv: 1,
             normalized: true,
         });
+    });
+});
+
+describe("analysisSnapshotMultiPvToRecordedEvalInfoEvent", () => {
+    it("multiPv 候補の multipv 番号と評価値を保持する", () => {
+        expect(
+            analysisSnapshotMultiPvToRecordedEvalInfoEvent({
+                multipv: 2,
+                evalCp: -80,
+                evalMate: undefined,
+                depth: 12,
+                pv: ["2g2f", "8c8d"],
+            }),
+        ).toMatchObject({
+            type: "info",
+            scoreCp: -80,
+            scoreMate: undefined,
+            depth: 12,
+            pv: ["2g2f", "8c8d"],
+            multipv: 2,
+            normalized: true,
+        });
+    });
+});
+
+describe("applyAnalysisSnapshotEntryEvals", () => {
+    it("主評価 (multipv:1) と各 multiPv 候補を multipv スロットへ再適用する", () => {
+        const clearEvalByPly = vi.fn();
+        const recordEvalByPly = vi.fn();
+
+        applyAnalysisSnapshotEntryEvals(
+            {
+                ply: 3,
+                evalCp: 40,
+                evalMate: null,
+                depth: 15,
+                pv: ["7g7f"],
+                multiPv: [
+                    { multipv: 1, evalCp: 40, depth: 15, pv: ["7g7f"] },
+                    { multipv: 2, evalCp: -20, depth: 15, pv: ["2g2f"] },
+                ],
+            },
+            { clearEvalByPly, recordEvalByPly },
+        );
+
+        expect(clearEvalByPly).toHaveBeenCalledExactlyOnceWith(3);
+        // 主評価 + multiPv 2 候補 = 3 回
+        expect(recordEvalByPly).toHaveBeenCalledTimes(3);
+        expect(recordEvalByPly).toHaveBeenNthCalledWith(
+            1,
+            3,
+            expect.objectContaining({ multipv: 1, scoreCp: 40 }),
+        );
+        expect(recordEvalByPly).toHaveBeenNthCalledWith(
+            2,
+            3,
+            expect.objectContaining({ multipv: 1, scoreCp: 40 }),
+        );
+        expect(recordEvalByPly).toHaveBeenNthCalledWith(
+            3,
+            3,
+            expect.objectContaining({ multipv: 2, scoreCp: -20 }),
+        );
+    });
+
+    it("multiPv が null のときは主評価のみ再適用する", () => {
+        const clearEvalByPly = vi.fn();
+        const recordEvalByPly = vi.fn();
+
+        applyAnalysisSnapshotEntryEvals(
+            { ply: 1, evalCp: 10, evalMate: null, depth: 8, pv: null, multiPv: null },
+            { clearEvalByPly, recordEvalByPly },
+        );
+
+        expect(clearEvalByPly).toHaveBeenCalledExactlyOnceWith(1);
+        expect(recordEvalByPly).toHaveBeenCalledTimes(1);
+        expect(recordEvalByPly).toHaveBeenCalledWith(
+            1,
+            expect.objectContaining({ multipv: 1, scoreCp: 10 }),
+        );
     });
 });
 

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -210,6 +210,42 @@ export const analysisSnapshotEntryToRecordedEvalInfoEvent = (
     normalized: true,
 });
 
+/** 保存済み snapshot の multiPv 候補 1 件を再適用用イベントへ変換する (multipv 番号を保持)。 */
+export const analysisSnapshotMultiPvToRecordedEvalInfoEvent = (
+    multiPv: NonNullable<AnalysisSnapshotEntryDraft["multiPv"]>[number],
+): RecordedEvalInfoEvent => ({
+    type: "info",
+    scoreCp: multiPv.evalCp ?? undefined,
+    scoreMate: multiPv.evalMate ?? undefined,
+    depth: multiPv.depth ?? undefined,
+    pv: multiPv.pv ?? undefined,
+    multipv: multiPv.multipv,
+    normalized: true,
+});
+
+/**
+ * 保存済み snapshot の 1 entry を棋譜ツリーへ再適用する。ply の評価を一旦クリアし、
+ * 主評価 (multipv:1) と各 multiPv 候補を multipv スロットごとに記録する。
+ * multiPv に multipv:1 が含まれても、主評価との二重記録は setNodeMultiPvEval の
+ * 深さ比較で吸収されるため無害 (multiPv が空/なしの経路のため主評価記録は残す)。
+ */
+export const applyAnalysisSnapshotEntryEvals = (
+    entry: AnalysisSnapshotEntryDraft,
+    handlers: {
+        clearEvalByPly: (ply: number) => void;
+        recordEvalByPly: (ply: number, event: RecordedEvalInfoEvent) => void;
+    },
+): void => {
+    handlers.clearEvalByPly(entry.ply);
+    handlers.recordEvalByPly(entry.ply, analysisSnapshotEntryToRecordedEvalInfoEvent(entry));
+    for (const multiPv of entry.multiPv ?? []) {
+        handlers.recordEvalByPly(
+            entry.ply,
+            analysisSnapshotMultiPvToRecordedEvalInfoEvent(multiPv),
+        );
+    }
+};
+
 export function useInitialReviewSync({
     positionReady,
     initialReview,
@@ -1600,8 +1636,7 @@ export function ShogiMatch({
         }
 
         for (const entry of initialAnalysisEntries) {
-            clearEvalByPly(entry.ply);
-            recordEvalByPly(entry.ply, analysisSnapshotEntryToRecordedEvalInfoEvent(entry));
+            applyAnalysisSnapshotEntryEvals(entry, { clearEvalByPly, recordEvalByPly });
         }
 
         initialAnalysisAppliedRef.current = signature;


### PR DESCRIPTION
## Summary

- 保存済み解析 snapshot を棋譜ツリーへ再適用する処理(`ShogiMatch` 内 `initialAnalysisEntries` の useEffect)は、各 entry を `analysisSnapshotEntryToRecordedEvalInfoEvent` で **`multipv: 1` の単一イベントに変換し `entry.multiPv[]` を捨てて**いた。このため保存時に持っていた multiPV 評価(`multiPv[].evalCp` / `evalMate` / `depth` / `pv`)が、再読込・snapshot 切替時に UI/棋譜ツリーへ**復元されなかった**(`±Infinity` に限らず有限値も同様)。
- 主評価(`multipv:1`)に加え、各 `multiPv` 候補を `multipv` スロットごとに `recordEvalByPly` する `applyAnalysisSnapshotEntryEvals` へ再適用ループを切り出し、`multipv` 番号を保持して復元する。

## 変更

- `analysisSnapshotMultiPvToRecordedEvalInfoEvent`: multiPv 候補 1 件 → `RecordedEvalInfoEvent`(`multipv` 番号保持、`normalized: true`)
- `applyAnalysisSnapshotEntryEvals`: `clearEvalByPly` → 主評価 record → 各 multiPv 候補 record。再適用 useEffect はこの helper 呼び出しに簡素化
- `shogi-match.test.ts`: converter・helper のユニットテスト追加(multiPv 復元、`multiPv:null` 時は主評価のみ)

## 設計根拠

- `recordEvalByPly(ply, event)` は `event.multipv` スロットへ `setNodeMultiPvEval` で記録し、`multipv===1` のとき単一 `eval` も更新する。
- `clearEvalByPly` は `eval` と `multiPvEvals` の両方をクリアするため、snapshot 切替の再適用で stale が残らない。
- 主評価と `multiPv[0]`(`multipv:1`)の二重 record は `setNodeMultiPvEval` の深さ比較で吸収されるため無害。`multiPv` が空/なしの経路のため主評価 record は残す。
- save 側(`multipv` 1-indexed)と load 側の形状は対称。`normalized:true` 付与で二重正規化も起きない(両レビューで確認)。

## 背景

- PR #87(#74)のレビューで判明した既存の UI 再適用 gap。wire/サーバー側は #87 で既に multiPV を無損失で保存・取得済みで、本 PR は取得後の UI 復元を補完する。

## Test plan

- [x] `@shogi/ui` vitest `shogi-match.test.ts` 10 pass(multiPv 復元・順序・null フォールバック)
- [x] `pnpm format:ci` / `pnpm lint` / `pnpm knip` green、`web`+`ui` typecheck green
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (汎用) APPROVE

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)