### PR TITLE
fix(match-client,ui): rshogi viewer の単局メタを meta ネストから decode する

### DIFF
--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -128,23 +128,26 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("decodes wire (snake_case + epoch_ms) into camelCase + epoch_ms domain types", async () => {
         const wirePayload = {
             game_id: "abc",
-            started_at_ms: 1777391025209,
-            ended_at_ms: 1777392877244,
-            black_handle: "alice",
-            white_handle: "bob",
-            result_kind: "WIN_BLACK",
-            end_reason: "RESIGN",
-            moves_count: 142,
-            clock: {
-                kind: "fischer",
-                total_sec: 300,
-                byoyomi_sec: 10,
-                byoyomi_ms: null,
-                increment_sec: 5,
-            },
-            source: "kifu",
-            event: "test event",
             csa: "V2.2\nN+alice\nN-bob\nPI\n+\n",
+            meta: {
+                game_id: "abc",
+                started_at_ms: 1777391025209,
+                ended_at_ms: 1777392877244,
+                black_handle: "alice",
+                white_handle: "bob",
+                result_kind: "WIN_BLACK",
+                end_reason: "RESIGN",
+                moves_count: 142,
+                clock: {
+                    kind: "fischer",
+                    total_sec: 300,
+                    byoyomi_sec: 10,
+                    byoyomi_ms: null,
+                    increment_sec: 5,
+                },
+                source: "kifu",
+                event: "test event",
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -190,16 +193,19 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("decodes WIN_WHITE + TIME_UP into gote winner + time_expired", async () => {
         const wirePayload = {
             game_id: "g1",
-            started_at_ms: 1,
-            ended_at_ms: 2,
-            black_handle: "B",
-            white_handle: "W",
-            result_kind: "WIN_WHITE",
-            end_reason: "TIME_UP",
-            moves_count: 50,
-            clock: { kind: "countdown", total_sec: 60, byoyomi_sec: 30 },
-            source: "floodgate",
             csa: "V2.2\n",
+            meta: {
+                game_id: "g1",
+                started_at_ms: 1,
+                ended_at_ms: 2,
+                black_handle: "B",
+                white_handle: "W",
+                result_kind: "WIN_WHITE",
+                end_reason: "TIME_UP",
+                moves_count: 50,
+                clock: { kind: "countdown", total_sec: 60, byoyomi_sec: 30 },
+                source: "floodgate",
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -221,11 +227,14 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("decodes DRAW + SENNICHITE into draw without winner", async () => {
         const wirePayload = {
             game_id: "g2",
-            black_handle: "B",
-            white_handle: "W",
-            result_kind: "DRAW",
-            end_reason: "SENNICHITE",
             csa: "V2.2\n",
+            meta: {
+                game_id: "g2",
+                black_handle: "B",
+                white_handle: "W",
+                result_kind: "DRAW",
+                end_reason: "SENNICHITE",
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -247,11 +256,14 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("decodes WIN_BLACK + JISHOGI into jishogi with sente winner", async () => {
         const wirePayload = {
             game_id: "g3",
-            black_handle: "B",
-            white_handle: "W",
-            result_kind: "WIN_BLACK",
-            end_reason: "JISHOGI",
             csa: "V2.2\n",
+            meta: {
+                game_id: "g3",
+                black_handle: "B",
+                white_handle: "W",
+                result_kind: "WIN_BLACK",
+                end_reason: "JISHOGI",
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -273,11 +285,14 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("decodes WIN_WHITE + OUTE_SENNICHITE into oute_sennichite with gote winner", async () => {
         const wirePayload = {
             game_id: "g4",
-            black_handle: "B",
-            white_handle: "W",
-            result_kind: "WIN_WHITE",
-            end_reason: "OUTE_SENNICHITE",
             csa: "V2.2\n",
+            meta: {
+                game_id: "g4",
+                black_handle: "B",
+                white_handle: "W",
+                result_kind: "WIN_WHITE",
+                end_reason: "OUTE_SENNICHITE",
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -299,10 +314,13 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("normalizes stopwatch clock from total_min/byoyomi_min", async () => {
         const wirePayload = {
             game_id: "g5",
-            black_handle: "B",
-            white_handle: "W",
-            clock: { kind: "stopwatch", total_min: 30, byoyomi_min: 1 },
             csa: "V2.2\n",
+            meta: {
+                game_id: "g5",
+                black_handle: "B",
+                white_handle: "W",
+                clock: { kind: "stopwatch", total_min: 30, byoyomi_min: 1 },
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -326,10 +344,13 @@ describe("fetchRshogiGame (real baseUrl)", () => {
     it("normalizes countdown_msec clock from total_ms/byoyomi_ms", async () => {
         const wirePayload = {
             game_id: "g6",
-            black_handle: "B",
-            white_handle: "W",
-            clock: { kind: "countdown_msec", total_ms: 30000, byoyomi_ms: 250 },
             csa: "V2.2\n",
+            meta: {
+                game_id: "g6",
+                black_handle: "B",
+                white_handle: "W",
+                clock: { kind: "countdown_msec", total_ms: 30000, byoyomi_ms: 250 },
+            },
         };
         const fetchImpl = vi.fn(
             async () =>
@@ -348,6 +369,28 @@ describe("fetchRshogiGame (real baseUrl)", () => {
             byoyomiMilliseconds: 250,
             incrementSeconds: undefined,
         });
+    });
+
+    it("degrades gracefully when meta is missing", async () => {
+        const wirePayload = {
+            game_id: "g7",
+            csa: "V2.2\n",
+        };
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(JSON.stringify(wirePayload), {
+                    status: 200,
+                }),
+        ) as unknown as typeof fetch;
+        const game = await fetchRshogiGame("g7", {
+            baseUrl: "https://rshogi.example.com",
+            fetchImpl,
+        });
+        expect(game.meta.gameId).toBe("g7");
+        expect(game.meta.senteName).toBe("");
+        expect(game.meta.goteName).toBe("");
+        expect(game.meta.result).toBeUndefined();
+        expect(game.csa).toBe("V2.2\n");
     });
 
     it("maps 404 to RshogiGameNotFoundError", async () => {

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -304,8 +304,17 @@ interface GameWireBase {
     event?: string | null;
 }
 
-interface GameDetailWire extends GameWireBase {
+/**
+ * 単局 GET (`/api/v1/games/:gameId`) のレスポンス (wire)。
+ *
+ * 一覧 (`GameWireBase` をフラットに並べる) と異なり、サーバ
+ * (rshogi-csa-server-workers viewer_api.rs::GameResponse) はメタを `meta` に
+ * ネストして返す。`meta` の中身は一覧 entry と同じ shape。
+ */
+interface GameDetailWire {
+    game_id: string;
     csa: string;
+    meta?: GameWireBase | null;
 }
 
 interface GameListResponseWire {
@@ -476,14 +485,19 @@ const decodeGameSummary = (wire: GameWireBase): RshogiGameSummary => ({
 });
 
 const decodeGameDetail = (wire: GameDetailWire): RshogiGame => {
-    const summary = decodeGameSummary(wire);
+    const metaWire: GameWireBase = wire.meta ?? {
+        game_id: wire.game_id,
+        black_handle: "",
+        white_handle: "",
+    };
+    const summary = decodeGameSummary(metaWire);
     const meta: RshogiGameMeta = {
-        gameId: summary.gameId,
+        gameId: wire.game_id,
         senteName: summary.senteName,
         goteName: summary.goteName,
         startedAtMs: summary.startedAtMs,
         endedAtMs: summary.endedAtMs,
-        event: decodeStringOrUndefined(wire.event ?? undefined),
+        event: decodeStringOrUndefined(metaWire.event ?? undefined),
         timeControl: summary.timeControl,
         result: summary.result,
         source: summary.source,

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -135,11 +135,14 @@ const createStaticGameFetch = () =>
             new Response(
                 JSON.stringify({
                     game_id: "game-1",
-                    black_handle: "alice",
-                    white_handle: "bob",
-                    result_kind: "WIN_WHITE",
-                    end_reason: "RESIGN",
                     csa: "V2.2\nN+alice\nN-bob\nPI\n+\n+7776FU\n%TORYO\n",
+                    meta: {
+                        game_id: "game-1",
+                        black_handle: "alice",
+                        white_handle: "bob",
+                        result_kind: "WIN_WHITE",
+                        end_reason: "RESIGN",
+                    },
                 }),
                 { status: 200, headers: { "content-type": "application/json" } },
             ),
@@ -159,11 +162,14 @@ const createInvalidStaticGameFetch = () =>
             new Response(
                 JSON.stringify({
                     game_id: "game-1",
-                    black_handle: "alice",
-                    white_handle: "bob",
-                    result_kind: "WIN_WHITE",
-                    end_reason: "RESIGN",
                     csa: "not csa",
+                    meta: {
+                        game_id: "game-1",
+                        black_handle: "alice",
+                        white_handle: "bob",
+                        result_kind: "WIN_WHITE",
+                        end_reason: "RESIGN",
+                    },
                 }),
                 { status: 200, headers: { "content-type": "application/json" } },
             ),

--- a/packages/ui/src/components/rshogi-csa-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.test.tsx
@@ -59,20 +59,36 @@ describe("RshogiCsaViewer: 対局情報パネル", () => {
         expect(screen.queryByText(/不明/)).toBeNull();
     });
 
-    it("winner なしの中断を引き分けと表示しない", async () => {
+    it("winner なしの異常終了を引き分けと表示しない", async () => {
         vi.mocked(fetchRshogiGame).mockResolvedValue({
             meta: {
                 gameId: GAME_ID,
                 senteName: "alice",
                 goteName: "bob",
-                result: { kind: "abort", endReason: "ILLEGAL" },
+                result: { kind: "abnormal", endReason: "ABNORMAL" },
             },
             csa: CSA_TEXT,
         });
 
         renderViewer();
 
-        expect(await screen.findByText("結果: 勝敗なし (中断)")).toBeTruthy();
+        expect(await screen.findByText("結果: 勝敗なし (異常終了)")).toBeTruthy();
+    });
+
+    it("反則時は勝者と反則を表示する", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                result: { kind: "abort", winner: "gote", endReason: "ILLEGAL" },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("結果: 後手 (bob) 勝ち (反則)")).toBeTruthy();
     });
 
     it("千日手は引き分けと表示する", async () => {

--- a/packages/ui/src/components/rshogi-csa-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.test.tsx
@@ -109,7 +109,28 @@ describe("RshogiCsaViewer: 対局情報パネル", () => {
 
         renderViewer();
 
-        expect(await screen.findByText("持ち時間: 1分 + 秒読み0.25秒")).toBeTruthy();
+        expect(await screen.findByText("持ち時間: 30秒 + 秒読み0.25秒")).toBeTruthy();
+    });
+
+    it("10秒の持ち時間と100msの秒読みを丸めず表示する", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                timeControl: {
+                    kind: "countdown_msec",
+                    mainSeconds: 10,
+                    byoyomiSeconds: 0,
+                    byoyomiMilliseconds: 100,
+                },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("持ち時間: 10秒 + 秒読み0.1秒")).toBeTruthy();
     });
 });
 

--- a/packages/ui/src/components/rshogi-csa-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.test.tsx
@@ -36,6 +36,83 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
+describe("RshogiCsaViewer: 対局情報パネル", () => {
+    it("メタ (対局者・時刻・持ち時間・結果) を表示する", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                startedAtMs: 1784307914273,
+                endedAtMs: 1784309092948,
+                timeControl: { kind: "countdown", mainSeconds: 600, byoyomiSeconds: 10 },
+                result: { kind: "resignation", winner: "gote", endReason: "RESIGN" },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("☗ alice vs ☖ bob")).toBeTruthy();
+        expect(screen.getByText("持ち時間: 10分 + 秒読み10秒")).toBeTruthy();
+        expect(screen.getByText("結果: 後手 (bob) 勝ち (投了)")).toBeTruthy();
+        expect(screen.queryByText(/不明/)).toBeNull();
+    });
+
+    it("winner なしの中断を引き分けと表示しない", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                result: { kind: "abort", endReason: "ILLEGAL" },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("結果: 勝敗なし (中断)")).toBeTruthy();
+    });
+
+    it("千日手は引き分けと表示する", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                result: { kind: "draw", endReason: "SENNICHITE" },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("結果: 引き分け (千日手)")).toBeTruthy();
+    });
+
+    it("秒未満の秒読みは ms から表示する", async () => {
+        vi.mocked(fetchRshogiGame).mockResolvedValue({
+            meta: {
+                gameId: GAME_ID,
+                senteName: "alice",
+                goteName: "bob",
+                timeControl: {
+                    kind: "countdown_msec",
+                    mainSeconds: 30,
+                    byoyomiSeconds: 0,
+                    byoyomiMilliseconds: 250,
+                },
+            },
+            csa: CSA_TEXT,
+        });
+
+        renderViewer();
+
+        expect(await screen.findByText("持ち時間: 1分 + 秒読み0.25秒")).toBeTruthy();
+    });
+});
+
 describe("RshogiCsaViewer", () => {
     it("ready 状態で CSA ダウンロードボタンを表示する", async () => {
         vi.mocked(fetchRshogiGame).mockResolvedValue(GAME);

--- a/packages/ui/src/components/rshogi-csa-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.tsx
@@ -96,7 +96,8 @@ const formatResult = (meta: RshogiGame["meta"]): string => {
               : result.kind === "draw" || result.kind === "max_moves"
                 ? "引き分け"
                 : "勝敗なし";
-    const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
+    const reason =
+        result.endReason === "ILLEGAL" ? "反則" : (RESULT_KIND_LABEL[result.kind] ?? "終局");
     return `結果: ${winnerLabel} (${reason})`;
 };
 

--- a/packages/ui/src/components/rshogi-csa-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.tsx
@@ -47,9 +47,17 @@ const formatTimestampMs = (value: number | undefined): string => {
     return date.toLocaleString("ja-JP");
 };
 
+const formatMainTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes === 0) return `${remainingSeconds}秒`;
+    if (remainingSeconds === 0) return `${minutes}分`;
+    return `${minutes}分${remainingSeconds}秒`;
+};
+
 const formatTimeControl = (value: RshogiGame["meta"]["timeControl"]): string => {
     if (!value) return "持ち時間: 不明";
-    const main = `${Math.round(value.mainSeconds / 60)}分`;
+    const main = formatMainTime(value.mainSeconds);
     // byoyomiSeconds は ms からの丸め値なので、秒未満の秒読み (countdown_msec) は
     // ms 側を優先して 0.25秒 のように表示する
     const byoyomiValue =

--- a/packages/ui/src/components/rshogi-csa-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-viewer.tsx
@@ -50,7 +50,13 @@ const formatTimestampMs = (value: number | undefined): string => {
 const formatTimeControl = (value: RshogiGame["meta"]["timeControl"]): string => {
     if (!value) return "持ち時間: 不明";
     const main = `${Math.round(value.mainSeconds / 60)}分`;
-    const byoyomi = value.byoyomiSeconds > 0 ? ` + 秒読み${value.byoyomiSeconds}秒` : "";
+    // byoyomiSeconds は ms からの丸め値なので、秒未満の秒読み (countdown_msec) は
+    // ms 側を優先して 0.25秒 のように表示する
+    const byoyomiValue =
+        value.byoyomiMilliseconds !== undefined && value.byoyomiMilliseconds > 0
+            ? value.byoyomiMilliseconds / 1000
+            : value.byoyomiSeconds;
+    const byoyomi = byoyomiValue > 0 ? ` + 秒読み${byoyomiValue}秒` : "";
     const inc =
         value.incrementSeconds && value.incrementSeconds > 0
             ? ` + 加算${value.incrementSeconds}秒`
@@ -73,12 +79,15 @@ const RESULT_KIND_LABEL: Record<NonNullable<RshogiGame["meta"]["result"]>["kind"
 const formatResult = (meta: RshogiGame["meta"]): string => {
     const result = meta.result;
     if (!result) return "結果: 不明";
+    // winner なし = 引き分けとは限らない (中断・異常終了も winner なし)
     const winnerLabel =
         result.winner === "sente"
             ? `先手 (${meta.senteName}) 勝ち`
             : result.winner === "gote"
               ? `後手 (${meta.goteName}) 勝ち`
-              : "引き分け";
+              : result.kind === "draw" || result.kind === "max_moves"
+                ? "引き分け"
+                : "勝敗なし";
     const reason = RESULT_KIND_LABEL[result.kind] ?? "終局";
     return `結果: ${winnerLabel} (${reason})`;
 };


### PR DESCRIPTION
## 問題

本番 viewer (例: /rshogi-viewer/r6-s7n4-1784307906-1784307914209) で、決着済みの対局なのに対局情報パネルが「☗ vs ☖ / 開始: 不明 / 終了: 不明 / 持ち時間: 不明 / 結果: 不明」になっていた。

## 原因

単局 GET (`/api/v1/games/:gameId`) は rshogi-csa-server-workers (`viewer_api.rs::GameResponse`、issue SH11235/rshogi#551 設計 v3) がメタを `meta` にネストした `{game_id, csa, meta: {...}}` を返すが、match-client の decode 層は一覧 API (`/games` 等) と同じフラット形を仮定して読んでいたため、全メタが undefined に decode されていた。

## 修正

- `GameDetailWire` を `{game_id, csa, meta?}` に改め、`decodeGameDetail` が `wire.meta` から decode (meta 欠落時は空メタで縮退)
- メタが正しく decode されると顕在化するパネルの既存バグ 2 件を修正
  - winner なしの中断/異常終了が「引き分け」表示 → kind が draw/max_moves のときのみ引き分け、それ以外は「勝敗なし」
  - 秒未満の秒読み (countdown_msec、例 250ms) が非表示 → `byoyomiMilliseconds` 優先で「秒読み0.25秒」
- 単局 fetch テストをネスト形に更新 + meta 欠落縮退テスト、パネル表示テスト 4 本を追加

## 検証

- match-client 103 / ui 417 tests パス、typecheck・biome クリーン
- 本番 API 実データで end-to-end 確認: 該当対局が `rs-fb-shiba vs rs-fm-husky / countdown 600s+10s / 後手勝ち (投了)` に正しく decode されることを確認
- local dual review (Codex + Claude 独立レビュー) 2 周 APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNix1rgfM2xZ4CWZ3QcJYQ