### PR TITLE
fix(viewer): resync live clocks from server

### DIFF
--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -279,6 +279,104 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         ]);
     });
 
+    it("broadcast move 直後の ##[CLOCK] でサーバー残時間を毎手再同期する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+
+        ws.fireLines([
+            "+7776FU,T8",
+            '##[CLOCK] {"black_remaining_ms":595123,"white_remaining_ms":600000,"side_to_move":"gote","ply":1}',
+        ]);
+
+        expect(events.errors).toEqual([]);
+        expect(events.moves).toEqual([{ csaMove: "7g7f", elapsedSec: 8 }]);
+        expect(events.clocks).toHaveLength(2);
+        expect(events.clocks[1]).toEqual({
+            remainingMs: { sente: 595_123, gote: 600_000 },
+            sideToMove: "gote",
+            ply: 1,
+        });
+    });
+
+    it("MONITOR2 END 前に flush された queued move/clock を snapshot の権威値にする", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+
+        // summary clock は着手前だが、snapshot 構築中に ply1 が競合して pending
+        // queue の move/clock が END より前へ flush された実 server 順序を再現する。
+        ws.fireLines(
+            buildSnapshotLines([
+                "+7776FU,T8",
+                '##[CLOCK] {"black_remaining_ms":595123,"white_remaining_ms":600000,"side_to_move":"gote","ply":1}',
+            ]),
+        );
+
+        expect(events.errors).toEqual([]);
+        expect(events.snapshot).toHaveLength(1);
+        expect(events.snapshot[0].moves).toEqual(["7g7f"]);
+        expect(events.snapshot[0].clocks).toEqual({
+            sente: 595_123,
+            gote: 600_000,
+            sideToMove: "gote",
+        });
+        expect(events.clocks[0]).toEqual({
+            remainingMs: { sente: 595_123, gote: 600_000 },
+            sideToMove: "gote",
+        });
+    });
+
+    it("盤面より未来の ##[CLOCK] は適用せずエラー通知する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines([]));
+
+        ws.fireLines([
+            '##[CLOCK] {"black_remaining_ms":595123,"white_remaining_ms":600000,"side_to_move":"gote","ply":1}',
+        ]);
+
+        expect(events.clocks).toHaveLength(1);
+        expect(events.errors).toHaveLength(1);
+        expect(events.errors[0].message).toContain("does not match live position");
+    });
+
+    it("snapshot queue から届く盤面より古い ##[CLOCK] は静かに無視する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+        ws.fireLines(buildSnapshotLines(["+7776FU,T8", "-3334FU,T7"]));
+
+        ws.fireLines([
+            '##[CLOCK] {"black_remaining_ms":592000,"white_remaining_ms":600000,"side_to_move":"gote","ply":1}',
+        ]);
+
+        expect(events.clocks).toHaveLength(1);
+        expect(events.errors).toEqual([]);
+    });
+
     it("broadcast move の適用失敗を通知し、後続 move の購読を継続する", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         subscribeRshogiLiveGame(
@@ -824,6 +922,26 @@ describe("subscribeRshogiLiveGame: room full", () => {
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+describe("parseSpectatorClockUpdate", () => {
+    it("structured clock wire を decode し、不正 payload を拒否する", () => {
+        expect(
+            __test_internals.parseSpectatorClockUpdate(
+                '##[CLOCK] {"black_remaining_ms":445123,"white_remaining_ms":405987,"side_to_move":"sente","ply":48}',
+            ),
+        ).toEqual({
+            remainingMs: { sente: 445_123, gote: 405_987 },
+            sideToMove: "sente",
+            ply: 48,
+        });
+        expect(__test_internals.parseSpectatorClockUpdate("##[CLOCK] not-json")).toBeNull();
+        expect(
+            __test_internals.parseSpectatorClockUpdate(
+                '##[CLOCK] {"black_remaining_ms":-1,"white_remaining_ms":0,"side_to_move":"sente","ply":1}',
+            ),
+        ).toBeNull();
     });
 });
 

--- a/packages/match-client/src/rshogi-csa/live.test.ts
+++ b/packages/match-client/src/rshogi-csa/live.test.ts
@@ -338,6 +338,28 @@ describe("subscribeRshogiLiveGame: snapshot → broadcast → end → close", ()
         });
     });
 
+    it("snapshot 内の不正 CLOCK は通知し、summary clock で snapshot を継続する", () => {
+        const { wsInstances, wsFactory, events, callbacks } = makeMocks();
+        subscribeRshogiLiveGame(
+            "game-1",
+            { apiBaseUrl: "https://example.com", webSocketFactory: wsFactory },
+            callbacks,
+        );
+        const ws = wsInstances[0];
+        ws.fireOpen();
+
+        ws.fireLines(buildSnapshotLines(["##[CLOCK] not-json"]));
+
+        expect(events.snapshot).toHaveLength(1);
+        expect(events.snapshot[0].clocks).toEqual({
+            sente: 600_000,
+            gote: 600_000,
+            sideToMove: "sente",
+        });
+        expect(events.errors).toHaveLength(1);
+        expect(events.errors[0].message).toContain("invalid spectator clock update in snapshot");
+    });
+
     it("盤面より未来の ##[CLOCK] は適用せずエラー通知する", () => {
         const { wsInstances, wsFactory, events, callbacks } = makeMocks();
         subscribeRshogiLiveGame(

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -154,6 +154,9 @@ export interface RshogiLiveClockEvent {
     ply?: number;
 }
 
+/** server の毎手 clock wire。snapshot callback と異なり ply を必須にする。 */
+type RshogiLiveClockUpdate = RshogiLiveClockEvent & { ply: number };
+
 export type RshogiLiveConnectionState = "connecting" | "connected" | "reconnecting" | "closed";
 
 export type RshogiLiveStaticFallbackReason =
@@ -366,6 +369,8 @@ const deriveTimeControl = (summary: ParsedSummary): RshogiTimeControl | undefine
     };
 };
 
+const SPECTATOR_CLOCK_PREFIX = "##[CLOCK] ";
+
 /**
  * snapshot block の wire 行群を `RshogiLiveSnapshot` に decode する。
  *
@@ -380,11 +385,12 @@ const deriveTimeControl = (summary: ParsedSummary): RshogiTimeControl | undefine
 const decodeSnapshotBlock = (
     gameId: string,
     snapshotLines: string[],
-): { snapshot: RshogiLiveSnapshot; finalResultLine?: string } => {
+): { snapshot: RshogiLiveSnapshot; finalResultLine?: string; warnings: Error[] } => {
     const summaryLines: string[] = [];
     /** move 行を順に蓄積する (token + 消費秒 + 直後に来たコメント)。 */
     const moveEntries: { token: string; elapsedSec: number; comment?: RshogiLiveComment }[] = [];
-    const queuedClockUpdates: RshogiLiveClockEvent[] = [];
+    const queuedClockUpdates: RshogiLiveClockUpdate[] = [];
+    const warnings: Error[] = [];
     let resultCodeLine: string | undefined;
     let inSummary = false;
     for (const raw of snapshotLines) {
@@ -415,8 +421,14 @@ const decodeSnapshotBlock = (
         }
         if (line.startsWith(SPECTATOR_CLOCK_PREFIX)) {
             const clock = parseSpectatorClockUpdate(line);
-            if (!clock) throw new Error(`invalid spectator clock update in snapshot: ${line}`);
-            queuedClockUpdates.push(clock);
+            // summary clock は独立した fallback として完全なので、不正な追加 clock
+            // だけを非致命 warning にして snapshot 自体は適用する。live 行と同じく
+            // consumer の onError へ通知し、接続と後続 move の処理は継続する。
+            if (clock) {
+                queuedClockUpdates.push(clock);
+            } else {
+                warnings.push(new Error(`invalid spectator clock update in snapshot: ${line}`));
+            }
             continue;
         }
         if (line.startsWith("#")) {
@@ -486,7 +498,7 @@ const decodeSnapshotBlock = (
             : undefined,
     };
 
-    return { snapshot, finalResultLine: resultCodeLine };
+    return { snapshot, finalResultLine: resultCodeLine, warnings };
 };
 
 /**
@@ -667,15 +679,13 @@ const parseLiveComment = (line: string): RshogiLiveComment => {
     return { raw };
 };
 
-const SPECTATOR_CLOCK_PREFIX = "##[CLOCK] ";
-
 /**
  * サーバーが指し手直後に送る ms 粒度の権威時計を decode する。
  *
  * 旧サーバーはこの行を送らない。payload は型・範囲を検証し、不正値を UI の
  * 時計状態へ混入させない。
  */
-const parseSpectatorClockUpdate = (line: string): RshogiLiveClockEvent | null => {
+const parseSpectatorClockUpdate = (line: string): RshogiLiveClockUpdate | null => {
     if (!line.startsWith(SPECTATOR_CLOCK_PREFIX)) return null;
     let value: unknown;
     try {
@@ -1074,7 +1084,7 @@ export function subscribeRshogiLiveGame(
         snapshotLines = [];
         inSnapshot = false;
         try {
-            const { snapshot, finalResultLine } = decodeSnapshotBlock(gameId, lines);
+            const { snapshot, finalResultLine, warnings } = decodeSnapshotBlock(gameId, lines);
             liveState = snapshot.state;
             liveTurn = snapshot.clocks.sideToMove;
             // ply カウンタを snapshot 手数に同期。以降の broadcast move で +1 され、
@@ -1099,6 +1109,7 @@ export function subscribeRshogiLiveGame(
                     err instanceof Error ? err : new Error(`onClock handler threw: ${String(err)}`),
                 );
             }
+            for (const warning of warnings) emitError(warning);
             // 終局済 DO に接続したケース: snapshot 内に result_code 行がある。
             if (finalResultLine && snapshot.finalResult) {
                 requestStaticFallback("terminal-snapshot");
@@ -1123,7 +1134,7 @@ export function subscribeRshogiLiveGame(
             // snapshot 中に queue された clock は、snapshot 自体がその ply を既に含むと
             // 古い順に flush される。それらは正常な競合なので静かに捨て、現在より未来の
             // ply または同一 ply で手番不一致だけを protocol error とする。
-            if (clock.ply !== undefined && clock.ply < liveMoveCount) return;
+            if (clock.ply < liveMoveCount) return;
             if (clock.ply !== liveMoveCount || clock.sideToMove !== liveTurn) {
                 emitError(
                     new Error(

--- a/packages/match-client/src/rshogi-csa/live.ts
+++ b/packages/match-client/src/rshogi-csa/live.ts
@@ -9,7 +9,8 @@
  *    `Black/White_Time_Remaining_Ms:` から残時間を抽出して `onClock`、
  *    move 行を `parseCsaMoves` でフル再パースして `onSnapshot`
  * 3. snapshot 後の broadcast move 行は `parseSingleCsaMove` で 1 手ずつ apply
- *    し `onMove` を発火
+ *    し `onMove` を発火。続く `##[CLOCK]` 行があればサーバーの ms 粒度残時間で
+ *    `onClock` を発火し、表示用時計を毎手再同期
  * 4. `%TORYO` / `%KACHI` / `%TIME_UP` / `#RESIGN` / `#TIME_UP` 等の終局コードで
  *    `onEnd` を発火し、reconnect 経路を停止
  *
@@ -145,10 +146,12 @@ export interface RshogiLiveMoveCommentEvent {
     comment: RshogiLiveComment;
 }
 
-/** snapshot 受信時の clock 同期イベント。 */
+/** snapshot または指し手直後の clock 同期イベント。 */
 export interface RshogiLiveClockEvent {
     remainingMs: { sente: number; gote: number };
     sideToMove: "sente" | "gote";
+    /** live の毎手同期では対応する手数。snapshot 同期では undefined。 */
+    ply?: number;
 }
 
 export type RshogiLiveConnectionState = "connecting" | "connected" | "reconnecting" | "closed";
@@ -168,14 +171,14 @@ export class RshogiLiveRoomFullError extends Error {
 export interface RshogiLiveCallbacks {
     /** 初回 + 再接続時に毎回呼ばれる (state を全置換)。 */
     onSnapshot(snapshot: RshogiLiveSnapshot): void;
-    /** 1 手 broadcast の到着。残り時間は本 callback には載せない (client 側 timer で計算)。 */
+    /** 1 手 broadcast の到着。旧サーバー互換のため client 側でも時計を暫定計算する。 */
     onMove(event: RshogiLiveMoveEvent): void;
     /**
      * move コメント (eval / PV) の到着。live stream では move 行の直後に別行で届く。
      * 任意 callback (旧 consumer との後方互換のため optional)。
      */
     onMoveComment?(event: RshogiLiveMoveCommentEvent): void;
-    /** clock countdown を再同期する任意 callback。snapshot 受信時のみ呼ばれる。 */
+    /** clock countdown を再同期する callback。snapshot と毎手の権威時計で呼ばれる。 */
     onClock(event: RshogiLiveClockEvent): void;
     /** 終局検知。`onEnd` 発火後は reconnect 経路を停止する。 */
     onEnd(result: RshogiGameResult): void;
@@ -369,6 +372,7 @@ const deriveTimeControl = (summary: ParsedSummary): RshogiTimeControl | undefine
  * snapshot 行群は以下の構造で並ぶ前提:
  * - `BEGIN Game_Summary` ... `END Game_Summary`
  * - move 行 (1 行 1 手、`+7776FU,T3` 形式)
+ * - snapshot 中に着手が競合した場合、queued move に続く `##[CLOCK]` 行
  * - 終局済 DO の場合のみ末尾に `#RESIGN` / `#TIME_UP` 等の result_code 行
  *
  * `BEGIN MONITOR2` / `END MONITOR2` 行自体は本関数には渡らない契約。
@@ -380,6 +384,7 @@ const decodeSnapshotBlock = (
     const summaryLines: string[] = [];
     /** move 行を順に蓄積する (token + 消費秒 + 直後に来たコメント)。 */
     const moveEntries: { token: string; elapsedSec: number; comment?: RshogiLiveComment }[] = [];
+    const queuedClockUpdates: RshogiLiveClockEvent[] = [];
     let resultCodeLine: string | undefined;
     let inSummary = false;
     for (const raw of snapshotLines) {
@@ -406,6 +411,12 @@ const decodeSnapshotBlock = (
             // `'` コメント行は直前の move 行に属する。move が未出現なら握り潰す。
             const last = moveEntries[moveEntries.length - 1];
             if (last) last.comment = parseLiveComment(line);
+            continue;
+        }
+        if (line.startsWith(SPECTATOR_CLOCK_PREFIX)) {
+            const clock = parseSpectatorClockUpdate(line);
+            if (!clock) throw new Error(`invalid spectator clock update in snapshot: ${line}`);
+            queuedClockUpdates.push(clock);
             continue;
         }
         if (line.startsWith("#")) {
@@ -450,6 +461,15 @@ const decodeSnapshotBlock = (
 
     // To_Move は初期局面手番であり現在手番ではないため、replay 後の手番を表示する。
     const sideToMove: "sente" | "gote" = state.turn;
+    // server は snapshot pending queue を MONITOR2 END より前に flush する。summary
+    // clock 採取後に着手が競合すると move と CLOCK がともに block 内へ入るため、
+    // replay 後の ply/手番に一致する最後の CLOCK を summary より優先する。
+    let authoritativeClock: RshogiLiveClockEvent | undefined;
+    for (const clock of queuedClockUpdates) {
+        if (clock.ply === moves.length && clock.sideToMove === sideToMove) {
+            authoritativeClock = clock;
+        }
+    }
 
     const snapshot: RshogiLiveSnapshot = {
         meta,
@@ -457,8 +477,8 @@ const decodeSnapshotBlock = (
         moveDetails,
         state,
         clocks: {
-            sente: summary.blackRemainingMs ?? 0,
-            gote: summary.whiteRemainingMs ?? 0,
+            sente: authoritativeClock?.remainingMs.sente ?? summary.blackRemainingMs ?? 0,
+            gote: authoritativeClock?.remainingMs.gote ?? summary.whiteRemainingMs ?? 0,
             sideToMove,
         },
         finalResult: resultCodeLine
@@ -645,6 +665,46 @@ const parseLiveComment = (line: string): RshogiLiveComment => {
         }
     }
     return { raw };
+};
+
+const SPECTATOR_CLOCK_PREFIX = "##[CLOCK] ";
+
+/**
+ * サーバーが指し手直後に送る ms 粒度の権威時計を decode する。
+ *
+ * 旧サーバーはこの行を送らない。payload は型・範囲を検証し、不正値を UI の
+ * 時計状態へ混入させない。
+ */
+const parseSpectatorClockUpdate = (line: string): RshogiLiveClockEvent | null => {
+    if (!line.startsWith(SPECTATOR_CLOCK_PREFIX)) return null;
+    let value: unknown;
+    try {
+        value = JSON.parse(line.slice(SPECTATOR_CLOCK_PREFIX.length));
+    } catch {
+        return null;
+    }
+    if (typeof value !== "object" || value === null) return null;
+    const wire = value as Record<string, unknown>;
+    const black = wire.black_remaining_ms;
+    const white = wire.white_remaining_ms;
+    const side = wire.side_to_move;
+    const ply = wire.ply;
+    if (
+        !Number.isSafeInteger(black) ||
+        (black as number) < 0 ||
+        !Number.isSafeInteger(white) ||
+        (white as number) < 0 ||
+        (side !== "sente" && side !== "gote") ||
+        !Number.isSafeInteger(ply) ||
+        (ply as number) < 1
+    ) {
+        return null;
+    }
+    return {
+        remainingMs: { sente: black as number, gote: white as number },
+        sideToMove: side,
+        ply: ply as number,
+    };
 };
 
 const isRoomFullText = (value: string): boolean => {
@@ -1054,6 +1114,33 @@ export function subscribeRshogiLiveGame(
     const handleLiveLine = (line: string) => {
         const trimmed = line.trim();
         if (trimmed.length === 0) return;
+        if (trimmed.startsWith(SPECTATOR_CLOCK_PREFIX)) {
+            const clock = parseSpectatorClockUpdate(trimmed);
+            if (!clock) {
+                emitError(new Error(`invalid spectator clock update: ${trimmed}`));
+                return;
+            }
+            // snapshot 中に queue された clock は、snapshot 自体がその ply を既に含むと
+            // 古い順に flush される。それらは正常な競合なので静かに捨て、現在より未来の
+            // ply または同一 ply で手番不一致だけを protocol error とする。
+            if (clock.ply !== undefined && clock.ply < liveMoveCount) return;
+            if (clock.ply !== liveMoveCount || clock.sideToMove !== liveTurn) {
+                emitError(
+                    new Error(
+                        `spectator clock update does not match live position: ply=${clock.ply}, expectedPly=${liveMoveCount}, side=${clock.sideToMove}, expectedSide=${liveTurn}`,
+                    ),
+                );
+                return;
+            }
+            try {
+                callbacks.onClock(clock);
+            } catch (err) {
+                emitError(
+                    err instanceof Error ? err : new Error(`onClock handler threw: ${String(err)}`),
+                );
+            }
+            return;
+        }
         // `'` コメント行は直前 move に属する。move / 終局判定より前に処理して、
         // 絶対に move 行・終局行として扱われないようにする (detectEndLine は `'`
         // に一致しないが、順序で確実に防御する)。
@@ -1344,4 +1431,5 @@ export const __test_internals = {
     extractElapsedSec,
     parseGameSummaryLines,
     parseLiveComment,
+    parseSpectatorClockUpdate,
 };

--- a/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.test.tsx
@@ -9,6 +9,7 @@ import {
     computeRemaining,
     deriveInByoyomi,
     formatByoyomiClock,
+    formatLiveTimeControl,
     formatOwnEval,
     type LiveClocks,
     moveDetailsToEvals,
@@ -24,11 +25,14 @@ vi.mock("./shogi-match", () => ({
     ShogiMatch: ({
         initialReview,
         reviewLeftContent,
+        reviewTopContent,
     }: {
         initialReview?: { moves?: string[] };
         reviewLeftContent?: ReactNode;
+        reviewTopContent?: ReactNode;
     }) => (
         <div data-testid="shogi-match" data-move-count={initialReview?.moves?.length ?? 0}>
+            {reviewTopContent}
             {reviewLeftContent}
         </div>
     ),
@@ -127,6 +131,15 @@ const buildLiveSnapshot = (moves: string[] = [], finalCode?: string): string[] =
     if (finalCode) lines.push(finalCode);
     lines.push("##[MONITOR2] END");
     return lines;
+};
+
+const buildTimedLiveSnapshot = (moves: string[] = []): string[] => {
+    const lines = LIVE_SNAPSHOT_LINES.flatMap((line) =>
+        line === "Black_Time_Remaining_Ms:600000"
+            ? ["BEGIN Time", "Time_Unit:1sec", "Total_Time:600", "Byoyomi:10", "END Time", line]
+            : [line],
+    );
+    return [...lines, ...moves, "##[MONITOR2] END"];
 };
 
 const createStaticGameFetch = () =>
@@ -419,6 +432,33 @@ describe("RshogiCsaLiveViewer: static fallback", () => {
             vi.useRealTimers();
         }
     });
+
+    it("毎手の権威 clock で暫定計算を上書きし、時間ルールも表示する", () => {
+        render(
+            <RshogiCsaLiveViewer
+                gameId="game-1"
+                engineOptions={[]}
+                manifestUrl="/nnue/manifest.json"
+                apiBaseUrl="https://example.com/api/v1"
+            />,
+        );
+
+        const ws = MockWebSocket.instances[0];
+        act(() => {
+            ws.fireOpen();
+            ws.fireLines(buildTimedLiveSnapshot());
+            // T8 の client 暫定値は 592s (09:52) だが、直後の server clock 595.123s
+            // (09:55) が権威値として上書きされる。
+            ws.fireLines([
+                "+7776FU,T8",
+                '##[CLOCK] {"black_remaining_ms":595123,"white_remaining_ms":600000,"side_to_move":"gote","ply":1}',
+            ]);
+        });
+
+        expect(screen.getByText("09:55")).toBeDefined();
+        expect(screen.queryByText("09:52")).toBeNull();
+        expect(screen.getByText("10分 + 秒読み10秒")).toBeDefined();
+    });
 });
 
 describe("computeRemaining", () => {
@@ -499,6 +539,15 @@ describe("formatByoyomiClock", () => {
         expect(formatByoyomiClock(119_999)).toBe("1:59");
         expect(formatByoyomiClock(120_000)).toBe("2:00");
         expect(formatByoyomiClock(0)).toBe("0:00");
+    });
+});
+
+describe("formatLiveTimeControl", () => {
+    it("Fischer 加算と秒読みを区別して表示する", () => {
+        expect(formatLiveTimeControl(FISCHER)).toBe("1分 + 1手5秒加算");
+        expect(formatLiveTimeControl(COUNTDOWN)).toBe("10分 + 秒読み10秒");
+        expect(formatLiveTimeControl(COUNTDOWN_MSEC)).toBe("10秒 + 秒読み0.5秒");
+        expect(formatLiveTimeControl(SUDDEN_DEATH)).toBe("5分 (切れ負け)");
     });
 });
 

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -281,7 +281,9 @@ export const formatByoyomiClock = (ms: number): string => {
 
 const formatRuleSeconds = (ms: number): string => {
     const seconds = Math.max(0, ms) / 1000;
-    return Number.isInteger(seconds) ? String(seconds) : String(Number(seconds.toFixed(3)));
+    return Number.isInteger(seconds)
+        ? String(seconds)
+        : String(Number.parseFloat(seconds.toFixed(3)));
 };
 
 /** live scoreboard に表示する時間ルールを、加算と秒読みを区別して整形する。 */
@@ -293,7 +295,7 @@ export const formatLiveTimeControl = (timeControl: RshogiTimeControl): string =>
     if (timeControl.kind === "fischer") {
         return `${main} + 1手${timeControl.incrementSeconds ?? 0}秒加算`;
     }
-    const byoyomiMs = timeControl.byoyomiMilliseconds ?? (timeControl.byoyomiSeconds ?? 0) * 1000;
+    const byoyomiMs = byoyomiFullMs(timeControl);
     return byoyomiMs > 0
         ? `${main} + 秒読み${formatRuleSeconds(byoyomiMs)}秒`
         : `${main} (切れ負け)`;

--- a/packages/ui/src/components/rshogi-csa-live-viewer.tsx
+++ b/packages/ui/src/components/rshogi-csa-live-viewer.tsx
@@ -8,7 +8,8 @@
  *   broadcast move では key を変えず initialReview.moves を伸ばし、prop 更新で反映する
  *   (毎手 remount しないので盤・棋譜がちらつかない)。
  * - 対局者・時計・手数・接続状態は上部のブロードキャスト・スコアボードに集約表示する。
- * - clock countdown は server の残時間を anchor に local timer で 1Hz 減算する。
+ * - clock countdown は server の残時間を anchor に local timer で補間し、毎手の
+ *   `##[CLOCK]` で権威値へ再同期する (旧 server は `T` から暫定計算)。
  * - 終局時に最終結果を表示する。
  */
 
@@ -276,6 +277,26 @@ export const formatByoyomiClock = (ms: number): string => {
     // 1:00 とは表示せず 0:59 に留める。
     const sec = Math.min(59, secWithinMinute);
     return `${min}:${String(sec).padStart(2, "0")}`;
+};
+
+const formatRuleSeconds = (ms: number): string => {
+    const seconds = Math.max(0, ms) / 1000;
+    return Number.isInteger(seconds) ? String(seconds) : String(Number(seconds.toFixed(3)));
+};
+
+/** live scoreboard に表示する時間ルールを、加算と秒読みを区別して整形する。 */
+export const formatLiveTimeControl = (timeControl: RshogiTimeControl): string => {
+    const main =
+        timeControl.mainSeconds > 0 && timeControl.mainSeconds % 60 === 0
+            ? `${timeControl.mainSeconds / 60}分`
+            : `${timeControl.mainSeconds}秒`;
+    if (timeControl.kind === "fischer") {
+        return `${main} + 1手${timeControl.incrementSeconds ?? 0}秒加算`;
+    }
+    const byoyomiMs = timeControl.byoyomiMilliseconds ?? (timeControl.byoyomiSeconds ?? 0) * 1000;
+    return byoyomiMs > 0
+        ? `${main} + 秒読み${formatRuleSeconds(byoyomiMs)}秒`
+        : `${main} (切れ負け)`;
 };
 
 /** timeControl から秒読みの full 量 (ms) を取り出す (ms 粒度優先、無ければ秒→ms)。 */
@@ -636,6 +657,11 @@ export function RshogiLiveScoreboard({
                     </span>
                 )}
                 <span className="text-xs text-muted-foreground">{turnLabel}</span>
+                {meta.timeControl && (
+                    <span className="text-center text-[11px] leading-tight text-muted-foreground">
+                        {formatLiveTimeControl(meta.timeControl)}
+                    </span>
+                )}
                 {lastMoveElapsedSec !== undefined && (
                     <span className="text-[11px] tabular-nums text-muted-foreground">
                         直前手 {lastMoveElapsedSec}秒
@@ -842,10 +868,9 @@ export function RshogiCsaLiveViewer({
                         moves: [...prev.moves, csaMove],
                         // 新規手を付随情報配列にも追加 (この時点では消費秒のみ、eval は後追い)。
                         moveEvals: appendMoveEval(prev.moveEvals, elapsedSec),
-                        // broadcast move 到着時に手番側 (= mover) の時計を kind ごとの
-                        // ルールで更新し、手番を相手側へ切り替える。local wall-clock では
-                        // なく wire の権威ある elapsedSec を使う (本 fix の要点)。
-                        // 秒切り捨て由来の最大 1 秒のドリフトは snapshot resync で補正される。
+                        // broadcast move 到着時は旧サーバー互換のため、手番側 (= mover) の
+                        // 時計を T<elapsedSec> から暫定更新する。新サーバーでは直後の
+                        // ##[CLOCK] → onClock が ms 粒度の権威値で上書きする。
                         clocks: prev.clocks
                             ? applyMoveToClocks(
                                   prev.clocks,
@@ -869,11 +894,10 @@ export function RshogiCsaLiveViewer({
             },
             onClock({ remainingMs, sideToMove }) {
                 setState((prev) => {
-                    // onClock は snapshot 完了直後 (onSnapshot の後) にのみ発火するため、
-                    // prev.snapshot は既に最新へ更新済み。そこから timeControl を引き、
-                    // 本体残 0 の秒読み局面を即座に秒読み表示へ乗せる。
-                    // もし契約外に snapshot なしで届いた場合は timeControl undefined とし、
-                    // 秒読み判定をスキップする (安全側で本体時計表示に寄せる)。
+                    // snapshot 完了直後と各 broadcast move 直後に届く権威時計で再同期する。
+                    // prev.snapshot から timeControl を引き、本体残 0 の秒読み局面も即座に
+                    // 秒読み表示へ乗せる。旧サーバーでは snapshot 時だけ呼ばれ、各 move は
+                    // applyMoveToClocks の暫定計算を継続するため後方互換を保つ。
                     const timeControl = prev.snapshot?.meta.timeControl;
                     return {
                         ...prev,


### PR DESCRIPTION
## 概要

rshogi live viewer の時計を、各指し手後にサーバーの ms 粒度残時間へ再同期します。対象ゲームの実ルールは 10分 + 1手10秒加算ではなく、10分 + 秒読み10秒でした。UI にルール種別を明示し、Fischer 加算と秒読みを区別します。

## 変更

- CLOCK control 行の厳格な decode と ply/手番検証
- snapshot 中の queued move/clock 競合でも最終盤面に一致する権威時計を採用
- 旧 server では従来の T 秒によるローカル計算を fallback として維持
- scoreboard に 10分 + 秒読み10秒 / 1手N秒加算などを表示
- parser、snapshot race、UI統合、時間ルール表示のテストを追加

## Server dependency

- https://github.com/SH11235/rshogi/pull/947
- 両側とも後方互換のため deploy 順序を問いませんが、staging では server を先に検証します。

## 検証

- match-client: 108 tests
- UI: 421 tests
- match-client / UI build and typecheck
- Biome lint / format
- git diff --check
- 別エージェント独立レビュー: APPROVE