### PR TITLE
fix(ui): KIF「不成」の成り誤変換を修正し、一括解析の WASM panic を解消

### DIFF
--- a/packages/app-core/src/game/board.test.ts
+++ b/packages/app-core/src/game/board.test.ts
@@ -217,6 +217,85 @@ describe("applyMoveWithState", () => {
             expect(result.ok).toBe(true);
             expect(result.next.board["5d"]?.promoted).toBe(true);
         });
+
+        it("成れない駒種（金）への成りフラグはエラーを返す", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            board["5c"] = { owner: "sente", type: "G" };
+
+            const state: PositionState = { board, hands, turn: "sente" };
+            const result = applyMoveWithState(state, "5c5b+", { validateTurn: false });
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("piece cannot promote");
+        });
+
+        it("玉への成りフラグはエラーを返す", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            board["5c"] = { owner: "sente", type: "K" };
+
+            const state: PositionState = { board, hands, turn: "sente" };
+            const result = applyMoveWithState(state, "5c5b+", { validateTurn: false });
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("piece cannot promote");
+        });
+
+        it("既に成っている駒への再度の成りフラグはエラーを返す", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            board["5c"] = { owner: "sente", type: "R", promoted: true };
+
+            const state: PositionState = { board, hands, turn: "sente" };
+            const result = applyMoveWithState(state, "5c5b+", { validateTurn: false });
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("piece is already promoted");
+        });
+
+        it("敵陣に出入りしない成りフラグはエラーを返す", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            // 先手の歩を中段に配置（移動元 5e も移動先 5d も敵陣外）
+            board["5e"] = { owner: "sente", type: "P" };
+
+            const state: PositionState = { board, hands, turn: "sente" };
+            const result = applyMoveWithState(state, "5e5d+", { validateTurn: false });
+
+            expect(result.ok).toBe(false);
+            expect(result.error).toBe("move does not enter promotion zone");
+        });
+
+        it("敵陣から出る成りも許可される（移動元が敵陣）", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            board["5c"] = { owner: "sente", type: "S" };
+
+            const state: PositionState = { board, hands, turn: "sente" };
+            const result = applyMoveWithState(state, "5c5d+", { validateTurn: false });
+
+            expect(result.ok).toBe(true);
+            expect(result.next.board["5d"]?.promoted).toBe(true);
+        });
+
+        it("後手の駒は下段（g,h,i）が敵陣として扱われる", () => {
+            const board = createInitialBoard();
+            const hands = createEmptyHands();
+
+            board["5g"] = { owner: "gote", type: "P" };
+
+            const state: PositionState = { board, hands, turn: "gote" };
+            const result = applyMoveWithState(state, "5g5h+", { validateTurn: false });
+
+            expect(result.ok).toBe(true);
+            expect(result.next.board["5h"]?.promoted).toBe(true);
+        });
     });
 
     describe("持ち駒の管理", () => {

--- a/packages/app-core/src/game/board.ts
+++ b/packages/app-core/src/game/board.ts
@@ -64,6 +64,16 @@ const ALL_SQUARES: Square[] = BOARD_RANKS.flatMap((rank) =>
 );
 
 const PIECE_POOL: PieceType[] = ["P", "L", "N", "S", "G", "B", "R", "K"];
+
+// 金・玉は成れず、既に成った駒も再度成れない。
+const PROMOTABLE_TYPES: ReadonlySet<PieceType> = new Set(["P", "L", "N", "S", "B", "R"]);
+const SENTE_PROMOTION_RANKS: ReadonlySet<Rank> = new Set(["a", "b", "c"]);
+const GOTE_PROMOTION_RANKS: ReadonlySet<Rank> = new Set(["g", "h", "i"]);
+
+function isInPromotionZone(square: Square, owner: Player): boolean {
+    const rank = square[1] as Rank;
+    return owner === "sente" ? SENTE_PROMOTION_RANKS.has(rank) : GOTE_PROMOTION_RANKS.has(rank);
+}
 const PROMOTED_FROM: Record<PieceType, PieceType> = {
     P: "P",
     L: "L",
@@ -308,6 +318,21 @@ export function applyMoveWithState(
     const targetPiece = board[parsed.to];
     if (targetPiece && targetPiece.owner === fromPiece.owner) {
         return { ok: false, next: state, error: "cannot capture own piece" };
+    }
+
+    if (parsed.promote) {
+        if (!PROMOTABLE_TYPES.has(fromPiece.type)) {
+            return { ok: false, next: state, error: "piece cannot promote" };
+        }
+        if (fromPiece.promoted) {
+            return { ok: false, next: state, error: "piece is already promoted" };
+        }
+        if (
+            !isInPromotionZone(parsed.from, fromPiece.owner) &&
+            !isInPromotionZone(parsed.to, fromPiece.owner)
+        ) {
+            return { ok: false, next: state, error: "move does not enter promotion zone" };
+        }
     }
 
     let updatedHands = hands;

--- a/packages/app-core/src/game/board.ts
+++ b/packages/app-core/src/game/board.ts
@@ -74,6 +74,7 @@ function isInPromotionZone(square: Square, owner: Player): boolean {
     const rank = square[1] as Rank;
     return owner === "sente" ? SENTE_PROMOTION_RANKS.has(rank) : GOTE_PROMOTION_RANKS.has(rank);
 }
+
 const PROMOTED_FROM: Record<PieceType, PieceType> = {
     P: "P",
     L: "L",

--- a/packages/engine-wasm/src/index.test.ts
+++ b/packages/engine-wasm/src/index.test.ts
@@ -906,6 +906,76 @@ describe("createWasmEngineClient", () => {
             ack(workers[1], restoredNnue);
         });
 
+        it("待機中コマンドの ack エラーが panic を示す場合も worker を作り直す", async () => {
+            const { workers, workerFactory } = setupWorkers();
+            const client = createWasmEngineClient({ workerFactory });
+
+            const initPromise = client.init();
+            ack(workers[0], workers[0].postMessage.mock.calls[0][0]);
+            await initPromise;
+
+            const loadPromise = client.loadPosition("startpos", ["7c8c+"]);
+            await tick();
+            const loadCall = lastCallOfType(workers[0], "loadPosition");
+            workers[0].onmessage?.({
+                data: {
+                    type: "ack",
+                    requestId: loadCall.requestId,
+                    error: "RuntimeError: unreachable",
+                },
+            } as MessageEvent);
+
+            await expect(loadPromise).rejects.toThrow("unreachable");
+            await tick();
+
+            expect(workers[0].terminate).toHaveBeenCalled();
+            expect(workerFactory).toHaveBeenCalledTimes(2);
+
+            const reinitCall = lastCallOfType(workers[1], "init");
+            expect(reinitCall).toBeDefined();
+            ack(workers[1], reinitCall);
+            await tick();
+
+            const nextLoadPromise = client.loadPosition("startpos", ["7g7f"]);
+            await tick();
+            const nextLoadCall = lastCallOfType(workers[1], "loadPosition");
+            expect(nextLoadCall).toBeDefined();
+            ack(workers[1], nextLoadCall);
+            await nextLoadPromise;
+        });
+
+        it("panic 復旧の完了時に警告イベントで局面リセットを通知する", async () => {
+            const { workers, workerFactory } = setupWorkers();
+            const client = createWasmEngineClient({ workerFactory });
+
+            const initPromise = client.init();
+            ack(workers[0], workers[0].postMessage.mock.calls[0][0]);
+            await initPromise;
+
+            const events: unknown[] = [];
+            client.subscribe((event) => events.push(event));
+
+            workers[0].onmessage?.({
+                data: {
+                    type: "event",
+                    payload: { type: "error", message: "RuntimeError: unreachable" },
+                },
+            } as MessageEvent);
+            await tick();
+
+            const reinitCall = lastCallOfType(workers[1], "init");
+            ack(workers[1], reinitCall);
+            await tick();
+
+            expect(events).toContainEqual(
+                expect.objectContaining({
+                    type: "error",
+                    severity: "warning",
+                    code: "WASM_WORKER_FAILED",
+                }),
+            );
+        });
+
         it("通常のエラー (panic でない) では worker を作り直さない", async () => {
             const { workers, workerFactory } = setupWorkers();
             const client = createWasmEngineClient({ workerFactory });

--- a/packages/engine-wasm/src/index.test.ts
+++ b/packages/engine-wasm/src/index.test.ts
@@ -809,4 +809,121 @@ describe("createWasmEngineClient", () => {
             expect(workerFactory).toHaveBeenCalledTimes(1);
         });
     });
+
+    describe("panic 復旧", () => {
+        const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+        const ack = (worker: MockWorker, call: { requestId: string }) => {
+            worker.onmessage?.({
+                data: { type: "ack", requestId: call.requestId },
+            } as MessageEvent);
+        };
+
+        const lastCallOfType = (worker: MockWorker, type: string) => {
+            const calls = worker.postMessage.mock.calls;
+            for (let i = calls.length - 1; i >= 0; i -= 1) {
+                if (calls[i][0].type === type) return calls[i][0];
+            }
+            return undefined;
+        };
+
+        const setupWorkers = () => {
+            const workers: MockWorker[] = [];
+            const workerFactory = vi.fn((_kind: WorkerKind) => {
+                const worker = createMockWorker();
+                workers.push(worker);
+                return worker as unknown as Worker;
+            });
+            return { workers, workerFactory };
+        };
+
+        it("panic (unreachable) 検出時に worker を作り直して再初期化する", async () => {
+            const { workers, workerFactory } = setupWorkers();
+            const client = createWasmEngineClient({ workerFactory });
+
+            const initPromise = client.init();
+            ack(workers[0], workers[0].postMessage.mock.calls[0][0]);
+            await initPromise;
+
+            // Rust panic はエラーイベントとして届く
+            workers[0].onmessage?.({
+                data: {
+                    type: "events",
+                    payload: [{ type: "error", message: "RuntimeError: unreachable executed" }],
+                },
+            } as MessageEvent);
+            await tick();
+
+            expect(workers[0].terminate).toHaveBeenCalled();
+            expect(workerFactory).toHaveBeenCalledTimes(2);
+
+            const reinitCall = lastCallOfType(workers[1], "init");
+            expect(reinitCall).toBeDefined();
+            ack(workers[1], reinitCall);
+            await tick();
+
+            // 復旧後は新 worker で loadPosition が成功する
+            const loadPromise = client.loadPosition("startpos", ["7g7f"]);
+            await tick();
+            const loadCall = lastCallOfType(workers[1], "loadPosition");
+            expect(loadCall).toBeDefined();
+            ack(workers[1], loadCall);
+            await loadPromise;
+
+            expect(client.getBackendStatus?.()).toBe("ready");
+        });
+
+        it("panic 復旧時に読み込み済み NNUE を再ロードする", async () => {
+            const { workers, workerFactory } = setupWorkers();
+            const client = createWasmEngineClient({ workerFactory });
+
+            const initPromise = client.init();
+            ack(workers[0], workers[0].postMessage.mock.calls[0][0]);
+            await initPromise;
+
+            const nnuePromise = client.loadNnue?.("nnue-1");
+            await tick();
+            const nnueCall = lastCallOfType(workers[0], "loadNnue");
+            ack(workers[0], nnueCall);
+            await nnuePromise;
+
+            workers[0].onmessage?.({
+                data: {
+                    type: "event",
+                    payload: { type: "error", message: "RuntimeError: unreachable" },
+                },
+            } as MessageEvent);
+            await tick();
+
+            const reinitCall = lastCallOfType(workers[1], "init");
+            ack(workers[1], reinitCall);
+            await tick();
+
+            // 再初期化パスで NNUE が再ロードされる
+            const restoredNnue = lastCallOfType(workers[1], "loadNnue");
+            expect(restoredNnue).toBeDefined();
+            expect(restoredNnue.source).toEqual({ type: "idb", id: "nnue-1" });
+            ack(workers[1], restoredNnue);
+        });
+
+        it("通常のエラー (panic でない) では worker を作り直さない", async () => {
+            const { workers, workerFactory } = setupWorkers();
+            const client = createWasmEngineClient({ workerFactory });
+
+            const initPromise = client.init();
+            ack(workers[0], workers[0].postMessage.mock.calls[0][0]);
+            await initPromise;
+
+            workers[0].onmessage?.({
+                data: {
+                    type: "event",
+                    payload: { type: "error", message: "no legal moves" },
+                },
+            } as MessageEvent);
+            await tick();
+
+            expect(workers[0].terminate).not.toHaveBeenCalled();
+            expect(workerFactory).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/packages/engine-wasm/src/index.ts
+++ b/packages/engine-wasm/src/index.ts
@@ -102,6 +102,17 @@ function classifyErrorCode(error: unknown): EngineErrorCode {
 }
 
 /**
+ * Rust の panic は wasm では `unreachable` トラップになり、以降その wasm
+ * インスタンスは全操作が失敗する不可逆状態になる。JS 側にはメッセージ経由で
+ * `RuntimeError: unreachable` として届くため、これを検知して worker ごと
+ * 作り直す判定に使う。
+ */
+function isWasmPanic(message: string): boolean {
+    const lower = message.toLowerCase();
+    return lower.includes("unreachable") || lower.includes("runtimeerror");
+}
+
+/**
  * NNUE ロード元の種別
  */
 type NnueLoadSource =
@@ -284,6 +295,8 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
         moves: string[];
         passRights?: { sente: number; gote: number };
     } | null = null;
+    // panic 後の worker 再生成時に NNUE を再ロードするため、最後に読んだ源を保持する。
+    let lastNnueSource: NnueLoadSource | null = null;
     let threadedDisabled = false;
     let activeThreads: number | null = null;
 
@@ -311,6 +324,9 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
             handler(event);
         }
     };
+
+    const isPanicEvent = (event: EngineEvent): boolean =>
+        event.type === "error" && event.severity !== "warning" && isWasmPanic(event.message);
 
     const emitWarn = (code: EngineErrorCode, message: string) => {
         if (warnedReasons.has(code)) return;
@@ -546,10 +562,13 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
                 return;
             }
             if (data?.type === "event" && data.payload) {
+                // 再初期化を先に走らせ、後続ジョブの loadPosition が新 worker を待てるようにする。
+                if (isPanicEvent(data.payload)) recoverFromPanic();
                 emit(data.payload);
                 return;
             }
             if (data?.type === "events" && Array.isArray(data.payload)) {
+                if (data.payload.some(isPanicEvent)) recoverFromPanic();
                 for (const event of data.payload) {
                     emit(event);
                 }
@@ -615,6 +634,11 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
         });
     };
 
+    const restoreNnue = async () => {
+        if (!worker || !lastNnueSource) return;
+        await postToWorkerAwait({ type: "loadNnue", source: lastNnueSource });
+    };
+
     const initWorkerWithKind = async (
         kind: WorkerKind,
         opts: WasmEngineInitOptions,
@@ -628,6 +652,7 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
         await postToWorkerAwait({ type: "init", opts, wasmModule });
         initialized = true;
         await applyPendingOptions();
+        await restoreNnue();
         await restoreLastPosition();
         activeThreads = opts.threads ?? 1;
     };
@@ -719,6 +744,28 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
             const code = classifyErrorCode(error);
             enterErrorState("Wasm engine initialization failed", code);
         });
+    };
+
+    let recoveringFromPanic = false;
+
+    // panic 後の wasm インスタンスは復旧不能なので worker ごと作り直す。
+    // lastPosition は panic を招いた手を含む可能性があるため復元せず捨てる
+    // （再ロードすると再び panic して復旧が空回りする）。
+    const recoverFromPanic = () => {
+        if (backend === "mock" || backend === "error") return;
+        if (recoveringFromPanic) return;
+        recoveringFromPanic = true;
+        lastPosition = null;
+        replaceWorker("engine worker recovered after panic");
+        initInFlight = null;
+        void ensureReady()
+            .catch((error) => {
+                const code = classifyErrorCode(error);
+                enterErrorState("Wasm engine recovery after panic failed", code);
+            })
+            .finally(() => {
+                recoveringFromPanic = false;
+            });
     };
 
     return {
@@ -906,6 +953,7 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
             listeners.clear();
             nnueLoadListeners.clear();
             lastPosition = null;
+            lastNnueSource = null;
             lastInitOpts = undefined;
             pendingOptions.clear();
             warnedReasons.clear();
@@ -990,10 +1038,9 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
                 // モックフォールバック時は no-op
                 return;
             }
-            await postToWorkerAwait({
-                type: "loadNnue",
-                source: { type: "idb", id: nnueId },
-            });
+            const source: NnueLoadSource = { type: "idb", id: nnueId };
+            await postToWorkerAwait({ type: "loadNnue", source });
+            lastNnueSource = source;
         },
     };
 }

--- a/packages/engine-wasm/src/index.ts
+++ b/packages/engine-wasm/src/index.ts
@@ -105,11 +105,12 @@ function classifyErrorCode(error: unknown): EngineErrorCode {
  * Rust の panic は wasm では `unreachable` トラップになり、以降その wasm
  * インスタンスは全操作が失敗する不可逆状態になる。JS 側にはメッセージ経由で
  * `RuntimeError: unreachable` として届くため、これを検知して worker ごと
- * 作り直す判定に使う。
+ * 作り直す判定に使う。単語単体では「到達不能」を語るカスタムメッセージや
+ * wasm 無関係の RuntimeError と衝突するため、両方を含む場合のみ panic 扱い。
  */
 function isWasmPanic(message: string): boolean {
     const lower = message.toLowerCase();
-    return lower.includes("unreachable") || lower.includes("runtimeerror");
+    return lower.includes("runtimeerror") && lower.includes("unreachable");
 }
 
 /**
@@ -555,6 +556,10 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
                 if (!pending) return;
                 pendingAcks.delete(data.requestId);
                 if (data.error) {
+                    // 待機中コマンド内で panic した場合は ack(error) が error イベント
+                    // より先に届く。reject を受けた呼び出し側 (batch 解析等) が次の
+                    // ジョブを壊れた worker へ投げる前に再生成を始めておく。
+                    if (isWasmPanic(data.error)) recoverFromPanic();
                     pending.reject(new Error(data.error));
                 } else {
                     pending.resolve();
@@ -756,9 +761,21 @@ export function createWasmEngineClient(options: WasmEngineClientOptions = {}): W
         if (recoveringFromPanic) return;
         recoveringFromPanic = true;
         lastPosition = null;
-        replaceWorker("engine worker recovered after panic");
+        // 進行中の init を先に破棄してから worker を落とす。逆順だと replaceWorker
+        // の rejectAllPending で失敗した init が initInFlight に残ったまま
+        // ensureReady に await され得る。
         initInFlight = null;
+        replaceWorker("engine worker recovered after panic");
         void ensureReady()
+            .then(() => {
+                emit({
+                    type: "error",
+                    severity: "warning",
+                    code: "WASM_WORKER_FAILED",
+                    message:
+                        "エンジンを再起動しました。局面はリセットされたため、再度局面を読み込んでください。",
+                });
+            })
             .catch((error) => {
                 const code = classifyErrorCode(error);
                 enterErrorState("Wasm engine recovery after panic failed", code);

--- a/packages/ui/src/components/shogi-match/utils/kifParser.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifParser.test.ts
@@ -56,4 +56,53 @@ describe("parseKif", () => {
         expect(result.success).toBe(true);
         expect(result.startSfen).toBeUndefined();
     });
+
+    describe("成り判定", () => {
+        it("成りの指し手に + を付ける", () => {
+            const result = parseKif("1 ２二角成(88)");
+            expect(result.moves).toEqual(["8h2b+"]);
+        });
+
+        it("不成の指し手に + を付けない", () => {
+            const result = parseKif("1 ２三銀不成(34)");
+            expect(result.moves).toEqual(["3d2c"]);
+        });
+
+        it("成り駒（成銀など）の移動に + を付けない", () => {
+            const result = parseKif("1 ２三成銀(34)");
+            expect(result.moves).toEqual(["3d2c"]);
+        });
+
+        it("「同」表記の成りに + を付ける", () => {
+            const kif = ["1 ２二角成(88)", "2 同　飛成(24)"].join("\n");
+            const result = parseKif(kif);
+            expect(result.moves).toEqual(["8h2b+", "2d2b+"]);
+        });
+
+        it("相対表記を含む成りに + を付ける", () => {
+            const result = parseKif("1 ３三銀上成(24)");
+            expect(result.moves).toEqual(["2d3c+"]);
+        });
+
+        it("相対表記を含む不成に + を付けない", () => {
+            const result = parseKif("1 ２三銀右不成(34)");
+            expect(result.moves).toEqual(["3d2c"]);
+        });
+
+        it("相対表記のみ（成りなし）に + を付けない", () => {
+            const result = parseKif("1 ５八金右(49)");
+            expect(result.moves).toEqual(["4i5h"]);
+        });
+
+        it("成り駒の相対表記付き移動に + を付けない", () => {
+            const result = parseKif("1 ５五馬右(66)");
+            expect(result.moves).toEqual(["6f5e"]);
+        });
+
+        it("「同」表記の不成に + を付けない", () => {
+            const kif = ["1 ２三銀成(34)", "2 同　銀不成(12)"].join("\n");
+            const result = parseKif(kif);
+            expect(result.moves).toEqual(["3d2c+", "1b2c"]);
+        });
+    });
 });

--- a/packages/ui/src/components/shogi-match/utils/kifParser.ts
+++ b/packages/ui/src/components/shogi-match/utils/kifParser.ts
@@ -238,6 +238,18 @@ function parseStartSfenLine(line: string): string | null {
 }
 
 /**
+ * 指し手文字列が「成り」を表すか判定する
+ *
+ * 「成香」「成銀」等の成り駒名は駒名の先頭に「成」が付き、成りの指し手は
+ * 駒名の直後（移動元座標の直前）に「成」が付くため、移動元座標を除いた
+ * 末尾で判定する。「不成」も末尾が「成」になるので明示的に除外する。
+ */
+function detectsPromotion(moveStr: string): boolean {
+    const core = moveStr.replace(/\(\d{2}\)$/, "");
+    return core.endsWith("成") && !core.endsWith("不成");
+}
+
+/**
  * 1行のKIF指し手をパースしてUSI形式に変換
  *
  * 対応フォーマット:
@@ -248,6 +260,7 @@ function parseStartSfenLine(line: string): string | null {
  * - "同　歩(66)" - 「同」表記
  * - "５五角打" - 駒打ち
  * - "２二角成(88)" - 成り
+ * - "２三銀不成(34)" - 不成
  * - "   1 ７六歩(77)   ( 0:05/00:00:05)" - 消費時間付き
  *
  * @param line KIF形式の1行
@@ -329,14 +342,10 @@ function parseKifLine(line: string, prevTo: string | null): ParsedMoveLine | nul
     // 「同」表記のパース: "同　歩(66)" or "同歩(66)"
     // 駒名部分は検証不要（後続の PIECE_NAME_TO_USI で検証）、移動元座標のみ抽出
     // ============================================================
-    const sameMatch = moveStr.match(/^同[　\s]*(?:.+?)(?:成)?(?:\((\d{2})\))?$/);
+    const sameMatch = moveStr.match(/^同[　\s]*(?:.+?)(?:不成|成)?(?:\((\d{2})\))?$/);
     if (sameMatch && prevTo) {
         const [, fromDigits] = sameMatch;
-        const promotes =
-            moveStr.includes("成") &&
-            !moveStr.includes("成香") &&
-            !moveStr.includes("成桂") &&
-            !moveStr.includes("成銀");
+        const promotes = detectsPromotion(moveStr);
 
         if (!fromDigits) {
             // 移動元がない場合はパースできない
@@ -354,15 +363,11 @@ function parseKifLine(line: string, prevTo: string | null): ParsedMoveLine | nul
     // 通常移動のパース: "７六歩(77)" or "２二角成(88)"
     // ============================================================
     const normalMatch = moveStr.match(
-        /^([１２３４５６７８９1-9])([一二三四五六七八九])(.+?)(?:成)?(?:\((\d{2})\))?$/,
+        /^([１２３４５６７８９1-9])([一二三四五六七八九])(.+?)(?:不成|成)?(?:\((\d{2})\))?$/,
     );
     if (normalMatch) {
         const [, fileChar, rankChar, , fromDigits] = normalMatch;
-        const promotes =
-            moveStr.includes("成") &&
-            !moveStr.includes("成香") &&
-            !moveStr.includes("成桂") &&
-            !moveStr.includes("成銀");
+        const promotes = detectsPromotion(moveStr);
 
         const to = kanjiToUsi(fileChar, rankChar);
         if (!to) return null;


### PR DESCRIPTION
## 概要

一括解析実行時に WASM エンジン (rshogi-core do_move) が `Option::unwrap() on None` で panic し、特定 ply 以降の解析が全滅する問題の修正です。

## 原因

KIF パーサの成り判定が `moveStr.includes("成")` ベースの文字列判定で、**「不成」を成りとして誤変換**していました。例えば `２三銀不成(34)` が `3d2c+`(成) に変換され、以降の盤面が実際の棋譜とズレた結果、「成れない駒への成り」がエンジンに渡って panic していました。TS 層 (`board.ts`) も promote フラグを無検証で受け入れるため、インポート時の replay 検証をすり抜けていました。

## 変更内容

### 1. KIF パーサ修正 (packages/ui)
- 成り判定を `detectsPromotion()` に集約: 移動元座標 `(\d{2})` を除いた**末尾**が「成」で終わり、かつ「不成」で終わらない場合のみ `+` を付与
- 成駒名 (成香/成桂/成銀) の除外リストは末尾判定で不要になったため削除
- 相対表記 (右/左/上等) との組み合わせを含む回帰テスト 9 件追加

### 2. 堅牢化 (packages/app-core, packages/engine-wasm)
- **board.ts**: `applyMoveWithState` で promote フラグ付きの手を検証 (成れない駒種・既成駒・成りゾーン外を reject)。不正手をインポート時に検出可能に
- **engine-wasm**: Rust panic (`RuntimeError: unreachable`) を検知して worker を再生成・再初期化 (NNUE 再ロード含む)。panic 後に後続ジョブが全滅しなくなる

## レビュー

kifParser 修正は local の Codex + Claude の 2 レビュアーによる独立レビュー済み (両者とも実行ベースで正規表現・判定ロジックを検証、指摘のテスト不足は反映済み)。

## テスト

- app-core: 137 passed (promote 検証 6 件含む)
- engine-wasm: 192 passed (panic 復旧 3 件含む)
- ui: 409 passed (kifParser 16 件含む)
- typecheck / biome check 通過

## 注意

既にインポート済みの棋譜には誤変換された usiMove が保存されている可能性があるため、該当棋譜は再インポートが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REPXSpbPggdX2LXfFUPS99