### PR TITLE
feat(web,match-client): rshogi棋譜一覧に検索機能を追加

### DIFF
--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchRshogiGameList = vi.fn();
+const fetchRshogiGameSearch = vi.fn();
+const navigate = vi.fn();
+
+vi.mock("@shogi/match-client", () => ({
+    fetchRshogiGameList,
+    fetchRshogiGameSearch,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+    Link: ({ children }: { children: ReactNode }) => <a href="/live">{children}</a>,
+    useNavigate: () => navigate,
+}));
+
+vi.mock("@shogi/ui/components/rshogi-csa-game-list", () => ({
+    RshogiCsaGameList: ({
+        games,
+        onLoadMore,
+        hasMore,
+    }: {
+        games: { gameId: string }[];
+        onLoadMore?: () => void;
+        hasMore?: boolean;
+    }) => (
+        <div>
+            <span data-testid="game-ids">{games.map((game) => game.gameId).join(",")}</span>
+            {hasMore && onLoadMore && (
+                <button type="button" onClick={onLoadMore}>
+                    もっと読み込む
+                </button>
+            )}
+        </div>
+    ),
+}));
+
+vi.mock("../../components/HeaderNav", () => ({ HeaderNav: () => null }));
+vi.mock("../../components/PageHeader", () => ({ PageHeader: () => null }));
+vi.mock("../../components/PageContainer", () => ({
+    PageContainer: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+vi.mock("../../components/PageHeading", () => ({
+    PageHeading: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../../components/StatusBanner", () => ({
+    StatusBanner: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const { default: RshogiViewerListPage } = await import("./RshogiViewerListPage");
+
+describe("RshogiViewerListPage search", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchRshogiGameList.mockResolvedValue({
+            games: [{ gameId: "recent-1" }],
+            nextCursor: "cursor-2",
+        });
+        fetchRshogiGameSearch.mockResolvedValue({
+            games: [{ gameId: "search-1" }],
+            page: 1,
+            pageSize: 20,
+            totalCount: 23,
+        });
+    });
+
+    it("条件入力と検索実行で検索結果とページ番号方式へ切り替える", async () => {
+        render(<RshogiViewerListPage />);
+        await screen.findByText("もっと読み込む");
+
+        fireEvent.change(screen.getByLabelText("選手名"), { target: { value: "RAMU" } });
+        fireEvent.click(screen.getByRole("button", { name: "検索" }));
+
+        await waitFor(() => expect(fetchRshogiGameSearch).toHaveBeenCalledTimes(1));
+        expect(fetchRshogiGameSearch).toHaveBeenCalledWith(
+            expect.objectContaining({ name: "RAMU", page: 1, pageSize: 20 }),
+        );
+        expect(await screen.findByText("23件中 1-20件")).toBeTruthy();
+        expect(screen.getByTestId("game-ids").textContent).toBe("search-1");
+        expect(screen.queryByText("もっと読み込む")).toBeNull();
+        expect(screen.getByRole("button", { name: "前へ" })).toBeTruthy();
+        expect(screen.getByRole("button", { name: "次へ" })).toBeTruthy();
+    });
+
+    it("入力中の条件と実行済み条件を分離して次ページと前ページを取得する", async () => {
+        fetchRshogiGameSearch
+            .mockResolvedValueOnce({
+                games: [{ gameId: "search-1" }],
+                page: 1,
+                pageSize: 20,
+                totalCount: 23,
+            })
+            .mockResolvedValueOnce({
+                games: [{ gameId: "search-2" }],
+                page: 2,
+                pageSize: 20,
+                totalCount: 23,
+            })
+            .mockResolvedValueOnce({
+                games: [{ gameId: "search-1-returned" }],
+                page: 1,
+                pageSize: 20,
+                totalCount: 23,
+            });
+
+        render(<RshogiViewerListPage />);
+        await screen.findByText("もっと読み込む");
+
+        fireEvent.change(screen.getByLabelText("選手名"), { target: { value: "RAMU" } });
+        fireEvent.click(screen.getByRole("button", { name: "検索" }));
+        await screen.findByText("23件中 1-20件");
+
+        fireEvent.change(screen.getByLabelText("選手名"), { target: { value: "OTHER" } });
+        fireEvent.click(screen.getByRole("button", { name: "次へ" }));
+
+        await waitFor(() => expect(fetchRshogiGameSearch).toHaveBeenCalledTimes(2));
+        expect(fetchRshogiGameSearch).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ name: "RAMU", page: 2, pageSize: 20 }),
+        );
+        expect(await screen.findByText("23件中 21-23件")).toBeTruthy();
+        expect(screen.getByTestId("game-ids").textContent).toBe("search-2");
+
+        fireEvent.click(screen.getByRole("button", { name: "前へ" }));
+
+        await waitFor(() => expect(fetchRshogiGameSearch).toHaveBeenCalledTimes(3));
+        expect(fetchRshogiGameSearch).toHaveBeenNthCalledWith(
+            3,
+            expect.objectContaining({ name: "RAMU", page: 1, pageSize: 20 }),
+        );
+        expect(await screen.findByText("23件中 1-20件")).toBeTruthy();
+        expect(screen.getByTestId("game-ids").textContent).toBe("search-1-returned");
+        expect((screen.getByLabelText("選手名") as HTMLInputElement).value).toBe("OTHER");
+    });
+
+    it("クリアで検索条件とpaginationを消し、cursor一覧へ戻る", async () => {
+        render(<RshogiViewerListPage />);
+        await screen.findByText("もっと読み込む");
+        fireEvent.change(screen.getByLabelText("選手名"), { target: { value: "RAMU" } });
+        fireEvent.click(screen.getByRole("button", { name: "検索" }));
+        await screen.findByText("23件中 1-20件");
+
+        fireEvent.click(screen.getByRole("button", { name: "クリア" }));
+
+        expect((screen.getByLabelText("選手名") as HTMLInputElement).value).toBe("");
+        expect(screen.queryByText("23件中 1-20件")).toBeNull();
+        expect(screen.getByText("もっと読み込む")).toBeTruthy();
+        expect(screen.getByTestId("game-ids").textContent).toBe("recent-1");
+    });
+});

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.test.tsx
@@ -84,6 +84,18 @@ describe("RshogiViewerListPage search", () => {
         expect(screen.getByRole("button", { name: "次へ" })).toBeTruthy();
     });
 
+    it("検索リクエストが失敗した場合にエラーバナーを表示する", async () => {
+        fetchRshogiGameSearch.mockRejectedValueOnce(new Error("ネットワークエラー"));
+
+        render(<RshogiViewerListPage />);
+        await screen.findByText("もっと読み込む");
+
+        fireEvent.change(screen.getByLabelText("選手名"), { target: { value: "RAMU" } });
+        fireEvent.click(screen.getByRole("button", { name: "検索" }));
+
+        expect(await screen.findByText("ネットワークエラー")).toBeTruthy();
+    });
+
     it("入力中の条件と実行済み条件を分離して次ページと前ページを取得する", async () => {
         fetchRshogiGameSearch
             .mockResolvedValueOnce({

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -1,8 +1,14 @@
-import type { RshogiGameSummary } from "@shogi/match-client";
-import { fetchRshogiGameList } from "@shogi/match-client";
+import type {
+    FetchRshogiGameSearchOptions,
+    RshogiGameResultKind,
+    RshogiGameSearchPage,
+    RshogiGameSummary,
+} from "@shogi/match-client";
+import { fetchRshogiGameList, fetchRshogiGameSearch } from "@shogi/match-client";
+import { Input } from "@shogi/ui/components/input";
 import { RshogiCsaGameList } from "@shogi/ui/components/rshogi-csa-game-list";
 import { Link, useNavigate } from "@tanstack/react-router";
-import { type ReactElement, useEffect, useState } from "react";
+import { type FormEvent, type ReactElement, useEffect, useRef, useState } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
@@ -10,6 +16,58 @@ import { PageHeading } from "../../components/PageHeading";
 import { StatusBanner } from "../../components/StatusBanner";
 
 const PAGE_LIMIT = 50;
+const SEARCH_PAGE_SIZE = 20;
+
+interface SearchFormValues {
+    name: string;
+    result: "" | RshogiGameResultKind;
+    from: string;
+    to: string;
+    source: string;
+}
+
+const EMPTY_SEARCH_FORM: SearchFormValues = {
+    name: "",
+    result: "",
+    from: "",
+    to: "",
+    source: "",
+};
+
+const RESULT_OPTIONS: { value: RshogiGameResultKind; label: string }[] = [
+    { value: "resignation", label: "投了" },
+    { value: "time_expired", label: "時間切れ" },
+    { value: "draw", label: "千日手" },
+    { value: "jishogi", label: "入玉勝ち" },
+    { value: "oute_sennichite", label: "連続王手千日手" },
+    { value: "abort", label: "中断" },
+    { value: "max_moves", label: "最大手数" },
+    { value: "abnormal", label: "異常終了" },
+];
+
+const hasSearchCondition = (values: SearchFormValues): boolean =>
+    Object.values(values).some((value) => value.trim().length > 0);
+
+const dateStartMs = (value: string): number | undefined => {
+    if (!value) return undefined;
+    const date = new Date(`${value}T00:00:00`);
+    return Number.isNaN(date.getTime()) ? undefined : date.getTime();
+};
+
+const dateEndMs = (value: string): number | undefined => {
+    if (!value) return undefined;
+    const [year, month, day] = value.split("-").map(Number);
+    const nextDay = new Date(year, month - 1, day + 1);
+    return Number.isNaN(nextDay.getTime()) ? undefined : nextDay.getTime() - 1;
+};
+
+const toSearchOptions = (values: SearchFormValues): FetchRshogiGameSearchOptions => ({
+    name: values.name.trim() || undefined,
+    result: values.result || undefined,
+    source: values.source.trim() || undefined,
+    from: dateStartMs(values.from),
+    to: dateEndMs(values.to),
+});
 
 const resolveApiBaseUrl = (): string | undefined => {
     const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
@@ -24,6 +82,11 @@ export default function RshogiViewerListPage(): ReactElement {
     const [nextCursor, setNextCursor] = useState<string | undefined>(undefined);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [searchForm, setSearchForm] = useState<SearchFormValues>(EMPTY_SEARCH_FORM);
+    const [appliedSearch, setAppliedSearch] = useState<FetchRshogiGameSearchOptions | null>(null);
+    const [searchPage, setSearchPage] = useState<RshogiGameSearchPage | null>(null);
+    const [isSearchLoading, setIsSearchLoading] = useState(false);
+    const searchControllerRef = useRef<AbortController | null>(null);
 
     // 初回ロード
     useEffect(() => {
@@ -53,6 +116,7 @@ export default function RshogiViewerListPage(): ReactElement {
         })();
         return () => {
             controller.abort();
+            searchControllerRef.current?.abort();
         };
     }, [apiBaseUrl]);
 
@@ -84,6 +148,68 @@ export default function RshogiViewerListPage(): ReactElement {
         void navigate({ to: "/rshogi-viewer/$gameId", params: { gameId } });
     };
 
+    const runSearch = async (
+        conditions: FetchRshogiGameSearchOptions,
+        page: number,
+    ): Promise<void> => {
+        searchControllerRef.current?.abort();
+        const controller = new AbortController();
+        searchControllerRef.current = controller;
+        setIsSearchLoading(true);
+        setErrorMessage(null);
+        try {
+            const result = await fetchRshogiGameSearch({
+                ...conditions,
+                baseUrl: apiBaseUrl,
+                page,
+                pageSize: SEARCH_PAGE_SIZE,
+                signal: controller.signal,
+            });
+            if (!controller.signal.aborted) setSearchPage(result);
+        } catch (error) {
+            if (controller.signal.aborted) return;
+            setErrorMessage(
+                error instanceof Error ? error.message : `棋譜検索に失敗しました: ${String(error)}`,
+            );
+        } finally {
+            if (!controller.signal.aborted) setIsSearchLoading(false);
+        }
+    };
+
+    const handleSearch = (event: FormEvent<HTMLFormElement>): void => {
+        event.preventDefault();
+        if (!hasSearchCondition(searchForm)) return;
+        const conditions = toSearchOptions(searchForm);
+        setAppliedSearch(conditions);
+        setSearchPage(null);
+        void runSearch(conditions, 1);
+    };
+
+    const handleClear = (): void => {
+        searchControllerRef.current?.abort();
+        searchControllerRef.current = null;
+        setSearchForm(EMPTY_SEARCH_FORM);
+        setAppliedSearch(null);
+        setSearchPage(null);
+        setIsSearchLoading(false);
+        setErrorMessage(null);
+    };
+
+    const handleSearchPage = (page: number): void => {
+        if (!appliedSearch || isSearchLoading) return;
+        void runSearch(appliedSearch, page);
+    };
+
+    const isSearchMode = appliedSearch !== null;
+    const displayedGames = isSearchMode ? (searchPage?.games ?? []) : games;
+    const rangeStart =
+        searchPage && searchPage.totalCount > 0
+            ? (searchPage.page - 1) * searchPage.pageSize + 1
+            : 0;
+    const rangeEnd = searchPage
+        ? Math.min(searchPage.page * searchPage.pageSize, searchPage.totalCount)
+        : 0;
+
     return (
         <>
             <PageHeader
@@ -103,15 +229,156 @@ export default function RshogiViewerListPage(): ReactElement {
                     </Link>
                 </PageHeading>
 
+                <form
+                    onSubmit={handleSearch}
+                    className="mb-4 rounded-lg border border-wafuu-border bg-wafuu-washi-warm p-4"
+                    aria-label="棋譜検索"
+                >
+                    <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-5">
+                        <label
+                            htmlFor="rshogi-search-name"
+                            className="flex flex-col gap-1 text-sm text-wafuu-sumi"
+                        >
+                            選手名
+                            <Input
+                                id="rshogi-search-name"
+                                value={searchForm.name}
+                                onChange={(event) =>
+                                    setSearchForm({ ...searchForm, name: event.target.value })
+                                }
+                                placeholder="先手または後手"
+                            />
+                        </label>
+                        <label
+                            htmlFor="rshogi-search-result"
+                            className="flex flex-col gap-1 text-sm text-wafuu-sumi"
+                        >
+                            結果
+                            <select
+                                id="rshogi-search-result"
+                                value={searchForm.result}
+                                onChange={(event) =>
+                                    setSearchForm({
+                                        ...searchForm,
+                                        result: event.target.value as SearchFormValues["result"],
+                                    })
+                                }
+                                className="h-10 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                            >
+                                <option value="">すべて</option>
+                                {RESULT_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                        <label
+                            htmlFor="rshogi-search-from"
+                            className="flex flex-col gap-1 text-sm text-wafuu-sumi"
+                        >
+                            終了日（開始）
+                            <Input
+                                id="rshogi-search-from"
+                                type="date"
+                                value={searchForm.from}
+                                onChange={(event) =>
+                                    setSearchForm({ ...searchForm, from: event.target.value })
+                                }
+                            />
+                        </label>
+                        <label
+                            htmlFor="rshogi-search-to"
+                            className="flex flex-col gap-1 text-sm text-wafuu-sumi"
+                        >
+                            終了日（終了）
+                            <Input
+                                id="rshogi-search-to"
+                                type="date"
+                                value={searchForm.to}
+                                min={searchForm.from || undefined}
+                                onChange={(event) =>
+                                    setSearchForm({ ...searchForm, to: event.target.value })
+                                }
+                            />
+                        </label>
+                        <label
+                            htmlFor="rshogi-search-source"
+                            className="flex flex-col gap-1 text-sm text-wafuu-sumi"
+                        >
+                            source
+                            <select
+                                id="rshogi-search-source"
+                                value={searchForm.source}
+                                onChange={(event) =>
+                                    setSearchForm({ ...searchForm, source: event.target.value })
+                                }
+                                className="h-10 rounded-md border border-input bg-background px-3 text-sm text-foreground"
+                            >
+                                <option value="">すべて</option>
+                                <option value="kifu">kifu</option>
+                                <option value="floodgate">floodgate</option>
+                            </select>
+                        </label>
+                    </div>
+                    <div className="mt-3 flex flex-wrap justify-end gap-2">
+                        <button
+                            type="button"
+                            onClick={handleClear}
+                            disabled={!hasSearchCondition(searchForm) && !isSearchMode}
+                            className="rounded-md border border-wafuu-border px-4 py-2 text-sm text-wafuu-sumi disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            クリア
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={!hasSearchCondition(searchForm) || isSearchLoading}
+                            className="rounded-md bg-wafuu-shu px-4 py-2 text-sm text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                        >
+                            {isSearchLoading ? "検索中..." : "検索"}
+                        </button>
+                    </div>
+                </form>
+
                 {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
 
                 <RshogiCsaGameList
-                    games={games}
+                    games={displayedGames}
                     onSelect={handleSelect}
-                    onLoadMore={() => void handleLoadMore()}
-                    isLoading={isLoading}
-                    hasMore={nextCursor !== undefined}
+                    onLoadMore={isSearchMode ? undefined : () => void handleLoadMore()}
+                    isLoading={isSearchMode ? isSearchLoading : isLoading}
+                    hasMore={!isSearchMode && nextCursor !== undefined}
+                    emptyMessage={isSearchMode ? "検索条件に一致する棋譜はありません。" : undefined}
                 />
+
+                {isSearchMode && searchPage && (
+                    <nav
+                        className="mt-4 flex flex-wrap items-center justify-between gap-3"
+                        aria-label="検索結果のページネーション"
+                    >
+                        <span className="text-sm text-muted-foreground">
+                            {searchPage.totalCount}件中 {rangeStart}-{rangeEnd}件
+                        </span>
+                        <div className="flex gap-2">
+                            <button
+                                type="button"
+                                onClick={() => handleSearchPage(searchPage.page - 1)}
+                                disabled={searchPage.page <= 1 || isSearchLoading}
+                                className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                前へ
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => handleSearchPage(searchPage.page + 1)}
+                                disabled={rangeEnd >= searchPage.totalCount || isSearchLoading}
+                                className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                次へ
+                            </button>
+                        </div>
+                    </nav>
+                )}
             </PageContainer>
         </>
     );

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -2,6 +2,7 @@ import type {
     FetchRshogiGameSearchOptions,
     RshogiGameResultKind,
     RshogiGameSearchPage,
+    RshogiGameSource,
     RshogiGameSummary,
 } from "@shogi/match-client";
 import { fetchRshogiGameList, fetchRshogiGameSearch } from "@shogi/match-client";
@@ -23,7 +24,7 @@ interface SearchFormValues {
     result: "" | RshogiGameResultKind;
     from: string;
     to: string;
-    source: string;
+    source: RshogiGameSource | "";
 }
 
 const EMPTY_SEARCH_FORM: SearchFormValues = {
@@ -64,7 +65,7 @@ const dateEndMs = (value: string): number | undefined => {
 const toSearchOptions = (values: SearchFormValues): FetchRshogiGameSearchOptions => ({
     name: values.name.trim() || undefined,
     result: values.result || undefined,
-    source: values.source.trim() || undefined,
+    source: values.source || undefined,
     from: dateStartMs(values.from),
     to: dateEndMs(values.to),
 });
@@ -311,7 +312,10 @@ export default function RshogiViewerListPage(): ReactElement {
                                 id="rshogi-search-source"
                                 value={searchForm.source}
                                 onChange={(event) =>
-                                    setSearchForm({ ...searchForm, source: event.target.value })
+                                    setSearchForm({
+                                        ...searchForm,
+                                        source: event.target.value as SearchFormValues["source"],
+                                    })
                                 }
                                 className="h-10 rounded-md border border-input bg-background px-3 text-sm text-foreground"
                             >
@@ -356,7 +360,7 @@ export default function RshogiViewerListPage(): ReactElement {
                         className="mt-4 flex flex-wrap items-center justify-between gap-3"
                         aria-label="検索結果のページネーション"
                     >
-                        <span className="text-sm text-muted-foreground">
+                        <span className="text-sm text-muted-foreground" aria-live="polite">
                             {searchPage.totalCount}件中 {rangeStart}-{rangeEnd}件
                         </span>
                         <div className="flex gap-2">

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -48,6 +48,7 @@ export {
 export type {
     FetchRshogiGameListOptions,
     FetchRshogiGameOptions,
+    FetchRshogiGameSearchOptions,
     FetchRshogiLiveGameListOptions,
     RshogiClockKind,
     RshogiEndReason,
@@ -56,6 +57,7 @@ export type {
     RshogiGameMeta,
     RshogiGameResult,
     RshogiGameResultKind,
+    RshogiGameSearchPage,
     RshogiGameSource,
     RshogiGameSummary,
     RshogiLiveGameListPage,
@@ -65,6 +67,7 @@ export type {
 export {
     fetchRshogiGame,
     fetchRshogiGameList,
+    fetchRshogiGameSearch,
     fetchRshogiLiveGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -2,11 +2,88 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     fetchRshogiGame,
     fetchRshogiGameList,
+    fetchRshogiGameSearch,
     fetchRshogiLiveGameList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,
 } from "./client";
+
+describe("fetchRshogiGameSearch (mock fallback)", () => {
+    it("filters by name and paginates the embedded fixtures", async () => {
+        const first = await fetchRshogiGameSearch({ name: "ramu", page: 1, pageSize: 2 });
+        expect(first.games).toHaveLength(2);
+        expect(first.totalCount).toBeGreaterThan(2);
+        expect(first.page).toBe(1);
+        expect(first.pageSize).toBe(2);
+
+        const second = await fetchRshogiGameSearch({ name: "ramu", page: 2, pageSize: 2 });
+        expect(second.games[0].gameId).not.toBe(first.games[0].gameId);
+    });
+});
+
+describe("fetchRshogiGameSearch (real baseUrl)", () => {
+    it("builds all query parameters and decodes the search page", async () => {
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(
+                    JSON.stringify({
+                        games: [
+                            {
+                                game_id: "searched-1",
+                                black_handle: "Alice",
+                                white_handle: "Bob",
+                                ended_at_ms: 1777392877244,
+                                result_kind: "WIN_BLACK",
+                                end_reason: "RESIGN",
+                                source: "floodgate",
+                            },
+                        ],
+                        page: 2,
+                        page_size: 20,
+                        total_count: 35,
+                    }),
+                    { status: 200 },
+                ),
+        ) as unknown as typeof fetch;
+
+        const result = await fetchRshogiGameSearch({
+            baseUrl: "https://rshogi.example.com/api/v1/",
+            fetchImpl,
+            name: "Alice Bob",
+            result: "resignation",
+            source: "floodgate",
+            from: 1000,
+            to: 2000,
+            page: 2,
+            pageSize: 20,
+        });
+
+        expect(fetchImpl).toHaveBeenCalledWith(
+            "https://rshogi.example.com/api/v1/games/search?name=Alice+Bob&result=resignation&source=floodgate&from=1000&to=2000&page=2&pageSize=20",
+            { signal: undefined },
+        );
+        expect(result).toEqual({
+            games: [
+                expect.objectContaining({
+                    gameId: "searched-1",
+                    senteName: "Alice",
+                    goteName: "Bob",
+                    endedAtMs: 1777392877244,
+                    source: "floodgate",
+                    result: {
+                        kind: "resignation",
+                        winner: "sente",
+                        endReason: "RESIGN",
+                    },
+                }),
+            ],
+            page: 2,
+            pageSize: 20,
+            totalCount: 35,
+        });
+    });
+});
 
 // production code 側は `import.meta.env` → `process.env` の順で読むため、テストでは
 // `vi.stubEnv` で両方を上書きする (Vitest 4 では `vi.stubEnv` が `import.meta.env` と

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -499,7 +499,7 @@ const decodeGameListResponse = (wire: GameListResponseWire): RshogiGameListPage 
 const decodeGameSearchResponse = (wire: GameSearchResponseWire): RshogiGameSearchPage => ({
     games: Array.isArray(wire.games) ? wire.games.map(decodeGameSummary) : [],
     page: wire.page ?? 1,
-    pageSize: wire.page_size ?? 20,
+    pageSize: wire.page_size ?? 20, // server default
     totalCount: wire.total_count ?? 0,
 });
 

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -124,6 +124,13 @@ export interface RshogiGameListPage {
     nextCursor?: string;
 }
 
+export interface RshogiGameSearchPage {
+    games: RshogiGameSummary[];
+    page: number;
+    pageSize: number;
+    totalCount: number;
+}
+
 /**
  * 進行中対局一覧 API (`GET /api/v1/games/live`) の 1 件分。
  *
@@ -168,6 +175,18 @@ export interface FetchRshogiGameListOptions extends FetchRshogiGameOptions {
     cursor?: string;
     /** 1 ページあたり件数 (1〜100、サーバ既定 50)。 */
     limit?: number;
+}
+
+export interface FetchRshogiGameSearchOptions extends FetchRshogiGameOptions {
+    name?: string;
+    result?: RshogiGameResultKind;
+    source?: RshogiGameSource;
+    from?: number;
+    to?: number;
+    /** 1 始まり (サーバ既定 1)。 */
+    page?: number;
+    /** 1 ページあたり件数 (1〜100、サーバ既定 20)。 */
+    pageSize?: number;
 }
 
 export interface FetchRshogiLiveGameListOptions extends FetchRshogiGameOptions {
@@ -288,6 +307,13 @@ interface GameDetailWire extends GameWireBase {
 interface GameListResponseWire {
     games?: GameWireBase[];
     next_cursor?: string | null;
+}
+
+interface GameSearchResponseWire {
+    games?: GameWireBase[];
+    page?: number;
+    page_size?: number;
+    total_count?: number;
 }
 
 /**
@@ -470,6 +496,13 @@ const decodeGameListResponse = (wire: GameListResponseWire): RshogiGameListPage 
     };
 };
 
+const decodeGameSearchResponse = (wire: GameSearchResponseWire): RshogiGameSearchPage => ({
+    games: Array.isArray(wire.games) ? wire.games.map(decodeGameSummary) : [],
+    page: wire.page ?? 1,
+    pageSize: wire.page_size ?? 20,
+    totalCount: wire.total_count ?? 0,
+});
+
 const decodeLiveGameSummary = (wire: LiveGameWireBase): RshogiLiveGameSummary => ({
     gameId: wire.game_id,
     // black=sente, white=gote のマッピング (終局済 decode と対称)。
@@ -580,6 +613,48 @@ export async function fetchRshogiGameList(
     return decodeGameListResponse(payload);
 }
 
+/** rshogi の終局済棋譜を条件検索する (`GET /api/v1/games/search`)。 */
+export async function fetchRshogiGameSearch(
+    options: FetchRshogiGameSearchOptions = {},
+): Promise<RshogiGameSearchPage> {
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) {
+        return mockGameSearchPage(options);
+    }
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError("", "fetch is not available in this environment");
+    }
+
+    const params = new URLSearchParams();
+    const name = options.name?.trim();
+    if (name) params.set("name", name);
+    if (options.result) params.set("result", options.result);
+    if (options.source) params.set("source", options.source);
+    if (options.from !== undefined) params.set("from", String(options.from));
+    if (options.to !== undefined) params.set("to", String(options.to));
+    if (options.page !== undefined) params.set("page", String(options.page));
+    if (options.pageSize !== undefined) params.set("pageSize", String(options.pageSize));
+    const query = params.toString();
+    const url = `${trimTrailingSlash(baseUrl)}/games/search${query ? `?${query}` : ""}`;
+
+    const response = await fetchImpl(url, buildRequestInit(options.signal));
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            "",
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+
+    const payload = (await response.json()) as GameSearchResponseWire | null;
+    if (!payload || !Array.isArray(payload.games)) {
+        throw new RshogiGameFetchError("", "rshogi API response missing games array");
+    }
+    return decodeGameSearchResponse(payload);
+}
+
 /**
  * rshogi の進行中対局一覧 (`GET /api/v1/games/live`) を取得する。
  *
@@ -628,6 +703,7 @@ export async function fetchRshogiLiveGameList(
 
 const DEFAULT_MOCK_LIMIT = 50;
 const MAX_MOCK_LIMIT = 100;
+const DEFAULT_MOCK_SEARCH_PAGE_SIZE = 20;
 
 const mockGameListPage = (
     cursor: string | undefined,
@@ -658,6 +734,37 @@ const mockLiveGameListPage = (
     return {
         liveGames: slice,
         nextCursor: next < list.length ? String(next) : undefined,
+    };
+};
+
+const mockGameSearchPage = (options: FetchRshogiGameSearchOptions): RshogiGameSearchPage => {
+    const name = options.name?.trim().toLocaleLowerCase();
+    const filtered = MOCK_RSHOGI_GAME_LIST.filter((game) => {
+        if (
+            name &&
+            !game.senteName.toLocaleLowerCase().includes(name) &&
+            !game.goteName.toLocaleLowerCase().includes(name)
+        ) {
+            return false;
+        }
+        if (options.result && game.result?.kind !== options.result) return false;
+        if (options.source && game.source !== options.source) return false;
+        if (options.from !== undefined && (game.endedAtMs ?? -Infinity) < options.from)
+            return false;
+        if (options.to !== undefined && (game.endedAtMs ?? Infinity) > options.to) return false;
+        return true;
+    });
+    const page = Math.max(1, options.page ?? 1);
+    const pageSize = Math.min(
+        Math.max(1, options.pageSize ?? DEFAULT_MOCK_SEARCH_PAGE_SIZE),
+        MAX_MOCK_LIMIT,
+    );
+    const start = (page - 1) * pageSize;
+    return {
+        games: filtered.slice(start, start + pageSize),
+        page,
+        pageSize,
+        totalCount: filtered.length,
     };
 };
 


### PR DESCRIPTION
## Summary

- `/rshogi-viewer` 一覧ページに、先手/後手名の部分一致・結果種別・source・終局日時範囲での検索フォームを追加。
- 検索条件を1つも指定していない初期表示は既存のcursorベース無限スクロール(load more)のまま変更なし。検索を実行した場合のみページ番号方式のpagination(前へ/次へ+総件数表示)に切り替え、クリアで元の無限スクロールに戻る。
- `match-client` に `fetchRshogiGameSearch` を追加し、rshogi側の新設エンドポイント `GET /api/v1/games/search` 向けのwire decode層を実装(既存のsnake_case wire → camelCase decode規約を踏襲)。`baseUrl` 未指定時は既存のモックフォールバック方針を踏襲。
- 検索結果種別セレクトからは、このCSAサーバー実装が生成しない到達不能な選択肢(詰み)を除外。
- 進行中対局(live)一覧との統合は今回のスコープ外。

## 関連

- 対応するバックエンドAPI: SH11235/rshogi#923(未マージ、`GET /api/v1/games/search` 新設)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm turbo test`(match-client検索関連テスト・ページの検索/pagination/クリアのシナリオテスト含む)
- [x] `pnpm format:check`
- [x] local reviewer #1 (Codex系) APPROVE
- [x] local reviewer #2 (Claude/Fable系) APPROVE