### PR TITLE
feat(web): トップ入口カードを行き先1:1の4枚に再編し要ログインを明示

### DIFF
--- a/apps/web/src/components/AuthBadge.tsx
+++ b/apps/web/src/components/AuthBadge.tsx
@@ -1,0 +1,11 @@
+import type { ReactElement } from "react";
+
+// ログイン必須の導線に付ける共通バッジ。リンク先で AuthRequiredCard や /auth
+// リダイレクトに当たる前に、リンク時点で要否が分かるようにする。
+export function AuthBadge(): ReactElement {
+    return (
+        <span className="shrink-0 rounded-full border border-wafuu-border px-1.5 py-0.5 text-[10px] leading-none text-muted-foreground">
+            要ログイン
+        </span>
+    );
+}

--- a/apps/web/src/components/NavDrawer.test.tsx
+++ b/apps/web/src/components/NavDrawer.test.tsx
@@ -51,11 +51,12 @@ describe("NavDrawer", () => {
         for (const link of [
             "対局",
             "オンライン対局",
-            "マイ棋譜",
+            // 要ログイン導線はバッジ「要ログイン」がアクセシブルネームに続く
+            "マイ棋譜 要ログイン",
             "公開棋譜",
             "ライブ観戦",
             "CSA 棋譜ビューア",
-            "NNUE モデル",
+            "NNUE モデル 要ログイン",
             "ログイン",
         ]) {
             expect(screen.getByRole("link", { name: link })).toBeTruthy();

--- a/apps/web/src/components/NavDrawer.tsx
+++ b/apps/web/src/components/NavDrawer.tsx
@@ -4,6 +4,7 @@ import { Link, useLocation } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { useAuthSession } from "../hooks/useAuthSession";
+import { AuthBadge } from "./AuthBadge";
 
 type NavTo =
     | "/play"
@@ -19,6 +20,7 @@ interface NavItem {
     to: NavTo;
     label: string;
     active: boolean;
+    requiresAuth?: boolean;
 }
 
 interface NavSection {
@@ -51,7 +53,12 @@ function buildNavSections(pathname: string): NavSection[] {
         {
             label: "棋譜",
             items: [
-                { to: "/games", label: "マイ棋譜", active: pathname.startsWith("/games") },
+                {
+                    to: "/games",
+                    label: "マイ棋譜",
+                    active: pathname.startsWith("/games"),
+                    requiresAuth: true,
+                },
                 {
                     to: "/public/games",
                     label: "公開棋譜",
@@ -72,7 +79,14 @@ function buildNavSections(pathname: string): NavSection[] {
         },
         {
             label: "管理",
-            items: [{ to: "/nnue", label: "NNUE モデル", active: pathname === "/nnue" }],
+            items: [
+                {
+                    to: "/nnue",
+                    label: "NNUE モデル",
+                    active: pathname === "/nnue",
+                    requiresAuth: true,
+                },
+            ],
         },
     ];
 }
@@ -84,11 +98,12 @@ function DrawerLink({ item, onNavigate }: { item: NavItem; onNavigate: () => voi
             aria-current={item.active ? "page" : undefined}
             onClick={onNavigate}
             className={cn(
-                "block rounded-md border px-3 py-2 text-sm font-medium transition-colors",
+                "flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium transition-colors",
                 item.active ? activeClass : inactiveClass,
             )}
         >
             {item.label}
+            {item.requiresAuth && <AuthBadge />}
         </Link>
     );
 }

--- a/apps/web/src/pages/LandingPage.tsx
+++ b/apps/web/src/pages/LandingPage.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import type { ReactElement, ReactNode } from "react";
+import { AuthBadge } from "../components/AuthBadge";
 import { HeaderNav } from "../components/HeaderNav";
 import { HeroBoard } from "../components/HeroBoard";
 import { PageHeader } from "../components/PageHeader";
@@ -9,27 +10,31 @@ import { PageHeader } from "../components/PageHeader";
 // 色はすべて design-system の wafuu-*/shogi-* トークン経由（ハードコード禁止）。
 
 interface EntryCardProps {
-    to: "/play" | "/rshogi-viewer/live";
+    to: "/play" | "/online" | "/rshogi-viewer/live" | "/games";
     heading: string;
     tone: "shu" | "ai";
+    requiresAuth?: boolean;
     children: ReactNode;
 }
 
-function EntryCard({ to, heading, tone, children }: EntryCardProps): ReactElement {
+function EntryCard({ to, heading, tone, requiresAuth, children }: EntryCardProps): ReactElement {
     return (
         <Link
             to={to}
             className="group flex flex-col gap-2 rounded-xl border border-wafuu-border bg-wafuu-washi-warm p-4 transition-colors hover:border-wafuu-shu/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
         >
-            <h2
-                className={
-                    tone === "shu"
-                        ? "font-display text-xl font-semibold text-wafuu-shu"
-                        : "font-display text-xl font-semibold text-wafuu-ai"
-                }
-            >
-                {heading}
-            </h2>
+            <span className="flex items-center gap-2">
+                <h2
+                    className={
+                        tone === "shu"
+                            ? "font-display text-xl font-semibold text-wafuu-shu"
+                            : "font-display text-xl font-semibold text-wafuu-ai"
+                    }
+                >
+                    {heading}
+                </h2>
+                {requiresAuth && <AuthBadge />}
+            </span>
             <span className="text-[13px] leading-relaxed text-wafuu-sumi-light">{children}</span>
         </Link>
     );
@@ -66,12 +71,6 @@ export default function LandingPage(): ReactElement {
                                 <span aria-hidden>▲</span>
                                 対局をはじめる
                             </Link>
-                            <Link
-                                to="/games"
-                                className="inline-flex items-center gap-2 rounded-lg border border-wafuu-border px-5 py-3 text-sm font-semibold text-wafuu-sumi transition-colors hover:bg-wafuu-washi-warm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                            >
-                                棋譜を開く
-                            </Link>
                         </div>
                     </div>
                     <div className="relative mx-auto w-full max-w-[380px]">
@@ -83,15 +82,18 @@ export default function LandingPage(): ReactElement {
                     </div>
                 </section>
 
-                <section aria-label="はじめ方" className="grid gap-4 sm:grid-cols-3">
-                    <EntryCard to="/play" heading="対局" tone="shu">
-                        先手・後手を選んで人と指す。
+                <section aria-label="はじめ方" className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <EntryCard to="/play" heading="対局・検討" tone="shu">
+                        内蔵 NNUE エンジンと指す。検討モードに切り替えられる。ログイン不要。
                     </EntryCard>
-                    <EntryCard to="/play" heading="検討" tone="ai">
-                        内蔵 NNUE エンジンと指す。検討モードに切り替えられる。
+                    <EntryCard to="/online" heading="オンライン対局" tone="shu">
+                        部屋を作り、招待リンクで人と指す。名前を入れるだけで参加できる。
                     </EntryCard>
-                    <EntryCard to="/rshogi-viewer/live" heading="観戦" tone="shu">
+                    <EntryCard to="/rshogi-viewer/live" heading="観戦" tone="ai">
                         進行中のエンジン対局をリアルタイムで見る。
+                    </EntryCard>
+                    <EntryCard to="/games" heading="マイ棋譜" tone="ai" requiresAuth>
+                        指した対局を保存して振り返る。
                     </EntryCard>
                 </section>
             </main>


### PR DESCRIPTION
## 概要

トップの入口リンクが「ログイン要否」「人とのオンライン対局」「対AI・検討」の区別が付かない問題の解消。

## 変更内容

- 入口カードを行き先と 1:1 の4枚に再編:
  - **対局・検討** → `/play`（内蔵 NNUE エンジンとの対局・検討。ログイン不要を明記）
  - **オンライン対局** → `/online`（トップに欠落していた対人導線を新設。ゲスト参加可を明記）
  - **観戦** → `/rshogi-viewer/live`
  - **マイ棋譜** → `/games`（要ログインバッジ付き）
- 共通 `AuthBadge`（要ログイン）を新設し、トップカードと NavDrawer のマイ棋譜 / NNUE モデルに適用。バッジ文言はリンクのアクセシブルネームにも含まれる
- ヒーロー副CTA「棋譜を開く」を削除（要ログインの `/games` へ無表記で飛ばしており、マイ棋譜カードと重複）

実際の認証要件はルート実装を調査して反映: 要ログインは `/games`（一覧は AuthRequiredCard、詳細/検討は /auth リダイレクト）と `/nnue` のみ。`/online` はゲスト可。

## 検証
- tsc / web テスト 49 件パス
- デスクトップ・モバイル幅でスクリーンショット確認、stg デプロイ済み（stg.ramu-shogi.sh11235.com で目視確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Fjcp5t92PcukUfGPB4VXG