### PR TITLE
chore(rust-core): crossbeam-epoch 0.9.20 へ更新 (RUSTSEC-2026-0204)

### DIFF
--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -51,9 +51,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -537,3 +537,7 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[patch.unused]]
+name = "rshogi-core"
+version = "0.4.0"


### PR DESCRIPTION
## 概要

2026-07-06 公開の RUSTSEC-2026-0204 (crossbeam-epoch 0.9.18 の `fmt::Pointer` 実装における invalid pointer dereference) により CI の Security Audit が失敗するようになったため、`cargo update -p crossbeam-epoch` で 0.9.20 へ更新します。

`packages/rust-core/Cargo.lock` のみの変更で、他の依存に変化はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AUJFVLw41rkpCUwXE3RMyr