### PR TITLE
fix(match-client): rshogi API fetch に cache: no-store を付与 (live 一覧ゾンビ表示の再発防止)

### DIFF
--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -61,7 +61,7 @@ describe("fetchRshogiGameSearch (real baseUrl)", () => {
 
         expect(fetchImpl).toHaveBeenCalledWith(
             "https://rshogi.example.com/api/v1/games/search?name=Alice+Bob&result=resignation&source=floodgate&from=1000&to=2000&page=2&pageSize=20",
-            { signal: undefined },
+            { signal: undefined, cache: "no-store" },
         );
         expect(result).toEqual({
             games: [
@@ -664,7 +664,7 @@ describe("fetchRshogiGame* X-Client header (rshogi#564)", () => {
         await fetchRshogiGame("x1", { baseUrl: "https://rshogi.example.com", fetchImpl });
         const init = (fetchImpl as unknown as { mock: { calls: [string, RequestInit][] } }).mock
             .calls[0][1];
-        expect(init).toEqual({ signal: undefined });
+        expect(init).toEqual({ signal: undefined, cache: "no-store" });
         expect((init as { headers?: unknown }).headers).toBeUndefined();
     });
 

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -262,11 +262,15 @@ const buildClientHeaders = (): Record<string, string> => {
  * 付与する必要がない場合は `headers` を含めない (= 既存挙動完全互換)。
  */
 const buildRequestInit = (signal: AbortSignal | undefined): RequestInit => {
+    // `cache: "no-store"`: rshogi API は CDN edge 経由で `max-age` が長い値 (数時間)
+    // に書き換わることがあり、ブラウザ HTTP キャッシュに乗ると live 一覧のポーリングが
+    // ネットワークに出ず終局済み対局を「対局中」のまま表示し続ける。鮮度はサーバ側の
+    // edge キャッシュ (60 秒) に任せ、ブラウザ側では常にネットワークへ出す。
     const headers = buildClientHeaders();
     if (Object.keys(headers).length === 0) {
-        return { signal };
+        return { signal, cache: "no-store" };
     }
-    return { signal, headers };
+    return { signal, headers, cache: "no-store" };
 };
 
 // ===== wire format (snake_case) =====


### PR DESCRIPTION
## 問題

終局済みの対局が /rshogi-viewer/live に「対局中」のまま数時間表示され続ける事象が発生した (2026-07-17)。

調査の結果、サーバー側の live index は正常に解放されており (API 直叩きは空)、原因はキャッシュ:

- Worker は `Cache-Control: max-age=0, must-revalidate, s-maxage=60` を返すが、**CF edge キャッシュ HIT を経由したレスポンスは zone 既定の Browser Cache TTL により `max-age=14400` (4h) に書き換わる** (curl で両 variant を実測)
- この 4h 版をブラウザが受信すると、Chrome の HTTP キャッシュが以後の live 一覧ポーリング (60 秒間隔) をネットワークに出さず、古い一覧を返し続ける (ハードリロードで解消することを確認)

## 修正

rshogi API 共通の `buildRequestInit` に `cache: "no-store"` を付与。鮮度制御はサーバ側 edge キャッシュ (60 秒) に任せ、ブラウザ HTTP キャッシュには乗せない。

補完として zone 側の Cache Rule (browser_ttl respect_origin) を iac repo で別途追加予定 (こちらは根治、本 PR はクライアント側の恒久防御)。

## テスト

match-client 31 tests pass / typecheck OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MkZhYF4q21LWyaeg8UmTBb