### PR TITLE
feat(web,ui): トップ文言を NNUE 訴求の事実型に刷新し、ナビを左ドロワーへ統一

### DIFF
--- a/apps/web/src/components/HeaderNav.tsx
+++ b/apps/web/src/components/HeaderNav.tsx
@@ -1,179 +1,19 @@
-import { cn } from "@shogi/design-system";
-import { Popover, PopoverContent, PopoverTrigger } from "@shogi/ui/components/popover";
-import { Link, useLocation } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import type { ReactElement } from "react";
-import { useState } from "react";
 import { useAuthSession } from "../hooks/useAuthSession";
-
-// リンクの見た目は「現在ページかどうか」で表示/非表示を切り替えず、常に全導線を
-// 出したまま aria-current + 配色で現在地を示す。項目数が遷移で増減しないため
-// ヘッダーのレイアウトシフトが起きない。geometry (border/padding) は variant/active
-// 間で共通にし、色だけを変えて幅の揺れも防ぐ。
-const variantClass = {
-    // 主導線 (対局・オンライン): 朱アクセントで優先度を示す
-    primary: "border-wafuu-shu/40 text-wafuu-shu hover:bg-wafuu-shu/10",
-    // 副導線 (棋譜・NNUE・観戦系・ログイン): 落ち着いた muted 系
-    default: "border-border text-muted-foreground hover:bg-muted/50 hover:text-foreground",
-} as const;
-// 現在ページ: variant に関わらず塗りアクセントで現在地を強調
-const activeClass = "border-wafuu-shu bg-wafuu-shu/10 text-wafuu-shu";
-// PC ヘッダーの横並びピル / モバイルドロワーの縦積み行。geometry のみ差し替え、
-// 配色 (variantClass/activeClass) は共通で再利用する。
-const pillClass = "rounded-md border px-2.5 py-0.5 text-xs font-medium whitespace-nowrap";
-const rowClass = "block w-full rounded-md border px-3 py-1.5 text-sm font-medium";
-
-type NavVariant = keyof typeof variantClass;
-
-// Link の `to` は登録ルートで型付けされる。ヘッダーで使う遷移先はいずれも
-// params/search を要求しない静的パスなので、その literal union に限定する。
-type NavTo =
-    | "/"
-    | "/play"
-    | "/online"
-    | "/games"
-    | "/nnue"
-    | "/rshogi-viewer/live"
-    | "/rshogi-viewer"
-    | "/public/games"
-    | "/auth";
-
-interface NavItem {
-    to: NavTo;
-    label: string;
-    active: boolean;
-    variant?: NavVariant;
-}
-
-function NavLink({
-    item,
-    layout,
-    onNavigate,
-}: {
-    item: NavItem;
-    layout: "pill" | "row";
-    onNavigate?: () => void;
-}): ReactElement {
-    const geometry = layout === "pill" ? pillClass : rowClass;
-    return (
-        <Link
-            to={item.to}
-            aria-current={item.active ? "page" : undefined}
-            onClick={onNavigate}
-            className={cn(
-                geometry,
-                "transition-colors",
-                item.active ? activeClass : variantClass[item.variant ?? "default"],
-            )}
-        >
-            {item.label}
-        </Link>
-    );
-}
 
 export function HeaderNav(): ReactElement {
     const { session } = useAuthSession();
-    const { pathname } = useLocation();
-    const [menuOpen, setMenuOpen] = useState(false);
-
-    // 現在地判定。CSA 観戦系は live 一覧/観戦 と単局ビューアが prefix を共有する。
-    // 単局ビューアの動的 param (/rshogi-viewer/$gameId) が "live..." で始まる gameId を
-    // ライブと誤判定しないよう、live はセグメント境界で判定する (一覧 `/live` と観戦
-    // `/live/<id>` のみ)。ビューアは残りの /rshogi-viewer 配下 (一覧・単局)。
-    const isLive =
-        pathname === "/rshogi-viewer/live" || pathname.startsWith("/rshogi-viewer/live/");
-
-    const appItems: NavItem[] = [
-        { to: "/play", label: "対局", active: pathname.startsWith("/play"), variant: "primary" },
-        {
-            to: "/online",
-            label: "オンライン",
-            active: pathname.startsWith("/online"),
-            variant: "primary",
-        },
-        { to: "/games", label: "棋譜", active: pathname.startsWith("/games") },
-        { to: "/nnue", label: "NNUE", active: pathname === "/nnue" },
-    ];
-    const csaItems: NavItem[] = [
-        { to: "/rshogi-viewer/live", label: "ライブ", active: isLive },
-        {
-            to: "/rshogi-viewer",
-            label: "棋譜ビューア",
-            active: pathname.startsWith("/rshogi-viewer") && !isLive,
-        },
-        { to: "/public/games", label: "公開棋譜", active: pathname.startsWith("/public/games") },
-    ];
-    const authItem: NavItem = {
-        to: "/auth",
-        label: session?.authenticated ? session.user.displayName : "ログイン",
-        active: pathname === "/auth",
-    };
+    const authLabel = session?.authenticated ? session.user.displayName : "ログイン";
 
     return (
-        <>
-            {/* PC: 全導線を横並びピルで常時表示。狭幅では溢れるので min-[880px] 以上のみ。 */}
-            <nav
-                aria-label="サイト内ナビゲーション"
-                className="hidden items-center gap-1.5 min-[880px]:flex"
+        <nav aria-label="ヘッダーアクション" className="flex items-center gap-2">
+            <Link
+                to="/auth"
+                className="inline-flex h-8 min-w-0 max-w-32 items-center truncate rounded-md px-2 text-sm text-wafuu-sumi-light transition-colors hover:bg-muted/50 hover:text-wafuu-sumi"
             >
-                {appItems.map((item) => (
-                    <NavLink key={item.to} item={item} layout="pill" />
-                ))}
-                <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />
-                {/* CSA サーバー連携 (観戦・棋譜) */}
-                <span className="select-none text-[10px] text-muted-foreground">観戦</span>
-                {csaItems.map((item) => (
-                    <NavLink key={item.to} item={item} layout="pill" />
-                ))}
-                <span aria-hidden className="mx-0.5 h-4 w-px shrink-0 bg-wafuu-border" />
-                <NavLink item={authItem} layout="pill" />
-            </nav>
-
-            {/* モバイル: 全導線をドロワーに畳む。トリガーは固定幅なのでヘッダーが
-                溢れず、ページ全体の横スクロールも起きない。 */}
-            <div className="min-[880px]:hidden">
-                <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-                    <PopoverTrigger asChild>
-                        <button
-                            type="button"
-                            aria-label="メニュー"
-                            aria-expanded={menuOpen}
-                            className="flex h-8 w-8 items-center justify-center rounded-md border border-border text-base leading-none text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
-                        >
-                            <span aria-hidden>☰</span>
-                        </button>
-                    </PopoverTrigger>
-                    <PopoverContent align="end" className="w-56 p-2">
-                        <nav aria-label="サイト内ナビゲーション" className="flex flex-col gap-1">
-                            {appItems.map((item) => (
-                                <NavLink
-                                    key={item.to}
-                                    item={item}
-                                    layout="row"
-                                    onNavigate={() => setMenuOpen(false)}
-                                />
-                            ))}
-                            <div className="my-1 flex items-center gap-2 px-1">
-                                <span className="text-[10px] text-muted-foreground">観戦</span>
-                                <span className="h-px flex-1 bg-wafuu-border" />
-                            </div>
-                            {csaItems.map((item) => (
-                                <NavLink
-                                    key={item.to}
-                                    item={item}
-                                    layout="row"
-                                    onNavigate={() => setMenuOpen(false)}
-                                />
-                            ))}
-                            <span aria-hidden className="my-1 h-px bg-wafuu-border" />
-                            <NavLink
-                                item={authItem}
-                                layout="row"
-                                onNavigate={() => setMenuOpen(false)}
-                            />
-                        </nav>
-                    </PopoverContent>
-                </Popover>
-            </div>
-        </>
+                {authLabel}
+            </Link>
+        </nav>
     );
 }

--- a/apps/web/src/components/HeroBoard.tsx
+++ b/apps/web/src/components/HeroBoard.tsx
@@ -1,81 +1,25 @@
+import { createInitialPositionState } from "@shogi/app-core";
 import { cn } from "@shogi/design-system";
+import { boardToGrid, ShogiBoard } from "@shogi/ui";
 import type { ReactElement } from "react";
 
-// トップの装飾用に描く静的な初期局面盤。対局で使う ShogiBoard(状態・DnD・engine
-// 依存) は持ち込まず、design-system の shogi-* / wafuu-* トークンだけで組む軽量版。
-// 「盤を全ティア共通のアンカーにする」方針に沿い、実盤と同じ配色トークンを使う。
-// 先手=朱・後手=藍の意味色を駒に薄く乗せ、後手は 180 度回転する。
+// トップの装飾用に、対局で使う実盤 ShogiBoard を平手初期局面で静的描画する。
+// コールバックを渡さなければ純表示になる。装飾なので inert + aria-hidden で
+// 81 マスのボタンをフォーカス・支援技術の対象から外す。
 
-type Side = "sente" | "gote";
-interface Cell {
-    piece: string;
-    side: Side;
-}
-type Row = (Cell | null)[];
-
-const S = (piece: string): Cell => ({ piece, side: "sente" });
-const G = (piece: string): Cell => ({ piece, side: "gote" });
-
-// 平手初期配置（意匠用。段=上から後手→先手）
-const START: Row[] = [
-    [G("香"), G("桂"), G("銀"), G("金"), G("玉"), G("金"), G("銀"), G("桂"), G("香")],
-    [null, G("飛"), null, null, null, null, null, G("角"), null],
-    [G("歩"), G("歩"), G("歩"), G("歩"), G("歩"), G("歩"), G("歩"), G("歩"), G("歩")],
-    [null, null, null, null, null, null, null, null, null],
-    [null, null, null, null, null, null, null, null, null],
-    [null, null, null, null, null, null, null, null, null],
-    [S("歩"), S("歩"), S("歩"), S("歩"), S("歩"), S("歩"), S("歩"), S("歩"), S("歩")],
-    [null, S("角"), null, null, null, null, null, S("飛"), null],
-    [S("香"), S("桂"), S("銀"), S("金"), S("王"), S("金"), S("銀"), S("桂"), S("香")],
-];
-
-interface Square {
-    id: string;
-    cell: Cell | null;
-    light: boolean;
-}
-
-// 盤面を平坦化し、筋-段の一意 id(例 "7-1" = 7筋1段目)を持たせておく。render 側は
-// 配列 index を key に使わず、この id を key にする（局面は静的なので id は不変）。
-const SQUARES: Square[] = START.flatMap((row, r) =>
-    row.map((cell, c) => ({
-        id: `${9 - c}-${r + 1}`,
-        cell,
-        light: (r + c) % 2 === 0,
-    })),
-);
+const GRID = boardToGrid(createInitialPositionState().board);
 
 export function HeroBoard({ className }: { className?: string }): ReactElement {
     return (
         <div
+            inert
             aria-hidden
             className={cn(
-                "grid aspect-square w-full grid-cols-9 gap-px rounded-sm border-2 border-shogi-outer-border bg-shogi-border p-px shadow-card",
+                "flex select-none justify-center [--shogi-cell-size:clamp(30px,4vw,40px)]",
                 className,
             )}
         >
-            {SQUARES.map(({ id, cell, light }) => (
-                <div
-                    key={id}
-                    className={cn(
-                        "flex items-center justify-center",
-                        light ? "bg-shogi-cell-light" : "bg-shogi-cell-dark",
-                    )}
-                >
-                    {cell && (
-                        <span
-                            className={cn(
-                                "flex aspect-[6/7] w-[82%] items-center justify-center rounded-[2px] bg-shogi-piece-bg font-display text-[clamp(9px,2.1vw,15px)] leading-none shadow-sm",
-                                cell.side === "sente"
-                                    ? "border-b-2 border-wafuu-shu/40 text-wafuu-shu"
-                                    : "rotate-180 border-b-2 border-wafuu-ai/40 text-wafuu-ai",
-                            )}
-                        >
-                            {cell.piece}
-                        </span>
-                    )}
-                </div>
-            ))}
+            <ShogiBoard grid={GRID} />
         </div>
     );
 }

--- a/apps/web/src/components/NavDrawer.test.tsx
+++ b/apps/web/src/components/NavDrawer.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+let mockPathname = "/";
+
+vi.mock("@tanstack/react-router", () => ({
+    Link: ({
+        to,
+        children,
+        onClick,
+        className,
+        "aria-current": ariaCurrent,
+    }: {
+        to: string;
+        children: ReactNode;
+        onClick?: () => void;
+        className?: string;
+        "aria-current"?: "page";
+    }) => (
+        <a href={to} onClick={onClick} className={className} aria-current={ariaCurrent}>
+            {children}
+        </a>
+    ),
+    useLocation: () => ({ pathname: mockPathname }),
+}));
+
+vi.mock("../hooks/useAuthSession", () => ({
+    useAuthSession: () => ({
+        session: { authenticated: false, user: null },
+        sessionError: null,
+        isLoadingSession: false,
+        refreshSession: vi.fn(),
+    }),
+}));
+
+const { NavDrawer, buildNavSections } = await import("./NavDrawer");
+
+describe("NavDrawer", () => {
+    beforeEach(() => {
+        mockPathname = "/";
+    });
+
+    it("セクション構造でナビゲーションを表示する", () => {
+        render(<NavDrawer />);
+        fireEvent.click(screen.getByRole("button", { name: "メニュー" }));
+
+        for (const heading of ["指す", "棋譜", "観戦", "管理"]) {
+            expect(screen.getByRole("heading", { name: heading })).toBeTruthy();
+        }
+        for (const link of [
+            "対局",
+            "オンライン対局",
+            "マイ棋譜",
+            "公開棋譜",
+            "ライブ観戦",
+            "CSA 棋譜ビューア",
+            "NNUE モデル",
+            "ログイン",
+        ]) {
+            expect(screen.getByRole("link", { name: link })).toBeTruthy();
+        }
+    });
+
+    it("現在地を aria-current で示し、live はセグメント境界で判定する", () => {
+        const liveSections = buildNavSections("/rshogi-viewer/live/test");
+        const liveItem = liveSections
+            .flatMap((section) => section.items)
+            .find((item) => {
+                return item.to === "/rshogi-viewer/live";
+            });
+        expect(liveItem?.active).toBe(true);
+
+        mockPathname = "/rshogi-viewer/live-game-id";
+        render(<NavDrawer />);
+        fireEvent.click(screen.getByRole("button", { name: "メニュー" }));
+
+        expect(
+            screen.getByRole("link", { name: "CSA 棋譜ビューア" }).getAttribute("aria-current"),
+        ).toBe("page");
+        expect(screen.getByRole("link", { name: "ライブ観戦" }).getAttribute("aria-current")).toBe(
+            null,
+        );
+    });
+
+    it("リンククリックでドロワーを閉じる", async () => {
+        render(<NavDrawer />);
+        const trigger = screen.getByRole("button", { name: "メニュー" });
+
+        fireEvent.click(trigger);
+        expect(trigger.getAttribute("aria-expanded")).toBe("true");
+
+        fireEvent.click(screen.getByRole("link", { name: "対局" }));
+
+        await waitFor(() => {
+            expect(trigger.getAttribute("aria-expanded")).toBe("false");
+        });
+    });
+});

--- a/apps/web/src/components/NavDrawer.tsx
+++ b/apps/web/src/components/NavDrawer.tsx
@@ -1,0 +1,153 @@
+import { cn } from "@shogi/design-system";
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@shogi/ui";
+import { Link, useLocation } from "@tanstack/react-router";
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { useAuthSession } from "../hooks/useAuthSession";
+
+type NavTo =
+    | "/play"
+    | "/online"
+    | "/games"
+    | "/public/games"
+    | "/rshogi-viewer/live"
+    | "/rshogi-viewer"
+    | "/nnue"
+    | "/auth";
+
+interface NavItem {
+    to: NavTo;
+    label: string;
+    active: boolean;
+}
+
+interface NavSection {
+    label: string;
+    items: NavItem[];
+}
+
+const activeClass = "border-wafuu-shu bg-wafuu-shu/10 text-wafuu-shu";
+const inactiveClass = "border-transparent text-wafuu-sumi hover:bg-muted/50 hover:text-foreground";
+
+function isLiveViewerPath(pathname: string): boolean {
+    return pathname === "/rshogi-viewer/live" || pathname.startsWith("/rshogi-viewer/live/");
+}
+
+function buildNavSections(pathname: string): NavSection[] {
+    const isLive = isLiveViewerPath(pathname);
+
+    return [
+        {
+            label: "指す",
+            items: [
+                { to: "/play", label: "対局", active: pathname.startsWith("/play") },
+                {
+                    to: "/online",
+                    label: "オンライン対局",
+                    active: pathname.startsWith("/online"),
+                },
+            ],
+        },
+        {
+            label: "棋譜",
+            items: [
+                { to: "/games", label: "マイ棋譜", active: pathname.startsWith("/games") },
+                {
+                    to: "/public/games",
+                    label: "公開棋譜",
+                    active: pathname.startsWith("/public/games"),
+                },
+            ],
+        },
+        {
+            label: "観戦",
+            items: [
+                { to: "/rshogi-viewer/live", label: "ライブ観戦", active: isLive },
+                {
+                    to: "/rshogi-viewer",
+                    label: "CSA 棋譜ビューア",
+                    active: pathname.startsWith("/rshogi-viewer") && !isLive,
+                },
+            ],
+        },
+        {
+            label: "管理",
+            items: [{ to: "/nnue", label: "NNUE モデル", active: pathname === "/nnue" }],
+        },
+    ];
+}
+
+function DrawerLink({ item, onNavigate }: { item: NavItem; onNavigate: () => void }): ReactElement {
+    return (
+        <Link
+            to={item.to}
+            aria-current={item.active ? "page" : undefined}
+            onClick={onNavigate}
+            className={cn(
+                "block rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                item.active ? activeClass : inactiveClass,
+            )}
+        >
+            {item.label}
+        </Link>
+    );
+}
+
+export function NavDrawer(): ReactElement {
+    const { session } = useAuthSession();
+    const { pathname } = useLocation();
+    const [open, setOpen] = useState(false);
+    const sections = buildNavSections(pathname);
+    const authItem: NavItem = {
+        to: "/auth",
+        label: session?.authenticated ? session.user.displayName : "ログイン",
+        active: pathname === "/auth",
+    };
+
+    return (
+        <Sheet open={open} onOpenChange={setOpen}>
+            <SheetTrigger asChild>
+                <button
+                    type="button"
+                    aria-label="メニュー"
+                    aria-expanded={open}
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border text-wafuu-sumi transition-colors hover:bg-muted/50 hover:text-foreground"
+                >
+                    <span className="flex flex-col gap-1" aria-hidden>
+                        <span className="h-0.5 w-4 rounded-full bg-current" />
+                        <span className="h-0.5 w-4 rounded-full bg-current" />
+                        <span className="h-0.5 w-4 rounded-full bg-current" />
+                    </span>
+                </button>
+            </SheetTrigger>
+            <SheetContent side="left" className="flex w-72 max-w-[calc(100vw-32px)] flex-col p-4">
+                <SheetTitle className="sr-only">メニュー</SheetTitle>
+                <nav aria-label="サイト内ナビゲーション" className="flex flex-1 flex-col gap-5">
+                    <div className="flex flex-col gap-4">
+                        {sections.map((section) => (
+                            <section key={section.label} className="flex flex-col gap-1.5">
+                                <h2 className="px-3 text-xs font-medium text-muted-foreground">
+                                    {section.label}
+                                </h2>
+                                <div className="flex flex-col gap-1">
+                                    {section.items.map((item) => (
+                                        <DrawerLink
+                                            key={item.to}
+                                            item={item}
+                                            onNavigate={() => setOpen(false)}
+                                        />
+                                    ))}
+                                </div>
+                            </section>
+                        ))}
+                    </div>
+                    <div className="mt-auto border-t border-border pt-4">
+                        <DrawerLink item={authItem} onNavigate={() => setOpen(false)} />
+                    </div>
+                </nav>
+            </SheetContent>
+        </Sheet>
+    );
+}
+
+export { buildNavSections };

--- a/apps/web/src/components/PageHeader.tsx
+++ b/apps/web/src/components/PageHeader.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import type { ReactElement, ReactNode } from "react";
+import { NavDrawer } from "./NavDrawer";
 
 interface BreadcrumbItem {
     label: string;
@@ -15,25 +16,32 @@ export function PageHeader({ items, right }: PageHeaderProps): ReactElement {
     return (
         <header className="border-b border-wafuu-border bg-wafuu-washi-warm px-4">
             <div className="flex h-10 items-center justify-between text-sm">
-                <nav aria-label="パンくずリスト" className="flex items-center gap-1">
-                    {items.map((item, i) => (
-                        <span key={item.label} className="flex items-center gap-1">
-                            {i > 0 && (
-                                <span className="mx-0.5 select-none text-wafuu-border">›</span>
-                            )}
-                            {item.to ? (
-                                <Link
-                                    to={item.to}
-                                    className="text-wafuu-sumi-light transition-colors hover:text-wafuu-sumi"
-                                >
-                                    {item.label}
-                                </Link>
-                            ) : (
-                                <span className="font-medium text-wafuu-sumi">{item.label}</span>
-                            )}
-                        </span>
-                    ))}
-                </nav>
+                <div className="flex min-w-0 items-center gap-2">
+                    <NavDrawer />
+                    <nav aria-label="パンくずリスト" className="flex min-w-0 items-center gap-1">
+                        {items.map((item, i) => (
+                            <span key={item.label} className="flex min-w-0 items-center gap-1">
+                                {i > 0 && (
+                                    <span className="mx-0.5 shrink-0 select-none text-wafuu-border">
+                                        ›
+                                    </span>
+                                )}
+                                {item.to ? (
+                                    <Link
+                                        to={item.to}
+                                        className="truncate text-wafuu-sumi-light transition-colors hover:text-wafuu-sumi"
+                                    >
+                                        {item.label}
+                                    </Link>
+                                ) : (
+                                    <span className="truncate font-medium text-wafuu-sumi">
+                                        {item.label}
+                                    </span>
+                                )}
+                            </span>
+                        ))}
+                    </nav>
+                </div>
                 {right}
             </div>
         </header>

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -10,29 +10,26 @@ import { PageHeader } from "../components/PageHeader";
 
 interface EntryCardProps {
     to: "/play" | "/rshogi-viewer/live";
-    mark: string;
-    markTone: "shu" | "ai";
-    title: string;
+    heading: string;
+    tone: "shu" | "ai";
     children: ReactNode;
 }
 
-function EntryCard({ to, mark, markTone, title, children }: EntryCardProps): ReactElement {
+function EntryCard({ to, heading, tone, children }: EntryCardProps): ReactElement {
     return (
         <Link
             to={to}
             className="group flex flex-col gap-2 rounded-xl border border-wafuu-border bg-wafuu-washi-warm p-4 transition-colors hover:border-wafuu-shu/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-            <span
-                aria-hidden
+            <h2
                 className={
-                    markTone === "shu"
-                        ? "font-display text-xl text-wafuu-shu"
-                        : "font-display text-xl text-wafuu-ai"
+                    tone === "shu"
+                        ? "font-display text-xl font-semibold text-wafuu-shu"
+                        : "font-display text-xl font-semibold text-wafuu-ai"
                 }
             >
-                {mark}
-            </span>
-            <h2 className="font-display text-[15px] font-semibold text-wafuu-sumi">{title}</h2>
+                {heading}
+            </h2>
             <span className="text-[13px] leading-relaxed text-wafuu-sumi-light">{children}</span>
         </Link>
     );
@@ -46,11 +43,20 @@ export default function LandingPage(): ReactElement {
                 <section className="grid items-center gap-8 md:grid-cols-[1.05fr_0.95fr]">
                     <div className="flex flex-col gap-5">
                         <h1 className="text-balance font-display text-4xl leading-tight text-wafuu-sumi sm:text-5xl">
-                            今日の一局を、<span className="text-wafuu-shu">すぐに</span>。
+                            セットアップなしで、<span className="text-wafuu-shu">NNUE 検討</span>。
                         </h1>
-                        <p className="max-w-[34ch] text-[15px] leading-relaxed text-wafuu-sumi-light">
-                            人と指す。AI
-                            と指す。棋譜を並べる。迷わず盤の前に座れることだけを、この画面の仕事にする。
+                        {/* 折返しは文単位に限定する（inline-block）。字数依存の ch 幅だと
+                            NNUE/GUI など欧文混じりで語の途中に改行が落ちるため使わない。 */}
+                        <p className="max-w-[26rem] text-[15px] leading-relaxed text-wafuu-sumi-light">
+                            <span className="inline-block">
+                                NNUE エンジンがブラウザ内で動きます。
+                            </span>
+                            <span className="inline-block">
+                                評価関数の導入も GUI の設定も不要。
+                            </span>
+                            <span className="inline-block">
+                                人との対局、棋譜の再生もこの画面から。
+                            </span>
                         </p>
                         <div className="flex flex-wrap gap-3">
                             <Link
@@ -78,14 +84,14 @@ export default function LandingPage(): ReactElement {
                 </section>
 
                 <section aria-label="はじめ方" className="grid gap-4 sm:grid-cols-3">
-                    <EntryCard to="/play" mark="対" markTone="shu" title="人と対局">
-                        同じ盤を囲む。先手・後手を選んで一手目へ。
+                    <EntryCard to="/play" heading="対局" tone="shu">
+                        先手・後手を選んで人と指す。
                     </EntryCard>
-                    <EntryCard to="/play" mark="析" markTone="ai" title="AI と対局・検討">
-                        内蔵 NNUE エンジンと指す。そのまま検討へ持ち込める。
+                    <EntryCard to="/play" heading="検討" tone="ai">
+                        内蔵 NNUE エンジンと指す。検討モードに切り替えられる。
                     </EntryCard>
-                    <EntryCard to="/rshogi-viewer/live" mark="観" markTone="shu" title="ライブ観戦">
-                        進行中のエンジン対局をリアルタイムで眺める。
+                    <EntryCard to="/rshogi-viewer/live" heading="観戦" tone="shu">
+                        進行中のエンジン対局をリアルタイムで見る。
                     </EntryCard>
                 </section>
             </main>

--- a/apps/web/src/pages/online/OnlinePage.test.tsx
+++ b/apps/web/src/pages/online/OnlinePage.test.tsx
@@ -19,7 +19,7 @@ vi.mock("../../hooks/useAuthSession", () => ({
     }),
 }));
 
-// @shogi/ui のモック（PositionPresetSelector と、HeaderNav が使う Popover 系）
+// @shogi/ui のモック（PositionPresetSelector と、PageHeader が使う Sheet 系）
 vi.mock("@shogi/ui", () => ({
     PositionPresetSelector: ({
         value,
@@ -36,9 +36,10 @@ vi.mock("@shogi/ui", () => ({
             <option value="startpos">平手</option>
         </select>
     ),
-    Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
-    PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
-    PopoverContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Sheet: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SheetTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SheetContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    SheetTitle: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
 // import はモック設定後

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -1,0 +1,114 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@shogi/design-system";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentPropsWithoutRef, ComponentRef, ReactElement } from "react";
+import { forwardRef } from "react";
+import { useSurfaceTheme } from "./surface-theme";
+
+export const Sheet = DialogPrimitive.Root;
+export const SheetTrigger = DialogPrimitive.Trigger;
+export const SheetClose = DialogPrimitive.Close;
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = forwardRef<
+    ComponentRef<typeof DialogPrimitive.Overlay>,
+    ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(function SheetOverlay({ className, ...props }, ref): ReactElement {
+    return (
+        <DialogPrimitive.Overlay
+            className={cn(
+                "fixed inset-0 z-50 bg-foreground/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=open]:fade-in",
+                className,
+            )}
+            ref={ref}
+            {...props}
+        />
+    );
+});
+
+const sheetVariants = cva(
+    "fixed z-[51] gap-4 bg-card p-6 text-foreground shadow-xl transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+    {
+        variants: {
+            side: {
+                top: "inset-x-0 top-0 border-b border-border data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+                bottom: "inset-x-0 bottom-0 border-t border-border data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+                left: "inset-y-0 left-0 h-full w-3/4 border-r border-border data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+                right: "inset-y-0 right-0 h-full w-3/4 border-l border-border data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+            },
+        },
+        defaultVariants: {
+            side: "right",
+        },
+    },
+);
+
+export const SheetContent = forwardRef<
+    ComponentRef<typeof DialogPrimitive.Content>,
+    ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & VariantProps<typeof sheetVariants>
+>(function SheetContent({ side = "right", className, children, ...props }, ref): ReactElement {
+    const surfaceTheme = useSurfaceTheme();
+    return (
+        <SheetPortal>
+            <SheetOverlay />
+            <DialogPrimitive.Content
+                aria-describedby={undefined}
+                className={cn(surfaceTheme, sheetVariants({ side }), className)}
+                ref={ref}
+                {...props}
+            >
+                {children}
+            </DialogPrimitive.Content>
+        </SheetPortal>
+    );
+});
+
+export function SheetHeader({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>): ReactElement {
+    return (
+        <div
+            className={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
+            {...props}
+        />
+    );
+}
+
+export function SheetFooter({
+    className,
+    ...props
+}: React.HTMLAttributes<HTMLDivElement>): ReactElement {
+    return (
+        <div
+            className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+            {...props}
+        />
+    );
+}
+
+export const SheetTitle = forwardRef<
+    ComponentRef<typeof DialogPrimitive.Title>,
+    ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(function SheetTitle({ className, ...props }, ref): ReactElement {
+    return (
+        <DialogPrimitive.Title
+            className={cn("text-lg font-semibold text-foreground", className)}
+            ref={ref}
+            {...props}
+        />
+    );
+});
+
+export const SheetDescription = forwardRef<
+    ComponentRef<typeof DialogPrimitive.Description>,
+    ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(function SheetDescription({ className, ...props }, ref): ReactElement {
+    return (
+        <DialogPrimitive.Description
+            className={cn("text-sm text-muted-foreground", className)}
+            ref={ref}
+            {...props}
+        />
+    );
+});

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,14 +18,10 @@ export type { UseRoomConnectionOptions, UseRoomConnectionReturn } from "./hooks/
 export { useRoomConnection } from "./hooks/useRoomConnection";
 export type { UseRshogiLiveGameListReturn } from "./hooks/useRshogiLiveGameList";
 export { useRshogiLiveGameList } from "./hooks/useRshogiLiveGameList";
+
 // ============================================================
 // Components
 // ============================================================
-
-// AboutDialog
-// alert-dialog
-// button
-// dialog
 
 // engine-control-panel
 export { EngineControlPanel } from "./components/engine-control-panel";
@@ -38,6 +34,20 @@ export type {
 // position-preset-selector
 export { POSITION_PRESETS, PositionPresetSelector } from "./components/PositionPresetSelector";
 export { Popover, PopoverContent, PopoverTrigger } from "./components/popover";
+// AboutDialog
+// alert-dialog
+// button
+// dialog
+export {
+    Sheet,
+    SheetClose,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from "./components/sheet";
 export type { ShogiBoardCell, ShogiBoardPiece } from "./components/shogi-board";
 // shogi-board (online game 用)
 export { ShogiBoard } from "./components/shogi-board";


### PR DESCRIPTION
## 概要

密度勾配デザイン刷新の続き。トップ（迎える面）の文言・ヒーロー盤と、全ページ共通ナビゲーションを刷新する。

## 変更内容

### トップ文言（事実型コピーへ）
- H1: 「セットアップなしで、NNUE 検討。」— 固有の差別化（NNUE がブラウザ内 WASM で動く）を訴求。H1=全層に通じる帰結、リード先頭=NNUE 名指し、の二層分担
- リード文は文単位でのみ折り返す（inline-block。ch 幅指定は欧文混在で語中改行が落ちるため廃止）
- 入口カード: 一字マーク「対・析・観」を廃止し「対局・検討・観戦」の二字熟語見出しへ

### ヒーロー盤
- フェイク盤（市松+長方形駒）を廃止し、実対局の `ShogiBoard` を平手初期局面で静的描画
- 装飾用途のため `inert` + `aria-hidden` で 81 マスのボタンをフォーカス/AT から除外

### ナビゲーション（左ドロワー統一）
- PC 横並びピル8個 + モバイル右 Popover の二重実装を廃止
- `PageHeader` 左端のハンバーガー → `NavDrawer`（左 Sheet）に PC/モバイル共通で統一
- セクション構造: 指す（対局/オンライン対局）・棋譜（マイ棋譜/公開棋譜）・観戦（ライブ観戦/CSA 棋譜ビューア）・管理（NNUE モデル）
- ヘッダー右はログイン導線のみ（「対局する」ボタンはドロワー内「対局」と重複するため不採用）
- 現在ページは非表示にせず aria-current + 朱配色で表示（レイアウトシフト防止ルール継続）
- `packages/ui` に radix dialog ベースの Sheet プリミティブを追加

## 検証
- tsc（web / @shogi/ui）、web テスト 45 件、ui テスト 411 件、biome すべてパス
- デスクトップ/モバイル幅でスクリーンショット確認、stg デプロイ済み（ramu-shogi-stg で目視確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Fjcp5t92PcukUfGPB4VXG