### PR TITLE
feat(engine-client,app-controller,engine-tauri,engine-wasm,desktop): 持ち時間 (btime/wtime) をエンジンまで伝搬して時間配分を有効化

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -148,6 +148,8 @@ struct InitOptions {
 struct SearchLimitsInput {
     max_depth: Option<i32>,
     nodes: Option<u64>,
+    btime_ms: Option<i64>,
+    wtime_ms: Option<i64>,
     byoyomi_ms: Option<i64>,
     movetime_ms: Option<i64>,
 }
@@ -439,6 +441,12 @@ fn build_limits(params: &SearchParamsInput, options: &EngineOptions) -> LimitsTy
         if let Some(nodes) = limits_input.nodes {
             eprintln!("build_limits: setting nodes = {}", nodes);
             limits.nodes = nodes;
+        }
+        if let Some(btime) = limits_input.btime_ms {
+            limits.time[Color::Black.index()] = btime;
+        }
+        if let Some(wtime) = limits_input.wtime_ms {
+            limits.time[Color::White.index()] = wtime;
         }
         if let Some(byoyomi) = limits_input.byoyomi_ms {
             eprintln!("build_limits: setting byoyomi = {}", byoyomi);
@@ -956,7 +964,10 @@ fn ensure_path_within_dir(dir: &Path, path: &Path) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ensure_path_within_dir, validate_nnue_id};
+    use super::{
+        Color, EngineOptions, SearchLimitsInput, SearchParamsInput, build_limits,
+        ensure_path_within_dir, validate_nnue_id,
+    };
     use std::fs;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -970,6 +981,27 @@ mod tests {
             .expect("system time before unix epoch")
             .as_nanos();
         std::env::temp_dir().join(format!("{prefix}-{nanos}-{n}"))
+    }
+
+    #[test]
+    fn build_limits_maps_sente_and_gote_time() {
+        let params = SearchParamsInput {
+            limits: Some(SearchLimitsInput {
+                max_depth: None,
+                nodes: None,
+                btime_ms: Some(12_000),
+                wtime_ms: Some(6_500),
+                byoyomi_ms: Some(1_000),
+                movetime_ms: None,
+            }),
+            ponder: Some(false),
+        };
+
+        let limits = build_limits(&params, &EngineOptions::default());
+
+        assert_eq!(limits.time[Color::Black.index()], 12_000);
+        assert_eq!(limits.time[Color::White.index()], 6_500);
+        assert_eq!(limits.byoyomi, [1_000; Color::NUM]);
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/usi_engine.rs
+++ b/apps/desktop/src-tauri/src/usi_engine.rs
@@ -312,9 +312,38 @@ impl Default for UsiEngineManager {
 pub struct SearchParamsInput {
     pub max_depth: Option<u32>,
     pub nodes: Option<u64>,
+    pub btime_ms: Option<u64>,
+    pub wtime_ms: Option<u64>,
     pub byoyomi_ms: Option<u64>,
     pub movetime_ms: Option<u64>,
     pub infinite: Option<bool>,
+}
+
+fn build_go_command(params: &SearchParamsInput) -> String {
+    let mut cmd = "go".to_string();
+    if params.infinite == Some(true) {
+        cmd.push_str(" infinite");
+        return cmd;
+    }
+    if let Some(depth) = params.max_depth {
+        cmd.push_str(&format!(" depth {depth}"));
+    }
+    if let Some(nodes) = params.nodes {
+        cmd.push_str(&format!(" nodes {nodes}"));
+    }
+    if let Some(btime) = params.btime_ms {
+        cmd.push_str(&format!(" btime {btime}"));
+    }
+    if let Some(wtime) = params.wtime_ms {
+        cmd.push_str(&format!(" wtime {wtime}"));
+    }
+    if let Some(byoyomi) = params.byoyomi_ms {
+        cmd.push_str(&format!(" byoyomi {byoyomi}"));
+    }
+    if let Some(movetime) = params.movetime_ms {
+        cmd.push_str(&format!(" movetime {movetime}"));
+    }
+    cmd
 }
 
 /// Saved option value for an engine.
@@ -637,24 +666,7 @@ impl UsiEngineManager {
             (Arc::clone(&session.stdin), Arc::clone(&session.status))
         };
 
-        let mut cmd = "go".to_string();
-        if params.infinite == Some(true) {
-            cmd.push_str(" infinite");
-        } else {
-            if let Some(depth) = params.max_depth {
-                cmd.push_str(&format!(" depth {depth}"));
-            }
-            if let Some(nodes) = params.nodes {
-                cmd.push_str(&format!(" nodes {nodes}"));
-            }
-            if let Some(byoyomi) = params.byoyomi_ms {
-                cmd.push_str(&format!(" byoyomi {byoyomi}"));
-            }
-            if let Some(movetime) = params.movetime_ms {
-                cmd.push_str(&format!(" movetime {movetime}"));
-            }
-        }
-
+        let cmd = build_go_command(params);
         if let Ok(mut s) = status.lock() {
             *s = EngineStatus::Searching;
         }
@@ -798,6 +810,39 @@ fn parse_combo_vars(s: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn build_go_command_orders_clock_limits_before_byoyomi() {
+        let params = SearchParamsInput {
+            max_depth: None,
+            nodes: None,
+            btime_ms: Some(12_000),
+            wtime_ms: Some(6_500),
+            byoyomi_ms: Some(1_000),
+            movetime_ms: None,
+            infinite: Some(false),
+        };
+
+        assert_eq!(
+            build_go_command(&params),
+            "go btime 12000 wtime 6500 byoyomi 1000"
+        );
+    }
+
+    #[test]
+    fn build_go_command_keeps_byoyomi_only_compatible() {
+        let params = SearchParamsInput {
+            max_depth: None,
+            nodes: None,
+            btime_ms: None,
+            wtime_ms: None,
+            byoyomi_ms: Some(1_000),
+            movetime_ms: None,
+            infinite: Some(false),
+        };
+
+        assert_eq!(build_go_command(&params), "go byoyomi 1000");
+    }
 
     // ── id name / id author ────────────────────────────────────────
 

--- a/packages/app-controller/src/engine-controller.test.ts
+++ b/packages/app-controller/src/engine-controller.test.ts
@@ -342,6 +342,64 @@ describe("createEngineController", () => {
         expect(controller.getState().engineReady.sente).toBe(true);
     });
 
+    it("後手の探索に両者の残り持ち時間を渡す", async () => {
+        const mockClient = createMockEngineClient();
+        const controller = createEngineController({
+            createClient: () => mockClient.client,
+            getClockState: () => ({
+                sente: { mainMs: 12_000, byoyomiMs: 1_000 },
+                gote: { mainMs: 8_000, byoyomiMs: 1_000 },
+                lastUpdatedAt: 1_000,
+                ticking: "gote",
+            }),
+            now: () => 2_500,
+            resolveNnue: async () => null,
+            callbacks: { onMoveFromEngine: vi.fn(), onMatchEnd: vi.fn() },
+        });
+        controller.command.syncContext({
+            sides: { sente: { role: "human" }, gote: { role: "engine", engineId: "engine1" } },
+            position: { startSfen: "startpos", moves: [], turn: "gote", ready: true },
+            matchRunning: true,
+        });
+
+        await controller.command.startTurn("gote");
+        await flushPromises();
+
+        expect(mockClient.search).toHaveBeenCalledWith({
+            limits: { btimeMs: 12_000, wtimeMs: 6_500, byoyomiMs: 1_000 },
+            ponder: false,
+        });
+    });
+
+    it("純秒読みでは btime/wtime を渡さない", async () => {
+        const mockClient = createMockEngineClient();
+        const controller = createEngineController({
+            createClient: () => mockClient.client,
+            getClockState: () => ({
+                sente: { mainMs: 0, byoyomiMs: 1_000 },
+                gote: { mainMs: 0, byoyomiMs: 1_000 },
+                lastUpdatedAt: 1_000,
+                ticking: "sente",
+            }),
+            now: () => 1_200,
+            resolveNnue: async () => null,
+            callbacks: { onMoveFromEngine: vi.fn(), onMatchEnd: vi.fn() },
+        });
+        controller.command.syncContext({
+            sides: { sente: { role: "engine", engineId: "engine1" }, gote: { role: "human" } },
+            position: { startSfen: "startpos", moves: [], turn: "sente", ready: true },
+            matchRunning: true,
+        });
+
+        await controller.command.startTurn("sente");
+        await flushPromises();
+
+        expect(mockClient.search).toHaveBeenCalledWith({
+            limits: { byoyomiMs: 800 },
+            ponder: false,
+        });
+    });
+
     it("bestmove の通常手でコールバックを呼ぶ", async () => {
         const mockClient = createMockEngineClient();
         const onMoveFromEngine = vi.fn();

--- a/packages/app-controller/src/engine-controller.test.ts
+++ b/packages/app-controller/src/engine-controller.test.ts
@@ -371,6 +371,35 @@ describe("createEngineController", () => {
         });
     });
 
+    it("手番側の持ち時間切れ後も btime 0 を渡す", async () => {
+        const mockClient = createMockEngineClient();
+        const controller = createEngineController({
+            createClient: () => mockClient.client,
+            getClockState: () => ({
+                sente: { mainMs: 0, byoyomiMs: 1_000 },
+                gote: { mainMs: 8_000, byoyomiMs: 1_000 },
+                lastUpdatedAt: 1_000,
+                ticking: "sente",
+            }),
+            now: () => 1_200,
+            resolveNnue: async () => null,
+            callbacks: { onMoveFromEngine: vi.fn(), onMatchEnd: vi.fn() },
+        });
+        controller.command.syncContext({
+            sides: { sente: { role: "engine", engineId: "engine1" }, gote: { role: "human" } },
+            position: { startSfen: "startpos", moves: [], turn: "sente", ready: true },
+            matchRunning: true,
+        });
+
+        await controller.command.startTurn("sente");
+        await flushPromises();
+
+        expect(mockClient.search).toHaveBeenCalledWith({
+            limits: { btimeMs: 0, wtimeMs: 8_000, byoyomiMs: 800 },
+            ponder: false,
+        });
+    });
+
     it("純秒読みでは btime/wtime を渡さない", async () => {
         const mockClient = createMockEngineClient();
         const controller = createEngineController({

--- a/packages/app-controller/src/engine-controller.ts
+++ b/packages/app-controller/src/engine-controller.ts
@@ -968,12 +968,18 @@ export function createEngineController(
             }
 
             const effectiveByoyomiMs = Math.max(100, remainingByoyomiMs);
+            const hasMainTime = clocks.sente.mainMs > 0 || clocks.gote.mainMs > 0;
+            const btimeMs = side === "sente" ? remainingMainMs : clocks.sente.mainMs;
+            const wtimeMs = side === "gote" ? remainingMainMs : clocks.gote.mainMs;
 
             liveSearchStats[side] = {};
             liveThinkLimitMs[side] = effectiveByoyomiMs;
 
             const handle = await client.search({
-                limits: { byoyomiMs: effectiveByoyomiMs },
+                limits: {
+                    byoyomiMs: effectiveByoyomiMs,
+                    ...(hasMainTime ? { btimeMs, wtimeMs } : {}),
+                },
                 ponder: false,
             });
 

--- a/packages/engine-client/src/index.ts
+++ b/packages/engine-client/src/index.ts
@@ -98,6 +98,10 @@ export interface SearchLimits {
     nodes?: number;
     /** 秒読み (ms) */
     byoyomiMs?: number;
+    /** 先手の残り持ち時間 (ms) */
+    btimeMs?: number;
+    /** 後手の残り持ち時間 (ms) */
+    wtimeMs?: number;
     /** 固定消費時間 (ms) */
     movetimeMs?: number;
 }

--- a/packages/engine-client/src/index.ts
+++ b/packages/engine-client/src/index.ts
@@ -96,12 +96,12 @@ export interface SearchLimits {
     maxDepth?: number;
     /** ノード数上限 */
     nodes?: number;
-    /** 秒読み (ms) */
-    byoyomiMs?: number;
     /** 先手の残り持ち時間 (ms) */
     btimeMs?: number;
     /** 後手の残り持ち時間 (ms) */
     wtimeMs?: number;
+    /** 秒読み (ms) */
+    byoyomiMs?: number;
     /** 固定消費時間 (ms) */
     movetimeMs?: number;
 }

--- a/packages/engine-tauri/src/usi-engine-client.test.ts
+++ b/packages/engine-tauri/src/usi-engine-client.test.ts
@@ -152,4 +152,25 @@ describe("createUsiEngineClient", () => {
         });
         expect(unlistenMock).toHaveBeenCalledTimes(1);
     });
+
+    it("探索時間を USI go 用パラメーターに変換する", async () => {
+        const client = createUsiEngineClient({ registrationId: "reg-1" });
+        await client.init();
+        await client.search({
+            limits: { btimeMs: 12_000, wtimeMs: 6_500, byoyomiMs: 1_000 },
+        });
+
+        expect(invokeMock).toHaveBeenCalledWith("usi_engine_go", {
+            session_id: "session-1",
+            params: {
+                maxDepth: undefined,
+                nodes: undefined,
+                btimeMs: 12_000,
+                wtimeMs: 6_500,
+                byoyomiMs: 1_000,
+                movetimeMs: undefined,
+                infinite: false,
+            },
+        });
+    });
 });

--- a/packages/engine-tauri/src/usi-engine-client.ts
+++ b/packages/engine-tauri/src/usi-engine-client.ts
@@ -136,6 +136,8 @@ export function createUsiEngineClient(options: UsiEngineClientOptions): EngineCl
                 params: {
                     maxDepth: params.limits?.maxDepth,
                     nodes: params.limits?.nodes,
+                    btimeMs: params.limits?.btimeMs,
+                    wtimeMs: params.limits?.wtimeMs,
                     byoyomiMs: params.limits?.byoyomiMs,
                     movetimeMs: params.limits?.movetimeMs,
                     infinite: !params.limits,

--- a/packages/rust-core/crates/engine-wasm/src/lib.rs
+++ b/packages/rust-core/crates/engine-wasm/src/lib.rs
@@ -14,7 +14,7 @@ use rshogi_core::nnue::{detect_format, init_nnue_from_bytes, set_fv_scale_overri
 use rshogi_core::position::{Position, SFEN_HIRATE};
 use rshogi_core::search::{LimitsType, Search, SearchInfo, SearchResult, SkillOptions};
 use rshogi_core::types::json::BoardStateJson;
-use rshogi_core::types::{Move, Value};
+use rshogi_core::types::{Color, Move, Value};
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen as swb;
 use wasm_bindgen::JsCast;
@@ -49,6 +49,8 @@ struct InitOptions {
 struct JsLimits {
     max_depth: Option<i32>,
     nodes: Option<u64>,
+    btime_ms: Option<i64>,
+    wtime_ms: Option<i64>,
     byoyomi_ms: Option<i64>,
     movetime_ms: Option<i64>,
 }
@@ -217,6 +219,8 @@ fn parse_limits(value: JsValue) -> Result<JsLimits, JsValue> {
     Ok(JsLimits {
         max_depth: get_optional_i32(&value, "maxDepth")?,
         nodes: get_optional_u64(&value, "nodes")?,
+        btime_ms: get_optional_i64(&value, "btimeMs")?,
+        wtime_ms: get_optional_i64(&value, "wtimeMs")?,
         byoyomi_ms: get_optional_i64(&value, "byoyomiMs")?,
         movetime_ms: get_optional_i64(&value, "movetimeMs")?,
     })
@@ -797,6 +801,12 @@ pub fn search(params: Option<JsValue>) -> Result<(), JsValue> {
             }
             if let Some(nodes) = lim.nodes {
                 limits.nodes = nodes;
+            }
+            if let Some(btime) = lim.btime_ms {
+                limits.time[Color::Black.index()] = btime;
+            }
+            if let Some(wtime) = lim.wtime_ms {
+                limits.time[Color::White.index()] = wtime;
             }
             if let Some(byo) = lim.byoyomi_ms {
                 limits.byoyomi = [byo, byo];


### PR DESCRIPTION
## Summary

- `SearchLimits` に `btimeMs` / `wtimeMs` を追加し、対局時計の残り持ち時間を WASM・Tauri 内蔵・外部 USI (`go btime <ms> wtime <ms> byoyomi <ms>`) の 3 経路すべてに伝搬
- 手番側は経過時間を差し引いた残り main time、非手番側は保存値をそのまま送る (btime=先手 / wtime=後手、rshogi-core の `Color::Black=0 / White=1` に対応)
- 純秒読み設定 (両者 main time = 0) では btime/wtime を送らず、外部 USI への go 文字列は従来どおり `go byoyomi <ms>` を維持
- binc/winc (Fischer 増加) はアプリの時計モデルに増加秒が無いためスコープ外

## 関連

- Closes #98

## Test plan

- [x] pnpm lint / pnpm test (CI filter set + engine-tauri / engine-wasm / desktop) 全 pass
- [x] rust-core / desktop src-tauri: cargo fmt --check / clippy -D warnings / cargo test 全 pass
- [x] local reviewer #1 (Codex) APPROVE
- [x] local reviewer #2 (Claude) APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YaJQR49QsGgdVkQXEBaVFS