### PR TITLE
fix(engine-tauri): 外部 USI エンジンの再 init によるセッションリークを解消

### DIFF
--- a/packages/engine-tauri/src/usi-engine-client.test.ts
+++ b/packages/engine-tauri/src/usi-engine-client.test.ts
@@ -79,11 +79,12 @@ describe("createUsiEngineClient", () => {
         // 新セッションを張っていない (start は初回の 1 回のみ)
         expect(invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_start")).toHaveLength(1);
 
-        // sessionId は保持されているため dispose で旧セッションを回収できる
+        // 失敗した quit は 1 回記録済み。dispose が改めて quit することを回数で検証する
+        expect(invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_quit")).toHaveLength(1);
         await client.dispose();
-        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
-            session_id: "session-1",
-        });
+        const quitCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_quit");
+        expect(quitCalls).toHaveLength(2);
+        expect(quitCalls[1]?.[1]).toEqual({ session_id: "session-1" });
     });
 
     it("並行 init は直列化され、片方のセッションがリークしない", async () => {
@@ -95,6 +96,15 @@ describe("createUsiEngineClient", () => {
         expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
             session_id: "session-1",
         });
+
+        // quit は 2 回目の start より先に実行される (直列化の検証)
+        const quitIndex = invokeMock.mock.calls.findIndex(([cmd]) => cmd === "usi_engine_quit");
+        const secondStartIndex = invokeMock.mock.calls.findIndex(
+            ([cmd], index) => cmd === "usi_engine_start" && index > 0,
+        );
+        expect(invokeMock.mock.invocationCallOrder[quitIndex] as number).toBeLessThan(
+            invokeMock.mock.invocationCallOrder[secondStartIndex] as number,
+        );
 
         await client.stop();
         expect(invokeMock).toHaveBeenCalledWith("usi_engine_stop", {
@@ -110,6 +120,25 @@ describe("createUsiEngineClient", () => {
         expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
             session_id: "session-1",
         });
+    });
+
+    it("購読失敗後の quit も失敗したら識別子を保持し dispose で回収できる", async () => {
+        listenMock.mockRejectedValueOnce(new Error("listen failed"));
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        invokeMock.mockImplementation(async (command: string) => {
+            if (command === "usi_engine_start") return "session-1";
+            if (command === "usi_engine_quit") throw new Error("ipc down");
+            return undefined;
+        });
+
+        await expect(client.init()).rejects.toThrow("listen failed");
+
+        // quit の失敗を解消した後、dispose で回収できる
+        invokeMock.mockImplementation(async () => undefined);
+        await client.dispose();
+        const quitCalls = invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_quit");
+        expect(quitCalls[quitCalls.length - 1]?.[1]).toEqual({ session_id: "session-1" });
+        expect(quitCalls).toHaveLength(2);
     });
 
     it("dispose はセッションを quit し購読を解除する", async () => {

--- a/packages/engine-tauri/src/usi-engine-client.test.ts
+++ b/packages/engine-tauri/src/usi-engine-client.test.ts
@@ -125,6 +125,7 @@ describe("createUsiEngineClient", () => {
     it("購読失敗後の quit も失敗したら識別子を保持し dispose で回収できる", async () => {
         listenMock.mockRejectedValueOnce(new Error("listen failed"));
         const client = createUsiEngineClient({ registrationId: "reg-1" });
+        // listen 失敗に加えて quit も失敗させる (init 実行前なので beforeEach の実装を上書きしてよい)
         invokeMock.mockImplementation(async (command: string) => {
             if (command === "usi_engine_start") return "session-1";
             if (command === "usi_engine_quit") throw new Error("ipc down");

--- a/packages/engine-tauri/src/usi-engine-client.test.ts
+++ b/packages/engine-tauri/src/usi-engine-client.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createUsiEngineClient } from "./usi-engine-client";
+
+const { invokeMock, listenMock } = vi.hoisted(() => ({
+    invokeMock: vi.fn(),
+    listenMock: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
+vi.mock("@tauri-apps/api/event", () => ({ listen: listenMock }));
+
+describe("createUsiEngineClient", () => {
+    let unlistenMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        unlistenMock = vi.fn();
+        listenMock.mockResolvedValue(unlistenMock);
+        let session = 0;
+        invokeMock.mockImplementation(async (command: string) => {
+            if (command === "usi_engine_start") {
+                session += 1;
+                return `session-${session}`;
+            }
+            return undefined;
+        });
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("初回 init では quit を呼ばない", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await client.init();
+
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_start", {
+            registration_id: "reg-1",
+        });
+        expect(invokeMock).not.toHaveBeenCalledWith("usi_engine_quit", expect.anything());
+    });
+
+    it("再 init は旧セッションを quit してから新セッションを張る", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await client.init();
+        await client.init();
+
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
+            session_id: "session-1",
+        });
+        expect(unlistenMock).toHaveBeenCalledTimes(1);
+
+        // quit → 2 回目の start の順で実行される
+        const quitOrder = invokeMock.mock.invocationCallOrder[
+            invokeMock.mock.calls.findIndex(([cmd]) => cmd === "usi_engine_quit")
+        ] as number;
+        const secondStartIndex = invokeMock.mock.calls.findIndex(
+            ([cmd], index) => cmd === "usi_engine_start" && index > 0,
+        );
+        expect(quitOrder).toBeLessThan(
+            invokeMock.mock.invocationCallOrder[secondStartIndex] as number,
+        );
+
+        // 新セッションで動作する
+        await client.stop();
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_stop", {
+            session_id: "session-2",
+        });
+    });
+
+    it("dispose はセッションを quit し購読を解除する", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await client.init();
+        await client.dispose();
+
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
+            session_id: "session-1",
+        });
+        expect(unlistenMock).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/engine-tauri/src/usi-engine-client.test.ts
+++ b/packages/engine-tauri/src/usi-engine-client.test.ts
@@ -67,6 +67,51 @@ describe("createUsiEngineClient", () => {
         });
     });
 
+    it("再 init で旧セッションの quit が失敗したら新 start を中止し、後で回収できる", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await client.init();
+
+        invokeMock.mockImplementationOnce(async (command: string) => {
+            if (command === "usi_engine_quit") throw new Error("ipc down");
+            return undefined;
+        });
+        await expect(client.init()).rejects.toThrow("ipc down");
+        // 新セッションを張っていない (start は初回の 1 回のみ)
+        expect(invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_start")).toHaveLength(1);
+
+        // sessionId は保持されているため dispose で旧セッションを回収できる
+        await client.dispose();
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
+            session_id: "session-1",
+        });
+    });
+
+    it("並行 init は直列化され、片方のセッションがリークしない", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await Promise.all([client.init(), client.init()]);
+
+        // 2 回 start され、先行分 (session-1) は quit 済み
+        expect(invokeMock.mock.calls.filter(([cmd]) => cmd === "usi_engine_start")).toHaveLength(2);
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
+            session_id: "session-1",
+        });
+
+        await client.stop();
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_stop", {
+            session_id: "session-2",
+        });
+    });
+
+    it("購読登録に失敗したら起動済みセッションを quit してから失敗する", async () => {
+        listenMock.mockRejectedValueOnce(new Error("listen failed"));
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+
+        await expect(client.init()).rejects.toThrow("listen failed");
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_quit", {
+            session_id: "session-1",
+        });
+    });
+
     it("dispose はセッションを quit し購読を解除する", async () => {
         const client = createUsiEngineClient({ registrationId: "reg-1" });
         await client.init();

--- a/packages/engine-tauri/src/usi-engine-client.ts
+++ b/packages/engine-tauri/src/usi-engine-client.ts
@@ -39,19 +39,41 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
         }
     };
 
-    const closeSession = async (): Promise<void> => {
+    // init / dispose の並行呼び出しでセッションが取りこぼされないよう直列化する
+    let opChain: Promise<unknown> = Promise.resolve();
+    const runExclusive = <T>(fn: () => Promise<T>): Promise<T> => {
+        const run = opChain.then(fn);
+        opChain = run.then(
+            () => undefined,
+            () => undefined,
+        );
+        return run;
+    };
+
+    const dropListener = (): void => {
+        if (!unlisten) return;
+        try {
+            unlisten();
+        } catch {
+            // ignore
+        }
+        unlisten = null;
+    };
+
+    // bestEffort=false では quit の失敗を伝播し、sessionId を保持したまま中断する
+    // (識別子を失うと旧プロセスを回収できなくなるため)。Rust 側の quit は
+    // 存在しない session_id にも Ok を返す冪等実装なので、失敗 = IPC 異常
+    const closeSession = async (bestEffort: boolean): Promise<void> => {
         if (sessionId) {
-            await tauriInvoke("usi_engine_quit", { session_id: sessionId }).catch(() => undefined);
+            const quit = tauriInvoke("usi_engine_quit", { session_id: sessionId });
+            if (bestEffort) {
+                await quit.catch(() => undefined);
+            } else {
+                await quit;
+            }
             sessionId = null;
         }
-        if (unlisten) {
-            try {
-                unlisten();
-            } catch {
-                // ignore
-            }
-            unlisten = null;
-        }
+        dropListener();
     };
 
     return {
@@ -60,18 +82,30 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
         // を優先し、UI の自動解決値で無条件に上書きしない。厳格な USI エンジンは
         // isready 後の setoption を反映しないため、起動後に送っても保証がない
         async init(_opts?: EngineInitOptions): Promise<void> {
-            // 再初期化 (retry / restartForNnue 等) で呼ばれたとき、旧セッションを
-            // quit せずに sessionId を上書きすると外部プロセスがリークする
-            await closeSession();
+            await runExclusive(async () => {
+                // 再初期化 (retry / restartForNnue 等) で呼ばれたとき、旧セッションを
+                // quit せずに sessionId を上書きすると外部プロセスがリークする
+                await closeSession(false);
 
-            sessionId = await tauriInvoke<string>("usi_engine_start", {
-                registration_id: registrationId,
-            });
+                const newSessionId = await tauriInvoke<string>("usi_engine_start", {
+                    registration_id: registrationId,
+                });
 
-            // Subscribe to session-scoped event channel
-            const channel = `engine://usi/${sessionId}`;
-            unlisten = await tauriListen<EngineEvent>(channel, (evt) => {
-                emit(evt.payload);
+                try {
+                    // Subscribe to session-scoped event channel
+                    const channel = `engine://usi/${newSessionId}`;
+                    unlisten = await tauriListen<EngineEvent>(channel, (evt) => {
+                        emit(evt.payload);
+                    });
+                } catch (error) {
+                    // 購読に失敗したまま session を持つと誰もイベントを受け取れない。
+                    // 起動済みプロセスを残さないよう片付けてから失敗させる
+                    await tauriInvoke("usi_engine_quit", { session_id: newSessionId }).catch(
+                        () => undefined,
+                    );
+                    throw error;
+                }
+                sessionId = newSessionId;
             });
         },
 
@@ -143,8 +177,10 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
         },
 
         async dispose(): Promise<void> {
-            await closeSession();
-            listeners.clear();
+            await runExclusive(async () => {
+                await closeSession(true);
+                listeners.clear();
+            });
         },
     };
 }

--- a/packages/engine-tauri/src/usi-engine-client.ts
+++ b/packages/engine-tauri/src/usi-engine-client.ts
@@ -39,12 +39,31 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
         }
     };
 
+    const closeSession = async (): Promise<void> => {
+        if (sessionId) {
+            await tauriInvoke("usi_engine_quit", { session_id: sessionId }).catch(() => undefined);
+            sessionId = null;
+        }
+        if (unlisten) {
+            try {
+                unlisten();
+            } catch {
+                // ignore
+            }
+            unlisten = null;
+        }
+    };
+
     return {
         // opts.threads は意図的に無視する。外部 USI エンジンのスレッド数は
         // エンジン登録時に保存したオプション (usi_engine_start が isready 前に適用)
         // を優先し、UI の自動解決値で無条件に上書きしない。厳格な USI エンジンは
         // isready 後の setoption を反映しないため、起動後に送っても保証がない
         async init(_opts?: EngineInitOptions): Promise<void> {
+            // 再初期化 (retry / restartForNnue 等) で呼ばれたとき、旧セッションを
+            // quit せずに sessionId を上書きすると外部プロセスがリークする
+            await closeSession();
+
             sessionId = await tauriInvoke<string>("usi_engine_start", {
                 registration_id: registrationId,
             });
@@ -124,20 +143,7 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
         },
 
         async dispose(): Promise<void> {
-            if (sessionId) {
-                await tauriInvoke("usi_engine_quit", { session_id: sessionId }).catch(
-                    () => undefined,
-                );
-                sessionId = null;
-            }
-            if (unlisten) {
-                try {
-                    unlisten();
-                } catch {
-                    // ignore
-                }
-                unlisten = null;
-            }
+            await closeSession();
             listeners.clear();
         },
     };

--- a/packages/engine-tauri/src/usi-engine-client.ts
+++ b/packages/engine-tauri/src/usi-engine-client.ts
@@ -64,6 +64,9 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
     // (識別子を失うと旧プロセスを回収できなくなるため)。Rust 側の quit は
     // 存在しない session_id にも Ok を返す冪等実装なので、失敗 = IPC 異常
     const closeSession = async (bestEffort: boolean): Promise<void> => {
+        // quit に伴う旧チャネルの EOF エラーイベントを購読者へ流さないよう、
+        // 購読解除を先に行う
+        dropListener();
         if (sessionId) {
             const quit = tauriInvoke("usi_engine_quit", { session_id: sessionId });
             if (bestEffort) {
@@ -73,7 +76,6 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
             }
             sessionId = null;
         }
-        dropListener();
     };
 
     return {
@@ -100,9 +102,12 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
                 } catch (error) {
                     // 購読に失敗したまま session を持つと誰もイベントを受け取れない。
                     // 起動済みプロセスを残さないよう片付けてから失敗させる
-                    await tauriInvoke("usi_engine_quit", { session_id: newSessionId }).catch(
-                        () => undefined,
-                    );
+                    try {
+                        await tauriInvoke("usi_engine_quit", { session_id: newSessionId });
+                    } catch {
+                        // quit まで失敗したら識別子を保持し、後続の dispose / 再 init で回収する
+                        sessionId = newSessionId;
+                    }
                     throw error;
                 }
                 sessionId = newSessionId;

--- a/packages/engine-tauri/src/usi-engine-client.ts
+++ b/packages/engine-tauri/src/usi-engine-client.ts
@@ -62,7 +62,9 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
 
     // bestEffort=false では quit の失敗を伝播し、sessionId を保持したまま中断する
     // (識別子を失うと旧プロセスを回収できなくなるため)。Rust 側の quit は
-    // 存在しない session_id にも Ok を返す冪等実装なので、失敗 = IPC 異常
+    // 存在しない session_id にも Ok を返す冪等実装なので、失敗 = IPC 異常。
+    // bestEffort=true (dispose 用) は終端操作として quit 失敗を無視し sessionId も
+    // 消去する — dispose 後のクライアント再利用は想定せず、回収不能を許容する
     const closeSession = async (bestEffort: boolean): Promise<void> => {
         // quit に伴う旧チャネルの EOF エラーイベントを購読者へ流さないよう、
         // 購読解除を先に行う


### PR DESCRIPTION
## 問題 (#104)

外部 USI エンジンクライアントの `init` が再実行される (controller の retry / restartForNnue 経路) と、`usi_engine_start` が新セッションを張って `sessionId` を上書きし、旧プロセスが quit されないままリークしていた。

## 修正

- `init` 冒頭で既存セッションを閉じてから新セッションを張る。quit の失敗は伝播して新 start を中止し、`sessionId` を保持して後続の dispose / 再 init で回収可能にする (Rust 側の quit は存在しない session_id にも Ok を返す冪等実装のため、失敗 = IPC 異常)
- `init` / `dispose` をクライアント内部の promise chain で直列化し、並行 init によるセッション取りこぼしを防止
- `usi_engine_start` 成功後に購読登録が失敗した場合は起動済みセッションを quit してから失敗させる。その quit まで失敗した場合も識別子を保持して回収可能にする
- 購読解除を quit より先に行い、quit に伴う旧チャネルの EOF エラーイベントが再起動直後の購読者へ流れる競合を排除
- dispose は共通の `closeSession` (best-effort) を使う形に集約

## テスト

`usi-engine-client.test.ts` を新規追加 (7 件): 初回 init は quit しない / 再 init の quit → start 順序 / quit 失敗時の中止と dispose での回収 (回数検証) / 並行 init の直列化 (順序検証) / 購読失敗時の quit / 購読失敗 + quit 失敗時の識別子保持と回収 / dispose の片付け。engine-tauri 39 件 green、typecheck / lint green。

Codex + Claude の 2 独立レビューで両者 APPROVE (Codex 3 巡)。

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQTCoUvUVbujyGyZLb77su