### PR TITLE
feat(ui,app-core,app-controller): 探索情報の網羅保持と表示トグル・JSONL エクスポート

### DIFF
--- a/packages/app-controller/src/engine-controller.test.ts
+++ b/packages/app-controller/src/engine-controller.test.ts
@@ -1,11 +1,39 @@
 import type { EngineEvent } from "@shogi/engine-client";
 import { describe, expect, it, vi } from "vitest";
 import {
+    accumulateSearchStats,
     createEngineController,
     determineBestmoveAction,
     handleBestmove,
     handleInfoEvent,
 } from "./engine-controller";
+
+describe("accumulateSearchStats", () => {
+    it("multipv 1 の各フィールドを last-wins で累積する", () => {
+        const first = accumulateSearchStats(
+            {},
+            {
+                type: "info",
+                depth: 10,
+                nodes: 100,
+                scoreCp: 20,
+            },
+        );
+        expect(accumulateSearchStats(first, { type: "info", depth: 12, nps: 5000 })).toEqual({
+            depth: 12,
+            nodes: 100,
+            scoreCp: 20,
+            nps: 5000,
+        });
+    });
+
+    it("multipv 2 以上を無視する", () => {
+        const current = { depth: 10, scoreCp: 20 };
+        expect(accumulateSearchStats(current, { type: "info", multipv: 2, depth: 99 })).toBe(
+            current,
+        );
+    });
+});
 
 describe("determineBestmoveAction", () => {
     it("通常の手の場合、apply_moveアクションを返す", () => {

--- a/packages/app-controller/src/engine-controller.ts
+++ b/packages/app-controller/src/engine-controller.ts
@@ -1,4 +1,10 @@
-import type { GameResult, NnueSelection, Player, ResolvedNnue } from "@shogi/app-core";
+import type {
+    GameResult,
+    MoveSearchStats,
+    NnueSelection,
+    Player,
+    ResolvedNnue,
+} from "@shogi/app-core";
 import type {
     EngineClient,
     EngineErrorCode,
@@ -148,6 +154,8 @@ interface EngineControllerCallbacks {
     onMoveFromEngine: (move: string) => void;
     onMatchEnd: (result: GameResult) => Promise<void>;
     onEvalUpdate?: (ply: number, event: EngineInfoEvent) => void;
+    onSearchComplete?: (ply: number, stats: MoveSearchStats) => void;
+    onLiveInfo?: (side: Player, event: EngineInfoEvent) => void;
 }
 
 interface EngineControllerDependencies {
@@ -451,6 +459,31 @@ export function handleInfoEvent(
     }
 }
 
+export function accumulateSearchStats(
+    current: MoveSearchStats,
+    event: EngineInfoEvent,
+): MoveSearchStats {
+    if (event.multipv !== undefined && event.multipv !== 1) return current;
+    const next = { ...current };
+    const fields = [
+        "depth",
+        "seldepth",
+        "scoreCp",
+        "scoreMate",
+        "nodes",
+        "nps",
+        "timeMs",
+        "hashfull",
+        "multipv",
+        "pv",
+    ] as const;
+    for (const field of fields) {
+        const value = event[field];
+        if (value !== undefined) Object.assign(next, { [field]: value });
+    }
+    return next;
+}
+
 export function createEngineController(
     dependencies: EngineControllerDependencies,
 ): EngineController {
@@ -460,6 +493,11 @@ export function createEngineController(
     const engineStates = createInitialEngineStates();
     const searchStates = createInitialSearchStates();
     const analysisState = createInitialAnalysisState();
+    const liveSearchStats = { sente: {}, gote: {} } as Record<Player, MoveSearchStats>;
+    const liveThinkLimitMs = { sente: undefined, gote: undefined } as Record<
+        Player,
+        number | undefined
+    >;
     // 側ごとの in-flight 初期化。並行呼び出しは同じ Promise を共有して二重初期化を防ぐ
     const initializing = { sente: null, gote: null } as Record<
         Player,
@@ -603,6 +641,11 @@ export function createEngineController(
                 }
 
                 if (result.action === "apply_move" && result.move) {
+                    callbacks.onSearchComplete?.(movesCount, {
+                        ...liveSearchStats[side],
+                        thinkLimitMs: liveThinkLimitMs[side],
+                        engineId,
+                    });
                     callbacks.onMoveFromEngine(result.move);
                 }
 
@@ -614,6 +657,8 @@ export function createEngineController(
             }
 
             if (event.type === "info") {
+                callbacks.onLiveInfo?.(side, event);
+                liveSearchStats[side] = accumulateSearchStats(liveSearchStats[side], event);
                 if (
                     callbacks.onEvalUpdate &&
                     (event.scoreCp !== undefined || event.scoreMate !== undefined)
@@ -926,6 +971,9 @@ export function createEngineController(
             }
 
             const effectiveByoyomiMs = Math.max(100, remainingByoyomiMs);
+
+            liveSearchStats[side] = {};
+            liveThinkLimitMs[side] = effectiveByoyomiMs;
 
             const handle = await client.search({
                 limits: { byoyomiMs: effectiveByoyomiMs },

--- a/packages/app-core/src/game/csa.test.ts
+++ b/packages/app-core/src/game/csa.test.ts
@@ -47,6 +47,15 @@ beforeEach(() => {
 });
 
 describe("movesToCsa", () => {
+    it("指定された各手の消費秒を指し手直後の T 行に出力する", () => {
+        expect(movesToCsa(["7g7f", "3c3d"], {}, undefined, [1.6, 0])).toContain(
+            "+7776FU\nT2\n-3334FU\nT0",
+        );
+    });
+
+    it("消費秒を省略した場合は T 行を出力しない", () => {
+        expect(movesToCsa(["7g7f"])).not.toContain("\nT");
+    });
     it("USI手順をCSA形式に変換する", () => {
         const moves = ["7g7f", "3c3d"];
         const result = movesToCsa(moves);

--- a/packages/app-core/src/game/csa.ts
+++ b/packages/app-core/src/game/csa.ts
@@ -229,6 +229,7 @@ export function movesToCsa(
     moves: string[],
     metadata: CsaMetadata = {},
     initialBoard?: BoardState,
+    elapsedSeconds?: Array<number | undefined>,
 ): string {
     const lines: string[] = [
         "V2.2",
@@ -272,6 +273,10 @@ export function movesToCsa(
             );
         }
         lines.push(csaMove);
+        const elapsed = elapsedSeconds?.[index];
+        if (elapsed !== undefined) {
+            lines.push(`T${Math.max(0, Math.round(elapsed))}`);
+        }
         state = result.next;
     });
 

--- a/packages/app-core/src/game/kifu-tree.test.ts
+++ b/packages/app-core/src/game/kifu-tree.test.ts
@@ -34,6 +34,16 @@ function createTestPosition(ply: number = 0): PositionState {
 }
 
 describe("kifu-tree", () => {
+    it("searchStats をノードと JSON スナップショットで保持する", () => {
+        const position = createTestPosition(0);
+        const stats = { depth: 20, nodes: 1234, pv: ["7g7f"], engineId: "test" };
+        const tree = addMove(createKifuTree(position, "startpos"), "7g7f", createTestPosition(1), {
+            searchStats: stats,
+        });
+        const node = tree.nodes.get(tree.currentNodeId);
+        expect(node?.searchStats).toEqual(stats);
+        expect(JSON.parse(JSON.stringify(node)).searchStats).toEqual(stats);
+    });
     describe("createKifuTree", () => {
         it("開始局面でツリーを作成できる", () => {
             const startPosition = createTestPosition(0);

--- a/packages/app-core/src/game/kifu-tree.ts
+++ b/packages/app-core/src/game/kifu-tree.ts
@@ -22,6 +22,22 @@ export interface KifuEval {
     pv?: string[];
 }
 
+/** 対局エンジンが1手を決定するまでに得られた探索統計 */
+export interface MoveSearchStats {
+    depth?: number;
+    seldepth?: number;
+    scoreCp?: number;
+    scoreMate?: number;
+    nodes?: number;
+    nps?: number;
+    timeMs?: number;
+    hashfull?: number;
+    multipv?: number;
+    pv?: string[];
+    thinkLimitMs?: number;
+    engineId?: string;
+}
+
 /** 棋譜ノード */
 export interface KifuNode {
     /** ノードID（UUID） */
@@ -51,6 +67,8 @@ export interface KifuNode {
     comment?: string;
     /** 消費時間（ミリ秒） */
     elapsedMs?: number;
+    /** この指し手を決定した探索の統計 */
+    searchStats?: MoveSearchStats;
 }
 
 /** 棋譜ツリー */
@@ -129,6 +147,8 @@ export interface AddMoveOptions {
     elapsedMs?: number;
     /** 評価値情報 */
     eval?: KifuEval;
+    /** この指し手を決定した探索の統計 */
+    searchStats?: MoveSearchStats;
 }
 
 export function addMove(
@@ -164,6 +184,7 @@ export function addMove(
         boardBefore: cloneBoard(currentNode.positionAfter.board),
         elapsedMs: options?.elapsedMs,
         eval: options?.eval,
+        searchStats: options?.searchStats,
     };
 
     // ノードマップを更新

--- a/packages/app-core/src/index.ts
+++ b/packages/app-core/src/index.ts
@@ -56,6 +56,7 @@ export type {
     KifuEval,
     KifuNode,
     KifuTree,
+    MoveSearchStats,
     PreferredPathCache,
 } from "./game/kifu-tree";
 export {

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1116,6 +1116,7 @@ export function ShogiMatch({
     const {
         eventLogs,
         errorLogs,
+        engineStatus,
         stopAllEngines,
         prepareEngines,
         isEngineTurn,
@@ -1168,6 +1169,16 @@ export function ShogiMatch({
     });
     stopAllEnginesRef.current = stopAllEngines;
     prepareEnginesRef.current = prepareEngines;
+
+    // fatal なエンジンエラーは対局停止 (isMatchRunning=false) に遷移しないため、
+    // error 状態を直接監視してライブ探索表示を消す
+    useEffect(() => {
+        if (engineStatus.sente !== "error" && engineStatus.gote !== "error") return;
+        liveInfoTrailingRef.current = null;
+        if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
+        liveInfoTimerRef.current = null;
+        setLiveSearchInfo(null);
+    }, [engineStatus.sente, engineStatus.gote]);
     restartEngineForNnueRef.current = restartEngineForNnue;
 
     // role変更時にエンジンを破棄するラッパー

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -569,12 +569,27 @@ export function ShogiMatch({
     } | null>(null);
     const liveInfoTrailingRef = useRef<{ side: Player; event: EngineInfoEvent } | null>(null);
     const liveInfoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const clearLiveSearchInfo = () => {
+        liveInfoTrailingRef.current = null;
+        if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
+        liveInfoTimerRef.current = null;
+        setLiveSearchInfo(null);
+    };
     useEffect(
         () => () => {
             if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
         },
         [],
     );
+    // 終局・一時停止・エラーで対局が止まったとき「思考中」の残留表示と未消費の統計を消す
+    useEffect(() => {
+        if (isMatchRunning) return;
+        pendingSearchStatsRef.current.clear();
+        liveInfoTrailingRef.current = null;
+        if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
+        liveInfoTimerRef.current = null;
+        setLiveSearchInfo(null);
+    }, [isMatchRunning]);
     // モバイル判定
     const isMobile = useIsMobile();
     // 検討モード: 編集モードでも対局中でも一時停止中でもない状態
@@ -1130,12 +1145,11 @@ export function ShogiMatch({
         onEvalUpdate: (ply, event) => handleEvalUpdateRef.current(ply, event),
         onSearchComplete: (ply, stats) => {
             pendingSearchStatsRef.current.set(ply, stats);
-            liveInfoTrailingRef.current = null;
-            if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
-            liveInfoTimerRef.current = null;
-            setLiveSearchInfo(null);
+            clearLiveSearchInfo();
         },
         onLiveInfo: (side, event) => {
+            // 対局停止後に flush された info が残留表示を再セットしないようにする
+            if (!isMatchRunning) return;
             liveInfoTrailingRef.current = { side, event };
             if (liveInfoTimerRef.current) return;
             liveInfoTimerRef.current = setTimeout(() => {
@@ -2049,8 +2063,12 @@ export function ShogiMatch({
                     isMatchRunning={isMatchRunning}
                     isPaused={isPaused}
                 />
-                {displaySettings.showSearchInfo && liveSearchInfo && (
-                    <SearchInfoPanel side={liveSearchInfo.side} info={liveSearchInfo.event} />
+                {displaySettings.showSearchInfo && isMatchRunning && liveSearchInfo && (
+                    <SearchInfoPanel
+                        side={liveSearchInfo.side}
+                        info={liveSearchInfo.event}
+                        isMobile={isMobile}
+                    />
                 )}
             </TooltipProvider>
         </ShogiMatchProvider>

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1149,8 +1149,8 @@ export function ShogiMatch({
             clearLiveSearchInfo();
         },
         onLiveInfo: (side, event) => {
-            // 対局停止後に flush された info が残留表示を再セットしないようにする
-            if (!isMatchRunning) return;
+            // 対局停止後や fatal エラー後に flush された info が残留表示を再セットしないようにする
+            if (!isMatchRunning || engineStatus[side] === "error") return;
             liveInfoTrailingRef.current = { side, event };
             if (liveInfoTimerRef.current) return;
             liveInfoTimerRef.current = setTimeout(() => {
@@ -2074,13 +2074,16 @@ export function ShogiMatch({
                     isMatchRunning={isMatchRunning}
                     isPaused={isPaused}
                 />
-                {displaySettings.showSearchInfo && isMatchRunning && liveSearchInfo && (
-                    <SearchInfoPanel
-                        side={liveSearchInfo.side}
-                        info={liveSearchInfo.event}
-                        isMobile={isMobile}
-                    />
-                )}
+                {displaySettings.showSearchInfo &&
+                    isMatchRunning &&
+                    liveSearchInfo &&
+                    engineStatus[liveSearchInfo.side] !== "error" && (
+                        <SearchInfoPanel
+                            side={liveSearchInfo.side}
+                            info={liveSearchInfo.event}
+                            isMobile={isMobile}
+                        />
+                    )}
             </TooltipProvider>
         </ShogiMatchProvider>
     );

--- a/packages/ui/src/components/shogi-match.tsx
+++ b/packages/ui/src/components/shogi-match.tsx
@@ -1,7 +1,9 @@
 import type {
     BoardState,
     GameResult,
+    KifuNode,
     LastMove,
+    MoveSearchStats,
     NnueSelection,
     PieceType,
     Player,
@@ -17,10 +19,12 @@ import {
     getPositionService,
     resolveWorkerCount,
 } from "@shogi/app-core";
+import type { EngineInfoEvent } from "@shogi/engine-client";
 import type { ReactElement } from "react";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { useShogiSound } from "../hooks/useShogiSound";
 import type { RemoteNnueManager } from "./nnue/types";
+import { SearchInfoPanel } from "./shogi-match/components/SearchInfoPanel";
 import {
     DEFAULT_BYOYOMI_MS,
     DEFAULT_MAX_LOGS,
@@ -80,6 +84,7 @@ import type {
     NavigationProps,
     PCSpecificProps,
 } from "./shogi-match/types/layoutProps";
+import { exportToRshogiJsonl } from "./shogi-match/utils/jsonlExport";
 import type { KifMove } from "./shogi-match/utils/kifFormat";
 import { LegalMoveCache } from "./shogi-match/utils/legalMoveCache";
 import {
@@ -557,6 +562,19 @@ export function ShogiMatch({
     const [isMatchRunning, setIsMatchRunning] = useState(false);
     const [isEditMode, setIsEditMode] = useState(true);
     const [isPaused, setIsPaused] = useState(false);
+    const pendingSearchStatsRef = useRef(new Map<number, MoveSearchStats>());
+    const [liveSearchInfo, setLiveSearchInfo] = useState<{
+        side: Player;
+        event: EngineInfoEvent;
+    } | null>(null);
+    const liveInfoTrailingRef = useRef<{ side: Player; event: EngineInfoEvent } | null>(null);
+    const liveInfoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    useEffect(
+        () => () => {
+            if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
+        },
+        [],
+    );
     // モバイル判定
     const isMobile = useIsMobile();
     // 検討モード: 編集モードでも対局中でも一時停止中でもない状態
@@ -1110,6 +1128,21 @@ export function ShogiMatch({
         onMoveFromEngine: (move) => handleMoveFromEngineRef.current(move),
         onMatchEnd: endMatch,
         onEvalUpdate: (ply, event) => handleEvalUpdateRef.current(ply, event),
+        onSearchComplete: (ply, stats) => {
+            pendingSearchStatsRef.current.set(ply, stats);
+            liveInfoTrailingRef.current = null;
+            if (liveInfoTimerRef.current) clearTimeout(liveInfoTimerRef.current);
+            liveInfoTimerRef.current = null;
+            setLiveSearchInfo(null);
+        },
+        onLiveInfo: (side, event) => {
+            liveInfoTrailingRef.current = { side, event };
+            if (liveInfoTimerRef.current) return;
+            liveInfoTimerRef.current = setTimeout(() => {
+                if (liveInfoTrailingRef.current) setLiveSearchInfo(liveInfoTrailingRef.current);
+                liveInfoTimerRef.current = null;
+            }, 250);
+        },
         maxLogs,
         senteNnueSelection,
         goteNnueSelection,
@@ -1225,7 +1258,11 @@ export function ShogiMatch({
         // 消費時間を計算
         const elapsedMs = Date.now() - turnStartTimeRef.current;
         // 棋譜ナビゲーションに手を追加（局面更新はonPositionChangeで自動実行）
-        navigation.addMove(move, nextPosition, { elapsedMs });
+        const ply = moves.length;
+        const searchStats =
+            source === "engine" ? pendingSearchStatsRef.current.get(ply) : undefined;
+        navigation.addMove(move, nextPosition, { elapsedMs, searchStats });
+        if (source === "engine") pendingSearchStatsRef.current.delete(ply);
         setLastMove(lastMoveInfo);
         setSelection(null);
         setMessage(null);
@@ -1628,6 +1665,69 @@ export function ShogiMatch({
         setIsMatchRunning,
     });
 
+    const handleExportJsonl = async (): Promise<void> => {
+        if (!navigation.tree) return;
+        // 現在のナビゲーション位置に依存しないよう、ツリーの主分岐を親子ペアで辿る
+        // (sfen_before と手番は親ノードの positionAfter から導出する)
+        const mainMoves: { node: KifuNode; parent: KifuNode }[] = [];
+        let node = navigation.tree.nodes.get(navigation.tree.rootId);
+        while (node?.children[0]) {
+            const child = navigation.tree.nodes.get(node.children[0]);
+            if (!child || !child.usiMove) break;
+            mainMoves.push({ node: child, parent: node });
+            node = child;
+        }
+        const service = getPositionService();
+        const jsonlNodes = await Promise.all(
+            mainMoves.map(async ({ node: mainNode, parent }) => ({
+                moveUsi: mainNode.usiMove as string,
+                sfenBefore: await service.boardToSfen(parent.positionAfter),
+                sideToMove: parent.positionAfter.turn,
+                elapsedMs: mainNode.elapsedMs,
+                searchStats: mainNode.searchStats,
+            })),
+        );
+        const now = new Date();
+        const filename = `${now.toISOString().replace(/[:.]/g, "-")}.jsonl`;
+        const labelFor = (side: Player) => {
+            const setting = sides[side];
+            if (setting.role === "human") return "human";
+            return (
+                engineOptions.find((option) => option.id === setting.engineId)?.label ??
+                setting.engineId ??
+                "engine"
+            );
+        };
+        const result = gameResult
+            ? {
+                  outcome:
+                      gameResult.winner === "sente"
+                          ? ("black_win" as const)
+                          : ("white_win" as const),
+                  reason: gameResult.reason.kind,
+                  winner: gameResult.winner,
+              }
+            : undefined;
+        const contents = exportToRshogiJsonl(jsonlNodes, {
+            timestamp: now,
+            output: filename,
+            startSfen,
+            maxMoves: Math.max(1, mainMoves.length),
+            byoyomiMs: Math.max(timeSettings.sente.byoyomiMs, timeSettings.gote.byoyomiMs),
+            mainTimeMs: Math.max(timeSettings.sente.mainMs, timeSettings.gote.mainMs),
+            threads: Math.max(1, engineThreads.sente, engineThreads.gote),
+            hashMb: 0,
+            labels: { sente: labelFor("sente"), gote: labelFor("gote") },
+            result,
+        });
+        const url = URL.createObjectURL(new Blob([contents], { type: "application/x-ndjson" }));
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = filename;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    };
+
     const initialAnalysisAppliedRef = useRef<string | null>(null);
 
     // initialReview を取り込む。live 観戦では moves が逐次伸びた場合だけ importSfen で
@@ -1858,6 +1958,7 @@ export function ShogiMatch({
         setDisplaySettings,
         handlePlySelect,
         handleCopyKif,
+        handleExportJsonl,
         handleMoveDetailSelect,
     };
 
@@ -1948,6 +2049,9 @@ export function ShogiMatch({
                     isMatchRunning={isMatchRunning}
                     isPaused={isPaused}
                 />
+                {displaySettings.showSearchInfo && liveSearchInfo && (
+                    <SearchInfoPanel side={liveSearchInfo.side} info={liveSearchInfo.event} />
+                )}
             </TooltipProvider>
         </ShogiMatchProvider>
     );

--- a/packages/ui/src/components/shogi-match/components/MobileSettingsSheet.tsx
+++ b/packages/ui/src/components/shogi-match/components/MobileSettingsSheet.tsx
@@ -126,6 +126,8 @@ interface MobileSettingsSheetProps {
     onImportKif?: (moves: string[], moveData: KifMoveData[], startSfen?: string) => Promise<void>;
     /** 局面が準備完了しているか */
     positionReady?: boolean;
+    /** rshogi 互換 JSONL をダウンロード */
+    onExportJsonl?: () => Promise<void>;
 }
 
 // iOS Safari は16px未満のinput/selectにフォーカスすると自動ズームするため、text-base(16px)を使用
@@ -304,6 +306,7 @@ export function MobileSettingsSheet({
     onImportSfen,
     onImportKif,
     positionReady = true,
+    onExportJsonl,
 }: MobileSettingsSheetProps): ReactElement {
     const threadOptions = buildThreadOptions();
     const externalEngines = engineOptions?.filter((engine) => engine.kind === "external") ?? [];
@@ -909,6 +912,16 @@ export function MobileSettingsSheet({
                 />
             )}
 
+            {onExportJsonl && (
+                <button
+                    type="button"
+                    onClick={() => void onExportJsonl()}
+                    className="w-full rounded-lg border border-border bg-background p-2 text-sm text-foreground"
+                >
+                    JSONL エクスポート
+                </button>
+            )}
+
             {/* 表示設定 */}
             <div className="space-y-3 pt-3 border-t border-border">
                 <div className="font-medium text-sm">表示設定</div>
@@ -964,6 +977,20 @@ export function MobileSettingsSheet({
                             className="w-4 h-4"
                         />
                         <span>最終手を強調表示</span>
+                    </label>
+                    <label className="flex items-center gap-2 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={displaySettings.showSearchInfo}
+                            onChange={(e) =>
+                                onDisplaySettingsChange({
+                                    ...displaySettings,
+                                    showSearchInfo: e.target.checked,
+                                })
+                            }
+                            className="w-4 h-4"
+                        />
+                        <span>探索情報 (NPS/深さ) を表示</span>
                     </label>
                     <label className="flex items-center gap-2 text-sm">
                         <input

--- a/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
+++ b/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
@@ -64,6 +64,8 @@ interface MoveDetailWindowProps {
     onClose: () => void;
     /** 現在位置がメインライン上にあるか */
     isOnMainLine?: boolean;
+    /** 保存済み探索統計を表示するか */
+    showSearchInfo?: boolean;
 }
 
 const DEFAULT_WIDTH = 320;
@@ -323,6 +325,7 @@ export function MoveDetailWindow({
     kifuTree,
     onClose,
     isOnMainLine = true,
+    showSearchInfo = false,
 }: MoveDetailWindowProps): ReactElement {
     const surfaceTheme = useSurfaceTheme();
     const { geometry, handlers } = useDraggableWindow(
@@ -386,6 +389,11 @@ export function MoveDetailWindow({
 
     const hasPv = pvList.length > 0;
     const hasMultiplePv = pvList.length > 1;
+    const searchStats = kifuTree
+        ? [...kifuTree.nodes.values()].find(
+              (node) => node.ply === move.ply && node.usiMove === move.usiMove,
+          )?.searchStats
+        : undefined;
 
     // NNUE選択肢を構築（プリセット + カスタムNNUE）
     const nnueOptions = buildNnueOptions({ presets, nnueList, isNnueListLoading });
@@ -422,6 +430,16 @@ export function MoveDetailWindow({
                     <span className="text-[11px] text-muted-foreground">{move.ply}手目</span>
                     <span className="text-[13px] font-medium">{move.displayText}</span>
                 </div>
+
+                {showSearchInfo && searchStats && (
+                    <div className="mb-3 grid grid-cols-2 gap-1 rounded-lg border border-border bg-muted/40 p-2 text-[11px] text-foreground">
+                        <span>選択深さ: {searchStats.seldepth ?? "-"}</span>
+                        <span>nodes: {searchStats.nodes?.toLocaleString() ?? "-"}</span>
+                        <span>NPS: {searchStats.nps?.toLocaleString() ?? "-"}</span>
+                        <span>探索時間: {searchStats.timeMs ?? "-"} ms</span>
+                        <span>思考上限: {searchStats.thinkLimitMs ?? "-"} ms</span>
+                    </div>
+                )}
                 <button
                     type="button"
                     className="bg-transparent border-none cursor-pointer px-2 py-1 rounded text-base leading-none text-muted-foreground hover:bg-accent"

--- a/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
+++ b/packages/ui/src/components/shogi-match/components/MoveDetailWindow.tsx
@@ -389,11 +389,24 @@ export function MoveDetailWindow({
 
     const hasPv = pvList.length > 0;
     const hasMultiplePv = pvList.length > 1;
-    const searchStats = kifuTree
-        ? [...kifuTree.nodes.values()].find(
-              (node) => node.ply === move.ply && node.usiMove === move.usiMove,
-          )?.searchStats
-        : undefined;
+    // 別分岐に同 ply・同指し手のノードがあり得るため、まず現在の経路 (currentNodeId の祖先) で解決する
+    const searchStats = (() => {
+        if (!kifuTree) return undefined;
+        let id: string | null = kifuTree.currentNodeId;
+        while (id) {
+            const node = kifuTree.nodes.get(id);
+            if (!node) break;
+            if (node.ply === move.ply) {
+                if (node.usiMove === move.usiMove) return node.searchStats;
+                break;
+            }
+            if (node.ply < move.ply) break;
+            id = node.parentId;
+        }
+        return [...kifuTree.nodes.values()].find(
+            (node) => node.ply === move.ply && node.usiMove === move.usiMove,
+        )?.searchStats;
+    })();
 
     // NNUE選択肢を構築（プリセット + カスタムNNUE）
     const nnueOptions = buildNnueOptions({ presets, nnueList, isNnueListLoading });

--- a/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
+++ b/packages/ui/src/components/shogi-match/components/PCKifuSection.tsx
@@ -77,6 +77,7 @@ export function PCKifuSection({
         onDisplaySettingsChange,
         handlePlySelect,
         handleCopyKif,
+        handleExportJsonl,
         handleMoveDetailSelect,
         isMatchRunning,
     } = useNavigation();
@@ -110,6 +111,13 @@ export function PCKifuSection({
                     initialOpen={evalPanelInitialOpen ?? false}
                     reviewMode={reviewMode}
                 />
+                <button
+                    type="button"
+                    onClick={() => void handleExportJsonl()}
+                    className="rounded border border-border bg-background px-2 py-1 text-xs text-foreground hover:bg-muted"
+                >
+                    JSONL エクスポート
+                </button>
 
                 {/* 棋譜パネル + ドロワー（横並び） */}
                 <div className="relative flex items-start">

--- a/packages/ui/src/components/shogi-match/components/SearchInfoPanel.tsx
+++ b/packages/ui/src/components/shogi-match/components/SearchInfoPanel.tsx
@@ -1,0 +1,50 @@
+import type { Player } from "@shogi/app-core";
+import type { EngineInfoEvent } from "@shogi/engine-client";
+import type { ReactElement } from "react";
+
+interface SearchInfoPanelProps {
+    side: Player;
+    info: EngineInfoEvent;
+}
+
+const formatCount = (value: number | undefined): string => {
+    if (value === undefined) return "-";
+    if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+    if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+    return String(value);
+};
+
+const formatScore = (info: EngineInfoEvent): string => {
+    if (info.scoreMate !== undefined) return `詰 ${info.scoreMate}`;
+    if (info.scoreCp !== undefined) return `${info.scoreCp >= 0 ? "+" : ""}${info.scoreCp}`;
+    return "-";
+};
+
+export function SearchInfoPanel({ side, info }: SearchInfoPanelProps): ReactElement {
+    const depth =
+        info.depth === undefined
+            ? "-"
+            : info.seldepth === undefined
+              ? String(info.depth)
+              : `${info.depth}/${info.seldepth}`;
+    return (
+        <aside className="fixed bottom-3 left-1/2 z-40 w-[min(44rem,calc(100%-1.5rem))] -translate-x-1/2 rounded-lg border border-border bg-card/95 p-2 text-xs text-foreground shadow-lg">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono tabular-nums">
+                <span>{side === "sente" ? "▲" : "△"} 思考中</span>
+                <span>深さ {depth}</span>
+                <span>評価 {formatScore(info)}</span>
+                <span>nodes {formatCount(info.nodes)}</span>
+                <span>NPS {formatCount(info.nps)}</span>
+                <span>
+                    時間 {info.timeMs === undefined ? "-" : `${(info.timeMs / 1000).toFixed(1)}秒`}
+                </span>
+                <span>hash {info.hashfull === undefined ? "-" : `${info.hashfull}‰`}</span>
+            </div>
+            {info.pv && info.pv.length > 0 && (
+                <div className="truncate pt-1 text-muted-foreground">
+                    PV {info.pv.slice(0, 8).join(" ")}
+                </div>
+            )}
+        </aside>
+    );
+}

--- a/packages/ui/src/components/shogi-match/components/SearchInfoPanel.tsx
+++ b/packages/ui/src/components/shogi-match/components/SearchInfoPanel.tsx
@@ -5,6 +5,8 @@ import type { ReactElement } from "react";
 interface SearchInfoPanelProps {
     side: Player;
     info: EngineInfoEvent;
+    /** モバイルでは右下 FAB (設定ボタン) と重ならないよう上にオフセットする */
+    isMobile?: boolean;
 }
 
 const formatCount = (value: number | undefined): string => {
@@ -20,15 +22,22 @@ const formatScore = (info: EngineInfoEvent): string => {
     return "-";
 };
 
-export function SearchInfoPanel({ side, info }: SearchInfoPanelProps): ReactElement {
+export function SearchInfoPanel({
+    side,
+    info,
+    isMobile = false,
+}: SearchInfoPanelProps): ReactElement {
     const depth =
         info.depth === undefined
             ? "-"
             : info.seldepth === undefined
               ? String(info.depth)
               : `${info.depth}/${info.seldepth}`;
+    const bottomClass = isMobile ? "bottom-[calc(4.5rem+env(safe-area-inset-bottom))]" : "bottom-3";
     return (
-        <aside className="fixed bottom-3 left-1/2 z-40 w-[min(44rem,calc(100%-1.5rem))] -translate-x-1/2 rounded-lg border border-border bg-card/95 p-2 text-xs text-foreground shadow-lg">
+        <aside
+            className={`fixed ${bottomClass} left-1/2 z-40 w-[min(44rem,calc(100%-1.5rem))] -translate-x-1/2 rounded-lg border border-border bg-card/95 p-2 text-xs text-foreground shadow-lg`}
+        >
             <div className="flex flex-wrap gap-x-4 gap-y-1 font-mono tabular-nums">
                 <span>{side === "sente" ? "▲" : "△"} 思考中</span>
                 <span>深さ {depth}</span>

--- a/packages/ui/src/components/shogi-match/contexts/NavigationContext.tsx
+++ b/packages/ui/src/components/shogi-match/contexts/NavigationContext.tsx
@@ -57,6 +57,7 @@ interface NavigationProviderProps {
     // 手の選択
     handlePlySelect: (ply: number) => void;
     handleCopyKif: () => string;
+    handleExportJsonl: () => Promise<void>;
     handleMoveDetailSelect: (move: KifMove | null, position: PositionState | null) => void;
 
     // 対局状態（ナビゲーション無効化用）
@@ -90,6 +91,7 @@ export function NavigationProvider({
     onDisplaySettingsChange,
     handlePlySelect,
     handleCopyKif,
+    handleExportJsonl,
     handleMoveDetailSelect,
     isMatchRunning,
     children,
@@ -116,6 +118,7 @@ export function NavigationProvider({
         onDisplaySettingsChange,
         handlePlySelect,
         handleCopyKif,
+        handleExportJsonl,
         handleMoveDetailSelect,
         isMatchRunning,
     };

--- a/packages/ui/src/components/shogi-match/contexts/NavigationContext.types.ts
+++ b/packages/ui/src/components/shogi-match/contexts/NavigationContext.types.ts
@@ -86,6 +86,7 @@ export interface NavigationContextValue {
     // 手の選択
     handlePlySelect: (ply: number) => void;
     handleCopyKif: () => string;
+    handleExportJsonl: () => Promise<void>;
     handleMoveDetailSelect: (move: KifMove | null, position: PositionState | null) => void;
 
     // 対局状態（ナビゲーション無効化用）

--- a/packages/ui/src/components/shogi-match/hooks/useEngineManager.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useEngineManager.ts
@@ -11,7 +11,13 @@ import type {
     SideSetting,
 } from "@shogi/app-controller";
 import { createEngineController } from "@shogi/app-controller";
-import type { GameResult, NnueSelection, Player, ResolvedNnue } from "@shogi/app-core";
+import type {
+    GameResult,
+    MoveSearchStats,
+    NnueSelection,
+    Player,
+    ResolvedNnue,
+} from "@shogi/app-core";
 import type { EngineClient, EngineInfoEvent } from "@shogi/engine-client";
 import { useEffect, useRef, useState } from "react";
 import type { EngineThreadSettings } from "../types";
@@ -42,6 +48,8 @@ interface UseEngineManagerProps {
     onMatchEnd: (result: GameResult) => Promise<void>;
     /** 評価値更新時のコールバック */
     onEvalUpdate?: (ply: number, event: EngineInfoEvent) => void;
+    onSearchComplete?: (ply: number, stats: MoveSearchStats) => void;
+    onLiveInfo?: (side: Player, event: EngineInfoEvent) => void;
     /** ログの最大件数 */
     maxLogs?: number;
     /** 対局用 NNUE 選択（先手） */
@@ -139,6 +147,8 @@ export function useEngineManager({
     onMoveFromEngine,
     onMatchEnd,
     onEvalUpdate,
+    onSearchComplete,
+    onLiveInfo,
     maxLogs = 80,
     senteNnueSelection,
     goteNnueSelection,
@@ -153,10 +163,22 @@ export function useEngineManager({
         engineOptionsRef.current = engineOptions;
     }, [engineOptions]);
 
-    const callbacksRef = useRef({ onMoveFromEngine, onMatchEnd, onEvalUpdate });
+    const callbacksRef = useRef({
+        onMoveFromEngine,
+        onMatchEnd,
+        onEvalUpdate,
+        onSearchComplete,
+        onLiveInfo,
+    });
     useEffect(() => {
-        callbacksRef.current = { onMoveFromEngine, onMatchEnd, onEvalUpdate };
-    }, [onMoveFromEngine, onMatchEnd, onEvalUpdate]);
+        callbacksRef.current = {
+            onMoveFromEngine,
+            onMatchEnd,
+            onEvalUpdate,
+            onSearchComplete,
+            onLiveInfo,
+        };
+    }, [onMoveFromEngine, onMatchEnd, onEvalUpdate, onSearchComplete, onLiveInfo]);
 
     const resolveNnueRef = useRef(resolveNnue);
     useEffect(() => {
@@ -184,6 +206,9 @@ export function useEngineManager({
                 onMoveFromEngine: (move) => callbacksRef.current.onMoveFromEngine(move),
                 onMatchEnd: (result) => callbacksRef.current.onMatchEnd(result),
                 onEvalUpdate: (ply, event) => callbacksRef.current.onEvalUpdate?.(ply, event),
+                onSearchComplete: (ply, stats) =>
+                    callbacksRef.current.onSearchComplete?.(ply, stats),
+                onLiveInfo: (side, event) => callbacksRef.current.onLiveInfo?.(side, event),
             },
         });
     }

--- a/packages/ui/src/components/shogi-match/hooks/useMoveExecution.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useMoveExecution.ts
@@ -2,7 +2,6 @@ import {
     applyMoveWithState,
     getPositionService,
     type LastMove,
-    type MoveSearchStats,
     type PieceType,
     type Player,
     type PositionState,
@@ -167,16 +166,11 @@ export function useMoveExecution({
     };
 
     // 対局モードで手を適用する
-    const applyMoveCommon = (
-        nextPosition: PositionState,
-        mv: string,
-        last?: LastMove,
-        searchStats?: MoveSearchStats,
-    ) => {
+    const applyMoveCommon = (nextPosition: PositionState, mv: string, last?: LastMove) => {
         // 消費時間を計算
         const elapsedMs = Date.now() - turnStartTimeRef.current;
         // 棋譜ナビゲーションに手を追加（局面更新はonPositionChangeで自動実行）
-        navigation.addMove(mv, nextPosition, { elapsedMs, searchStats });
+        navigation.addMove(mv, nextPosition, { elapsedMs });
         setLastMove(last);
         setSelection(null);
         setMessage(null);

--- a/packages/ui/src/components/shogi-match/hooks/useMoveExecution.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useMoveExecution.ts
@@ -2,6 +2,7 @@ import {
     applyMoveWithState,
     getPositionService,
     type LastMove,
+    type MoveSearchStats,
     type PieceType,
     type Player,
     type PositionState,
@@ -166,11 +167,16 @@ export function useMoveExecution({
     };
 
     // 対局モードで手を適用する
-    const applyMoveCommon = (nextPosition: PositionState, mv: string, last?: LastMove) => {
+    const applyMoveCommon = (
+        nextPosition: PositionState,
+        mv: string,
+        last?: LastMove,
+        searchStats?: MoveSearchStats,
+    ) => {
         // 消費時間を計算
         const elapsedMs = Date.now() - turnStartTimeRef.current;
         // 棋譜ナビゲーションに手を追加（局面更新はonPositionChangeで自動実行）
-        navigation.addMove(mv, nextPosition, { elapsedMs });
+        navigation.addMove(mv, nextPosition, { elapsedMs, searchStats });
         setLastMove(last);
         setSelection(null);
         setMessage(null);

--- a/packages/ui/src/components/shogi-match/layouts/MobileLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/MobileLayout.tsx
@@ -643,6 +643,7 @@ export function MobileLayout({
                     onImportSfen={onImportSfen}
                     onImportKif={onImportKif}
                     positionReady={positionReady}
+                    onExportJsonl={navigation.handleExportJsonl}
                 />
             </BottomSheet>
 

--- a/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/PCLayout.tsx
@@ -296,6 +296,20 @@ export function PCLayout({
                         <label className="flex items-center gap-3 text-sm cursor-pointer">
                             <input
                                 type="checkbox"
+                                checked={navDisplaySettings.showSearchInfo}
+                                onChange={(e) =>
+                                    setDisplaySettings({
+                                        ...navDisplaySettings,
+                                        showSearchInfo: e.target.checked,
+                                    })
+                                }
+                                className="w-4 h-4"
+                            />
+                            <span>探索情報 (NPS/深さ) を表示</span>
+                        </label>
+                        <label className="flex items-center gap-3 text-sm cursor-pointer">
+                            <input
+                                type="checkbox"
                                 checked={navDisplaySettings.enableWheelNavigation}
                                 onChange={(e) =>
                                     setDisplaySettings({

--- a/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
+++ b/packages/ui/src/components/shogi-match/layouts/ShogiMatchLayout.tsx
@@ -186,6 +186,7 @@ export function ShogiMatchLayout({
         setDisplaySettings,
         handlePlySelect,
         handleCopyKif,
+        handleExportJsonl,
         handleMoveDetailSelect,
     } = navigationProps;
 
@@ -337,6 +338,7 @@ export function ShogiMatchLayout({
                     isNnueListLoading={isNnueListLoading}
                     presets={presetConfigs}
                     kifuTree={kifuTree}
+                    showSearchInfo={displaySettings.showSearchInfo}
                     onClose={() => setSelectedMoveDetailPly(null)}
                     isOnMainLine={navigationState.isOnMainLine}
                 />
@@ -459,6 +461,7 @@ export function ShogiMatchLayout({
                                 onDisplaySettingsChange={setDisplaySettings}
                                 handlePlySelect={handlePlySelect}
                                 handleCopyKif={handleCopyKif}
+                                handleExportJsonl={handleExportJsonl}
                                 handleMoveDetailSelect={handleMoveDetailSelect}
                                 isMatchRunning={isMatchRunning}
                             >
@@ -592,6 +595,7 @@ export function ShogiMatchLayout({
                                 onDisplaySettingsChange={setDisplaySettings}
                                 handlePlySelect={handlePlySelect}
                                 handleCopyKif={handleCopyKif}
+                                handleExportJsonl={handleExportJsonl}
                                 handleMoveDetailSelect={handleMoveDetailSelect}
                                 isMatchRunning={isMatchRunning}
                             >

--- a/packages/ui/src/components/shogi-match/types.ts
+++ b/packages/ui/src/components/shogi-match/types.ts
@@ -43,6 +43,8 @@ export interface DisplaySettings {
     highlightLastMove: boolean;
     /** 棋譜パネルに評価値を表示 */
     showKifuEval: boolean;
+    /** 対局エンジンの探索情報を表示 */
+    showSearchInfo: boolean;
     /** マウスホイールで棋譜をナビゲート */
     enableWheelNavigation: boolean;
     /** サウンドフィードバック */
@@ -55,6 +57,7 @@ export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
     showBoardLabels: true,
     highlightLastMove: true,
     showKifuEval: false,
+    showSearchInfo: false,
     enableWheelNavigation: true,
     enableSound: true,
 };

--- a/packages/ui/src/components/shogi-match/types/layoutProps.ts
+++ b/packages/ui/src/components/shogi-match/types/layoutProps.ts
@@ -186,6 +186,7 @@ export interface NavigationProps {
     setDisplaySettings: import("react").Dispatch<import("react").SetStateAction<DisplaySettings>>;
     handlePlySelect: (ply: number) => void;
     handleCopyKif: () => string;
+    handleExportJsonl: () => Promise<void>;
     handleMoveDetailSelect: (
         move: import("../utils/kifFormat").KifMove | null,
         position: PositionState | null,

--- a/packages/ui/src/components/shogi-match/utils/jsonlExport.test.ts
+++ b/packages/ui/src/components/shogi-match/utils/jsonlExport.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { exportToRshogiJsonl } from "./jsonlExport";
+
+const meta = {
+    timestamp: new Date("2026-01-02T03:04:05.000Z"),
+    output: "game.jsonl",
+    startSfen: "startpos",
+    maxMoves: 256,
+    byoyomiMs: 1000,
+    mainTimeMs: 0,
+    threads: 2,
+    hashMb: 64,
+    labels: { sente: "engine", gote: "human" },
+} as const;
+
+describe("exportToRshogiJsonl", () => {
+    it("meta、move、result を互換キーで出力する", () => {
+        const lines = exportToRshogiJsonl(
+            [
+                {
+                    moveUsi: "7g7f",
+                    sfenBefore: "sfen-0",
+                    sideToMove: "sente" as const,
+                    elapsedMs: 120,
+                    searchStats: {
+                        scoreCp: 30,
+                        depth: 12,
+                        nodes: 500,
+                        pv: ["7g7f"],
+                        thinkLimitMs: 1000,
+                        engineId: "engine",
+                    },
+                },
+            ],
+            { ...meta, result: { outcome: "black_win", reason: "resignation", winner: "sente" } },
+        )
+            .split("\n")
+            .map((line) => JSON.parse(line));
+        expect(lines[0].settings.btime).toBeUndefined();
+        expect(lines[0].start_positions).toEqual(["position startpos"]);
+        expect(lines[1]).toMatchObject({
+            ply: 1,
+            side_to_move: "b",
+            eval: { score_cp: 30, depth: 12 },
+        });
+        expect(lines[2]).toMatchObject({ outcome: "black_win", plies: 1, winner: "engine" });
+    });
+
+    it("探索値のない人間の手では eval キーを省略する", () => {
+        const line = exportToRshogiJsonl(
+            [
+                {
+                    moveUsi: "7g7f",
+                    sfenBefore: "sfen-0",
+                    sideToMove: "sente" as const,
+                    elapsedMs: 20,
+                },
+            ],
+            meta,
+        )
+            .split("\n")
+            .map((entry) => JSON.parse(entry))[1];
+        expect(line.eval).toBeUndefined();
+    });
+});

--- a/packages/ui/src/components/shogi-match/utils/jsonlExport.ts
+++ b/packages/ui/src/components/shogi-match/utils/jsonlExport.ts
@@ -1,0 +1,103 @@
+import type { MoveSearchStats, Player } from "@shogi/app-core";
+
+interface JsonlMoveNode {
+    moveUsi: string;
+    sfenBefore: string;
+    /** この手を指した側。開始局面が後手番の場合があるため偶奇では決めない */
+    sideToMove: Player;
+    elapsedMs?: number;
+    searchStats?: MoveSearchStats;
+}
+
+interface JsonlExportMeta {
+    timestamp?: Date;
+    output: string;
+    startSfen: string;
+    maxMoves: number;
+    byoyomiMs: number;
+    mainTimeMs: number;
+    threads: number;
+    hashMb: number;
+    labels: Record<Player, string>;
+    result?: {
+        outcome: "black_win" | "white_win" | "draw";
+        reason: string;
+        winner?: Player;
+    };
+}
+
+const compactEval = (stats: MoveSearchStats | undefined): Record<string, unknown> | undefined => {
+    if (!stats) return undefined;
+    const values = {
+        score_cp: stats.scoreCp,
+        score_mate: stats.scoreMate,
+        depth: stats.depth,
+        seldepth: stats.seldepth,
+        nodes: stats.nodes,
+        time_ms: stats.timeMs,
+        nps: stats.nps,
+        pv: stats.pv,
+    };
+    const entries = Object.entries(values).filter(([, value]) => value !== undefined);
+    return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+};
+
+export function exportToRshogiJsonl(nodes: JsonlMoveNode[], meta: JsonlExportMeta): string {
+    const settings: Record<string, number> = {
+        games: 1,
+        max_moves: meta.maxMoves,
+        byoyomi: meta.byoyomiMs,
+        threads: meta.threads,
+        hash_mb: meta.hashMb,
+    };
+    if (meta.mainTimeMs > 0) settings.btime = meta.mainTimeMs;
+    const lines: unknown[] = [
+        {
+            type: "meta",
+            timestamp: (meta.timestamp ?? new Date()).toISOString(),
+            settings,
+            engine_cmd: {
+                path_black: meta.labels.sente,
+                path_white: meta.labels.gote,
+                label_black: meta.labels.sente,
+                label_white: meta.labels.gote,
+                usi_options_black: [],
+                usi_options_white: [],
+            },
+            start_positions: [
+                meta.startSfen === "startpos"
+                    ? "position startpos"
+                    : `position sfen ${meta.startSfen}`,
+            ],
+            output: meta.output,
+        },
+        ...nodes.map((node, index) => {
+            const stats = node.searchStats;
+            const evalEntry = compactEval(stats);
+            return {
+                type: "move",
+                game_id: 1,
+                ply: index + 1,
+                side_to_move: node.sideToMove === "sente" ? "b" : "w",
+                sfen_before: node.sfenBefore,
+                move_usi: node.moveUsi,
+                engine: stats?.engineId ?? meta.labels[node.sideToMove],
+                elapsed_ms: node.elapsedMs ?? 0,
+                think_limit_ms: stats?.thinkLimitMs ?? 0,
+                timed_out: false,
+                ...(evalEntry ? { eval: evalEntry } : {}),
+            };
+        }),
+    ];
+    if (meta.result) {
+        lines.push({
+            type: "result",
+            game_id: 1,
+            outcome: meta.result.outcome,
+            reason: meta.result.reason,
+            plies: nodes.length,
+            ...(meta.result.winner ? { winner: meta.labels[meta.result.winner] } : {}),
+        });
+    }
+    return lines.map((line) => JSON.stringify(line)).join("\n");
+}

--- a/packages/ui/src/components/shogi-match/utils/jsonlExport.ts
+++ b/packages/ui/src/components/shogi-match/utils/jsonlExport.ts
@@ -81,7 +81,7 @@ export function exportToRshogiJsonl(nodes: JsonlMoveNode[], meta: JsonlExportMet
                 side_to_move: node.sideToMove === "sente" ? "b" : "w",
                 sfen_before: node.sfenBefore,
                 move_usi: node.moveUsi,
-                engine: stats?.engineId ?? meta.labels[node.sideToMove],
+                engine: meta.labels[node.sideToMove],
                 elapsed_ms: node.elapsedMs ?? 0,
                 think_limit_ms: stats?.thinkLimitMs ?? 0,
                 timed_out: false,


### PR DESCRIPTION
## 概要

対局エンジンの探索詳細を「ユーザーの意志で ON/OFF できる形」で UI に出し、内部的には rshogi トーナメントツールの JSONL `move` 行相当を網羅保持する。

## 変更内容

**内部保持 (JSONL 相当)**
- `KifuNode.searchStats` (`MoveSearchStats`: depth / seldepth / scoreCp / scoreMate / nodes / nps / timeMs / hashfull / multipv / pv / thinkLimitMs / engineId) を追加
- controller が対局中の info イベントを side ごとに last-wins で累積し、bestmove 時に `onSearchComplete(ply, stats)` で確定 (`go` に渡した思考上限 ms を含む)。エンジン手の `addMove` 時にノードへ格納
- 既存の `KifuEval` / `onEvalUpdate` (グラフ・棋譜評価値) は無変更

**UI 表示トグル**
- 表示設定「探索情報 (NPS/深さ) を表示」を追加 (デフォルト **OFF** — 対 AI 戦では従来どおり隠れる。localStorage 永続化)
- ON のとき: 思考中エンジンのライブパネル (`SearchInfoPanel`、info 全件を `onLiveInfo` で受け 250ms trailing スロットル。深さ/選択深さ/評価値/nodes/NPS/時間/hashfull/PV) と、手詳細ウィンドウの探索統計 (現在経路優先でノード解決)
- 残留対策: 対局停止 (`isMatchRunning=false`) と fatal エンジンエラー (`engineStatus === "error"`) の両方でパネル・スロットルタイマー・未消費統計をクリアし、受信・描画の両方をゲート。モバイルでは右下 FAB と重ならない位置にオフセット

**棋譜への時間出力**
- KIF は既存の `( 0:05/00:00:05)` 出力を維持 (対局中の壁時計計測 `elapsedMs` は人間・エンジン共通で従来から保存済み)
- `movesToCsa` に optional の消費秒を追加し T 行を出力 (未指定時の出力は従来と同一)

**JSONL エクスポート (研究用)**
- rshogi 互換 (meta / move / result、eval キー省略規則含む) の JSONL を生成してダウンロードする導線を PC / モバイルに追加
- `sfen_before` と手番はツリー主分岐の親ノード `positionAfter` から導出 (ナビゲーション位置・後手番開始局面に依存しない)

## 制約 (既知)

- JSONL の `hash_mb` は UI 設定に無いため 0、`byoyomi` は先後の max、`timed_out` は常に false
- スナップショット / KIF インポートでは searchStats は復元されない (セッション内保持)

## テスト・レビュー

- app-core 158 / app-controller 25 / ui 413 全 green (searchStats 保持・last-wins 累積・CSA T 行・JSONL 省略規則の新規テスト含む)、typecheck / lint / knip clean
- 実装は Codex (codex exec)、レビューは Codex + Claude の 2 独立レビューで反復し両者 APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQTCoUvUVbujyGyZLb77su
