### PR TITLE
feat(web): add rshogi player ratings UI

### DIFF
--- a/apps/web/src/components/NavDrawer.test.tsx
+++ b/apps/web/src/components/NavDrawer.test.tsx
@@ -55,6 +55,7 @@ describe("NavDrawer", () => {
             "マイ棋譜 要ログイン",
             "公開棋譜",
             "ライブ観戦",
+            "選手番付",
             "CSA 棋譜ビューア",
             "NNUE モデル 要ログイン",
             "ログイン",
@@ -82,6 +83,14 @@ describe("NavDrawer", () => {
         expect(screen.getByRole("link", { name: "ライブ観戦" }).getAttribute("aria-current")).toBe(
             null,
         );
+
+        const playerSections = buildNavSections("/rshogi-viewer/players/p_one");
+        const activePlayerItems = playerSections
+            .flatMap((section) => section.items)
+            .filter((item) => item.active);
+        expect(activePlayerItems).toEqual([
+            expect.objectContaining({ to: "/rshogi-viewer/players" }),
+        ]);
     });
 
     it("リンククリックでドロワーを閉じる", async () => {

--- a/apps/web/src/components/NavDrawer.tsx
+++ b/apps/web/src/components/NavDrawer.tsx
@@ -12,6 +12,7 @@ type NavTo =
     | "/games"
     | "/public/games"
     | "/rshogi-viewer/live"
+    | "/rshogi-viewer/players"
     | "/rshogi-viewer"
     | "/nnue"
     | "/auth";
@@ -37,6 +38,8 @@ function isLiveViewerPath(pathname: string): boolean {
 
 function buildNavSections(pathname: string): NavSection[] {
     const isLive = isLiveViewerPath(pathname);
+    const isPlayers =
+        pathname === "/rshogi-viewer/players" || pathname.startsWith("/rshogi-viewer/players/");
 
     return [
         {
@@ -70,10 +73,11 @@ function buildNavSections(pathname: string): NavSection[] {
             label: "観戦",
             items: [
                 { to: "/rshogi-viewer/live", label: "ライブ観戦", active: isLive },
+                { to: "/rshogi-viewer/players", label: "選手番付", active: isPlayers },
                 {
                     to: "/rshogi-viewer",
                     label: "CSA 棋譜ビューア",
-                    active: pathname.startsWith("/rshogi-viewer") && !isLive,
+                    active: pathname.startsWith("/rshogi-viewer") && !isLive && !isPlayers,
                 },
             ],
         },

--- a/apps/web/src/lib/rshogiApiBaseUrl.test.ts
+++ b/apps/web/src/lib/rshogiApiBaseUrl.test.ts
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolveRshogiApiBaseUrl } from "./rshogiApiBaseUrl";
+
+describe("resolveRshogiApiBaseUrl", () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    it("前後の空白を除いて API URL を返す", () => {
+        vi.stubEnv("VITE_RSHOGI_API_BASE", "  https://rshogi.example.test/api/v1/  ");
+        expect(resolveRshogiApiBaseUrl()).toBe("https://rshogi.example.test/api/v1/");
+    });
+
+    it("空文字は未設定として扱う", () => {
+        vi.stubEnv("VITE_RSHOGI_API_BASE", "   ");
+        expect(resolveRshogiApiBaseUrl()).toBeUndefined();
+    });
+});

--- a/apps/web/src/lib/rshogiApiBaseUrl.ts
+++ b/apps/web/src/lib/rshogiApiBaseUrl.ts
@@ -1,0 +1,5 @@
+/** rshogi viewer API の Vite 設定値を正規化して返す。 */
+export const resolveRshogiApiBaseUrl = (): string | undefined => {
+    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
+    return raw?.trim() || undefined;
+};

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchRshogiPlayerDetail = vi.fn();
+const navigate = vi.fn();
+
+vi.mock("@shogi/match-client", () => ({ fetchRshogiPlayerDetail }));
+vi.mock("@tanstack/react-router", () => ({
+    getRouteApi: () => ({ useParams: () => ({ playerId: "p_one" }) }),
+    Link: ({ children }: { children: ReactNode }) => <a href="/players">{children}</a>,
+    useNavigate: () => navigate,
+}));
+vi.mock("@shogi/ui/components/rshogi-csa-game-list", () => ({
+    RshogiCsaGameList: ({
+        games,
+        onSelect,
+    }: {
+        games: { gameId: string }[];
+        onSelect: (gameId: string) => void;
+    }) => (
+        <button type="button" onClick={() => onSelect(games[0].gameId)}>
+            {games[0].gameId}
+        </button>
+    ),
+}));
+vi.mock("../../components/HeaderNav", () => ({ HeaderNav: () => null }));
+vi.mock("../../components/PageHeader", () => ({ PageHeader: () => null }));
+vi.mock("../../components/PageContainer", () => ({
+    PageContainer: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+vi.mock("../../components/StatusBanner", () => ({
+    StatusBanner: ({ children }: { children: ReactNode }) => <div role="alert">{children}</div>,
+}));
+
+const detail = {
+    player: {
+        playerId: "p_one",
+        displayName: "銀将",
+        rating: 1612,
+        games: 21,
+        wins: 12,
+        losses: 7,
+        draws: 2,
+        lastPlayedAtMs: 1_777_392_877_244,
+        legacy: false,
+    },
+    games: [{ gameId: "game-1" }],
+    page: 1,
+    pageSize: 20,
+    totalCount: 21,
+};
+
+const { default: RshogiPlayerDetailPage } = await import("./RshogiPlayerDetailPage");
+
+describe("RshogiPlayerDetailPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchRshogiPlayerDetail.mockResolvedValue(detail);
+    });
+
+    it("選手成績、対局履歴、ページ移動を表示する", async () => {
+        render(<RshogiPlayerDetailPage />);
+        expect(await screen.findByRole("heading", { name: "銀将" })).toBeTruthy();
+        expect(screen.getByText("1,612")).toBeTruthy();
+        expect(screen.getByText("全 21 局")).toBeTruthy();
+        expect(fetchRshogiPlayerDetail).toHaveBeenCalledWith(
+            "p_one",
+            expect.objectContaining({ page: 1, pageSize: 20 }),
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "game-1" }));
+        expect(navigate).toHaveBeenCalledWith({
+            to: "/rshogi-viewer/$gameId",
+            params: { gameId: "game-1" },
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "古い対局 →" }));
+        await waitFor(() =>
+            expect(fetchRshogiPlayerDetail).toHaveBeenLastCalledWith(
+                "p_one",
+                expect.objectContaining({ page: 2, pageSize: 20 }),
+            ),
+        );
+    });
+
+    it("取得失敗を表示する", async () => {
+        fetchRshogiPlayerDetail.mockRejectedValueOnce(new Error("player unavailable"));
+        render(<RshogiPlayerDetailPage />);
+        expect((await screen.findByRole("alert")).textContent).toContain("player unavailable");
+    });
+});

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
@@ -56,7 +56,16 @@ const { default: RshogiPlayerDetailPage } = await import("./RshogiPlayerDetailPa
 describe("RshogiPlayerDetailPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        fetchRshogiPlayerDetail.mockResolvedValue(detail);
+        fetchRshogiPlayerDetail.mockImplementation(
+            (_playerId: string, options: { page?: number }) => {
+                const page = options.page ?? 1;
+                return Promise.resolve({
+                    ...detail,
+                    games: [{ gameId: `game-${page}` }],
+                    page,
+                });
+            },
+        );
     });
 
     it("選手成績、対局履歴、ページ移動を表示する", async () => {
@@ -82,6 +91,24 @@ describe("RshogiPlayerDetailPage", () => {
                 expect.objectContaining({ page: 2, pageSize: 20 }),
             ),
         );
+        expect(await screen.findByRole("button", { name: "game-2" })).toBeTruthy();
+        expect(screen.getByText("2 / 2")).toBeTruthy();
+    });
+
+    it("次ページの取得失敗時は成功済みページを表示して再試行できる", async () => {
+        render(<RshogiPlayerDetailPage />);
+        await screen.findByRole("button", { name: "game-1" });
+
+        fetchRshogiPlayerDetail.mockRejectedValueOnce(new Error("page unavailable"));
+        fireEvent.click(screen.getByRole("button", { name: "古い対局 →" }));
+
+        expect((await screen.findByRole("alert")).textContent).toContain("page unavailable");
+        expect(screen.getByRole("button", { name: "game-1" })).toBeTruthy();
+        expect(screen.getByText("1 / 2")).toBeTruthy();
+
+        fireEvent.click(screen.getByRole("button", { name: "古い対局 →" }));
+        expect(await screen.findByRole("button", { name: "game-2" })).toBeTruthy();
+        expect(screen.getByText("2 / 2")).toBeTruthy();
     });
 
     it("取得失敗を表示する", async () => {

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
@@ -8,21 +8,17 @@ import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
 import { StatusBanner } from "../../components/StatusBanner";
+import { resolveRshogiApiBaseUrl } from "../../lib/rshogiApiBaseUrl";
 
 const PAGE_SIZE = 20;
 const routeApi = getRouteApi("/rshogi-viewer/players/$playerId");
 
-const resolveApiBaseUrl = (): string | undefined => {
-    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
-    return raw?.trim() || undefined;
-};
-
 export default function RshogiPlayerDetailPage(): ReactElement {
     const { playerId } = routeApi.useParams();
     const navigate = useNavigate();
-    const apiBaseUrl = resolveApiBaseUrl();
+    const apiBaseUrl = resolveRshogiApiBaseUrl();
     const [detail, setDetail] = useState<RshogiPlayerDetail | null>(null);
-    const [page, setPage] = useState(1);
+    const [pageRequest, setPageRequest] = useState({ page: 1, attempt: 0 });
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -32,7 +28,7 @@ export default function RshogiPlayerDetailPage(): ReactElement {
         setErrorMessage(null);
         void fetchRshogiPlayerDetail(playerId, {
             baseUrl: apiBaseUrl,
-            page,
+            page: pageRequest.page,
             pageSize: PAGE_SIZE,
             signal: controller.signal,
         })
@@ -52,10 +48,14 @@ export default function RshogiPlayerDetailPage(): ReactElement {
                 if (!controller.signal.aborted) setIsLoading(false);
             });
         return () => controller.abort();
-    }, [apiBaseUrl, page, playerId]);
+    }, [apiBaseUrl, pageRequest, playerId]);
 
     const player = detail?.player;
     const totalPages = detail ? Math.max(1, Math.ceil(detail.totalCount / detail.pageSize)) : 1;
+    const displayedPage = detail?.page ?? pageRequest.page;
+    const requestPage = (nextPage: number): void => {
+        setPageRequest((current) => ({ page: nextPage, attempt: current.attempt + 1 }));
+    };
 
     return (
         <>
@@ -172,23 +172,21 @@ export default function RshogiPlayerDetailPage(): ReactElement {
                                 >
                                     <button
                                         type="button"
-                                        onClick={() =>
-                                            setPage((current) => Math.max(1, current - 1))
-                                        }
-                                        disabled={page <= 1 || isLoading}
+                                        onClick={() => requestPage(Math.max(1, displayedPage - 1))}
+                                        disabled={displayedPage <= 1 || isLoading}
                                         className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
                                     >
                                         ← 新しい対局
                                     </button>
                                     <span className="font-mono text-xs text-muted-foreground">
-                                        {page} / {totalPages}
+                                        {displayedPage} / {totalPages}
                                     </span>
                                     <button
                                         type="button"
                                         onClick={() =>
-                                            setPage((current) => Math.min(totalPages, current + 1))
+                                            requestPage(Math.min(totalPages, displayedPage + 1))
                                         }
-                                        disabled={page >= totalPages || isLoading}
+                                        disabled={displayedPage >= totalPages || isLoading}
                                         className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
                                     >
                                         古い対局 →

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
@@ -1,0 +1,204 @@
+import type { RshogiPlayerDetail } from "@shogi/match-client";
+import { fetchRshogiPlayerDetail } from "@shogi/match-client";
+import { RshogiCsaGameList } from "@shogi/ui/components/rshogi-csa-game-list";
+import { getRouteApi, Link, useNavigate } from "@tanstack/react-router";
+import type { ReactElement } from "react";
+import { useEffect, useState } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+import { StatusBanner } from "../../components/StatusBanner";
+
+const PAGE_SIZE = 20;
+const routeApi = getRouteApi("/rshogi-viewer/players/$playerId");
+
+const resolveApiBaseUrl = (): string | undefined => {
+    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
+    return raw?.trim() || undefined;
+};
+
+export default function RshogiPlayerDetailPage(): ReactElement {
+    const { playerId } = routeApi.useParams();
+    const navigate = useNavigate();
+    const apiBaseUrl = resolveApiBaseUrl();
+    const [detail, setDetail] = useState<RshogiPlayerDetail | null>(null);
+    const [page, setPage] = useState(1);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setIsLoading(true);
+        setErrorMessage(null);
+        void fetchRshogiPlayerDetail(playerId, {
+            baseUrl: apiBaseUrl,
+            page,
+            pageSize: PAGE_SIZE,
+            signal: controller.signal,
+        })
+            .then((response) => {
+                if (!controller.signal.aborted) setDetail(response);
+            })
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage(
+                        error instanceof Error
+                            ? error.message
+                            : `選手情報の取得に失敗しました: ${String(error)}`,
+                    );
+                }
+            })
+            .finally(() => {
+                if (!controller.signal.aborted) setIsLoading(false);
+            });
+        return () => controller.abort();
+    }, [apiBaseUrl, page, playerId]);
+
+    const player = detail?.player;
+    const totalPages = detail ? Math.max(1, Math.ceil(detail.totalCount / detail.pageSize)) : 1;
+
+    return (
+        <>
+            <PageHeader
+                items={[
+                    { label: "ラム将棋", to: "/" },
+                    { label: "rshogi viewer", to: "/rshogi-viewer" },
+                    { label: "選手番付", to: "/rshogi-viewer/players" },
+                    { label: player?.displayName ?? "選手詳細" },
+                ]}
+                right={<HeaderNav />}
+            />
+            <PageContainer width="wide" className="gap-5">
+                {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
+                {isLoading && !detail && (
+                    <div
+                        className="rounded-xl border border-wafuu-border bg-wafuu-washi-warm px-5 py-16 text-center text-sm text-muted-foreground"
+                        aria-live="polite"
+                    >
+                        選手記録を読み込み中…
+                    </div>
+                )}
+                {player && (
+                    <>
+                        <section className="overflow-hidden rounded-2xl border border-wafuu-border bg-wafuu-washi-warm shadow-sm">
+                            <div className="grid lg:grid-cols-[minmax(0,1fr)_18rem]">
+                                <div className="flex min-w-0 flex-col justify-between gap-8 bg-wafuu-sumi px-5 py-7 text-wafuu-washi-warm sm:px-8 sm:py-9">
+                                    <div className="flex flex-col gap-3">
+                                        <div className="flex flex-wrap items-center gap-2 text-xs tracking-[0.18em] text-wafuu-kincha">
+                                            PLAYER RECORD
+                                            {player.legacy && (
+                                                <span className="rounded-sm border border-wafuu-kincha/50 px-1.5 py-0.5 text-[9px]">
+                                                    LEGACY
+                                                </span>
+                                            )}
+                                        </div>
+                                        <h1 className="truncate font-serif text-3xl font-bold sm:text-4xl">
+                                            {player.displayName}
+                                        </h1>
+                                        <code className="truncate text-[10px] text-wafuu-washi-warm/45 sm:text-xs">
+                                            {player.playerId}
+                                        </code>
+                                    </div>
+                                    <Link
+                                        to="/rshogi-viewer/players"
+                                        className="w-fit border-b border-wafuu-kincha pb-1 text-sm hover:text-wafuu-kincha"
+                                    >
+                                        ← 選手番付へ戻る
+                                    </Link>
+                                </div>
+                                <div className="flex flex-col justify-center gap-1 border-t border-wafuu-border px-6 py-7 lg:border-l lg:border-t-0">
+                                    <span className="text-xs tracking-[0.2em] text-muted-foreground">
+                                        ELO RATING
+                                    </span>
+                                    <strong className="font-mono text-5xl font-bold tabular-nums text-wafuu-shu">
+                                        {Math.round(player.rating).toLocaleString("ja-JP")}
+                                    </strong>
+                                    <span className="mt-2 text-xs text-muted-foreground">
+                                        初期値 1500 · K=32
+                                    </span>
+                                </div>
+                            </div>
+                            <dl className="grid grid-cols-4 divide-x divide-wafuu-border border-t border-wafuu-border">
+                                {[
+                                    ["対局", player.games],
+                                    ["勝", player.wins],
+                                    ["敗", player.losses],
+                                    ["分", player.draws],
+                                ].map(([label, value]) => (
+                                    <div
+                                        key={label}
+                                        className="flex flex-col items-center gap-1 px-2 py-4"
+                                    >
+                                        <dt className="text-[10px] tracking-widest text-muted-foreground">
+                                            {label}
+                                        </dt>
+                                        <dd className="font-mono text-xl tabular-nums text-wafuu-sumi">
+                                            {value}
+                                        </dd>
+                                    </div>
+                                ))}
+                            </dl>
+                        </section>
+
+                        <section className="flex flex-col gap-3">
+                            <div className="flex items-end justify-between gap-4 border-b border-wafuu-border pb-2">
+                                <div>
+                                    <p className="text-[10px] font-semibold tracking-[0.2em] text-wafuu-shu">
+                                        GAME ARCHIVE
+                                    </p>
+                                    <h2 className="font-serif text-xl font-bold text-wafuu-sumi">
+                                        対局記録
+                                    </h2>
+                                </div>
+                                <span className="text-xs text-muted-foreground">
+                                    全 {detail.totalCount} 局
+                                </span>
+                            </div>
+                            <RshogiCsaGameList
+                                games={detail.games}
+                                onSelect={(gameId) =>
+                                    void navigate({
+                                        to: "/rshogi-viewer/$gameId",
+                                        params: { gameId },
+                                    })
+                                }
+                                isLoading={isLoading}
+                                emptyMessage="この選手の棋譜はありません。"
+                            />
+                            {totalPages > 1 && (
+                                <nav
+                                    className="flex items-center justify-between border-t border-wafuu-border pt-3"
+                                    aria-label="対局記録ページ"
+                                >
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            setPage((current) => Math.max(1, current - 1))
+                                        }
+                                        disabled={page <= 1 || isLoading}
+                                        className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
+                                    >
+                                        ← 新しい対局
+                                    </button>
+                                    <span className="font-mono text-xs text-muted-foreground">
+                                        {page} / {totalPages}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        onClick={() =>
+                                            setPage((current) => Math.min(totalPages, current + 1))
+                                        }
+                                        disabled={page >= totalPages || isLoading}
+                                        className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
+                                    >
+                                        古い対局 →
+                                    </button>
+                                </nav>
+                            )}
+                        </section>
+                    </>
+                )}
+            </PageContainer>
+        </>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -19,35 +19,54 @@ vi.mock("../../components/StatusBanner", () => ({
 
 const { default: RshogiPlayerRankingPage } = await import("./RshogiPlayerRankingPage");
 
+const rankingResponse = {
+    players: [
+        {
+            playerId: "p_one",
+            displayName: "銀将",
+            rating: 1612.4,
+            games: 12,
+            wins: 8,
+            losses: 3,
+            draws: 1,
+            lastPlayedAtMs: 1_777_392_877_244,
+            legacy: false,
+        },
+        {
+            playerId: "legacy_two",
+            displayName: "桂馬",
+            rating: 1490,
+            games: 12,
+            wins: 3,
+            losses: 8,
+            draws: 1,
+            lastPlayedAtMs: 1_777_392_800_000,
+            legacy: true,
+        },
+    ],
+    page: 1,
+    pageSize: 50,
+    totalCount: 100,
+    totalGames: 12,
+    leader: {
+        playerId: "p_one",
+        displayName: "銀将",
+        rating: 1612.4,
+        games: 12,
+        wins: 8,
+        losses: 3,
+        draws: 1,
+        lastPlayedAtMs: 1_777_392_877_244,
+        legacy: false,
+    },
+};
+
 describe("RshogiPlayerRankingPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        fetchRshogiPlayerList.mockResolvedValue({
-            players: [
-                {
-                    playerId: "p_one",
-                    displayName: "銀将",
-                    rating: 1612.4,
-                    games: 12,
-                    wins: 8,
-                    losses: 3,
-                    draws: 1,
-                    lastPlayedAtMs: 1_777_392_877_244,
-                    legacy: false,
-                },
-                {
-                    playerId: "legacy_two",
-                    displayName: "桂馬",
-                    rating: 1490,
-                    games: 12,
-                    wins: 3,
-                    losses: 8,
-                    draws: 1,
-                    lastPlayedAtMs: 1_777_392_800_000,
-                    legacy: true,
-                },
-            ],
-        });
+        fetchRshogiPlayerList.mockImplementation((options: { page?: number }) =>
+            Promise.resolve({ ...rankingResponse, page: options.page ?? 1 }),
+        );
     });
 
     it("Elo順の番付と集計値を表示する", async () => {
@@ -59,7 +78,43 @@ describe("RshogiPlayerRankingPage", () => {
         expect(screen.getByText("LEGACY")).toBeTruthy();
         expect(screen.getByText("12", { selector: "section > div > strong" })).toBeTruthy();
         expect(fetchRshogiPlayerList).toHaveBeenCalledWith(
-            expect.objectContaining({ baseUrl: "https://example.test/rshogi" }),
+            expect.objectContaining({
+                baseUrl: "https://example.test/rshogi",
+                page: 1,
+                pageSize: 50,
+            }),
+        );
+        expect(screen.getAllByText(/2026年/)).toHaveLength(2);
+
+        fireEvent.click(screen.getByRole("button", { name: "下位 →" }));
+        await waitFor(() =>
+            expect(fetchRshogiPlayerList).toHaveBeenLastCalledWith(
+                expect.objectContaining({ page: 2, pageSize: 50 }),
+            ),
+        );
+        const list = screen.getByRole("list", { name: "選手ランキング" });
+        await waitFor(() => expect(list.getAttribute("start")).toBe("51"));
+        expect(screen.getByText("51").className).not.toContain("text-wafuu-shu");
+    });
+
+    it("下位ページの取得失敗時は成功済みページを表示して再試行できる", async () => {
+        render(<RshogiPlayerRankingPage />);
+        await screen.findByText("桂馬");
+
+        fetchRshogiPlayerList.mockRejectedValueOnce(new Error("page unavailable"));
+        fireEvent.click(screen.getByRole("button", { name: "下位 →" }));
+
+        expect((await screen.findByRole("alert")).textContent).toContain("page unavailable");
+        expect(screen.getByText("1 / 2")).toBeTruthy();
+        expect(screen.getByRole("list", { name: "選手ランキング" }).getAttribute("start")).toBe(
+            "1",
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "下位 →" }));
+        await waitFor(() =>
+            expect(screen.getByRole("list", { name: "選手ランキング" }).getAttribute("start")).toBe(
+                "51",
+            ),
         );
     });
 

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fetchRshogiPlayerList = vi.fn();
+
+vi.mock("@shogi/match-client", () => ({ fetchRshogiPlayerList }));
+vi.mock("@tanstack/react-router", () => ({
+    Link: ({ children }: { children: ReactNode }) => <a href="/target">{children}</a>,
+}));
+vi.mock("../../components/HeaderNav", () => ({ HeaderNav: () => null }));
+vi.mock("../../components/PageHeader", () => ({ PageHeader: () => null }));
+vi.mock("../../components/PageContainer", () => ({
+    PageContainer: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+vi.mock("../../components/StatusBanner", () => ({
+    StatusBanner: ({ children }: { children: ReactNode }) => <div role="alert">{children}</div>,
+}));
+
+const { default: RshogiPlayerRankingPage } = await import("./RshogiPlayerRankingPage");
+
+describe("RshogiPlayerRankingPage", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        fetchRshogiPlayerList.mockResolvedValue({
+            players: [
+                {
+                    playerId: "p_one",
+                    displayName: "銀将",
+                    rating: 1612.4,
+                    games: 12,
+                    wins: 8,
+                    losses: 3,
+                    draws: 1,
+                    lastPlayedAtMs: 1_777_392_877_244,
+                    legacy: false,
+                },
+                {
+                    playerId: "legacy_two",
+                    displayName: "桂馬",
+                    rating: 1490,
+                    games: 12,
+                    wins: 3,
+                    losses: 8,
+                    draws: 1,
+                    lastPlayedAtMs: 1_777_392_800_000,
+                    legacy: true,
+                },
+            ],
+        });
+    });
+
+    it("Elo順の番付と集計値を表示する", async () => {
+        render(<RshogiPlayerRankingPage />);
+
+        expect((await screen.findAllByText("銀将")).length).toBe(2);
+        expect(screen.getByText("桂馬")).toBeTruthy();
+        expect(screen.getByText("1,612")).toBeTruthy();
+        expect(screen.getByText("LEGACY")).toBeTruthy();
+        expect(screen.getByText("12", { selector: "section > div > strong" })).toBeTruthy();
+        expect(fetchRshogiPlayerList).toHaveBeenCalledWith(
+            expect.objectContaining({ baseUrl: "https://example.test/rshogi" }),
+        );
+    });
+
+    it("取得失敗をエラー表示する", async () => {
+        fetchRshogiPlayerList.mockRejectedValueOnce(new Error("rating unavailable"));
+        render(<RshogiPlayerRankingPage />);
+        expect((await screen.findByRole("alert")).textContent).toContain("rating unavailable");
+    });
+});

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.tsx
@@ -1,4 +1,4 @@
-import type { RshogiPlayerSummary } from "@shogi/match-client";
+import type { RshogiPlayerList, RshogiPlayerSummary } from "@shogi/match-client";
 import { fetchRshogiPlayerList } from "@shogi/match-client";
 import { Link } from "@tanstack/react-router";
 import type { ReactElement } from "react";
@@ -7,11 +7,9 @@ import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
 import { StatusBanner } from "../../components/StatusBanner";
+import { resolveRshogiApiBaseUrl } from "../../lib/rshogiApiBaseUrl";
 
-const resolveApiBaseUrl = (): string | undefined => {
-    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
-    return raw?.trim() || undefined;
-};
+const PAGE_SIZE = 50;
 
 const formatRate = (rating: number): string => Math.round(rating).toLocaleString("ja-JP");
 
@@ -25,6 +23,7 @@ const lastPlayed = (value: number | undefined): string => {
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return "日時不明";
     return new Intl.DateTimeFormat("ja-JP", {
+        year: "numeric",
         month: "short",
         day: "numeric",
         hour: "2-digit",
@@ -33,8 +32,9 @@ const lastPlayed = (value: number | undefined): string => {
 };
 
 export default function RshogiPlayerRankingPage(): ReactElement {
-    const apiBaseUrl = resolveApiBaseUrl();
-    const [players, setPlayers] = useState<RshogiPlayerSummary[]>([]);
+    const apiBaseUrl = resolveRshogiApiBaseUrl();
+    const [ranking, setRanking] = useState<RshogiPlayerList | null>(null);
+    const [pageRequest, setPageRequest] = useState({ page: 1, attempt: 0 });
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -42,9 +42,14 @@ export default function RshogiPlayerRankingPage(): ReactElement {
         const controller = new AbortController();
         setIsLoading(true);
         setErrorMessage(null);
-        void fetchRshogiPlayerList({ baseUrl: apiBaseUrl, signal: controller.signal })
+        void fetchRshogiPlayerList({
+            baseUrl: apiBaseUrl,
+            page: pageRequest.page,
+            pageSize: PAGE_SIZE,
+            signal: controller.signal,
+        })
             .then((response) => {
-                if (!controller.signal.aborted) setPlayers(response.players);
+                if (!controller.signal.aborted) setRanking(response);
             })
             .catch((error: unknown) => {
                 if (!controller.signal.aborted) {
@@ -59,12 +64,21 @@ export default function RshogiPlayerRankingPage(): ReactElement {
                 if (!controller.signal.aborted) setIsLoading(false);
             });
         return () => controller.abort();
-    }, [apiBaseUrl]);
+    }, [apiBaseUrl, pageRequest]);
 
+    const players = ranking?.players ?? [];
+    // player.games の合計を 2 で割る方法は全対局が二人制という前提に依存するため、
+    // 全体集計はページ外の選手も含めてサーバが返す値を使う。
     const totals = {
-        players: players.length,
-        games: Math.round(players.reduce((sum, player) => sum + player.games, 0) / 2),
-        leader: players[0],
+        players: ranking?.totalCount ?? 0,
+        games: ranking?.totalGames ?? 0,
+        leader: ranking?.leader,
+    };
+    const totalPages = ranking ? Math.max(1, Math.ceil(ranking.totalCount / ranking.pageSize)) : 1;
+    const firstRank = ranking ? (ranking.page - 1) * ranking.pageSize + 1 : 1;
+    const displayedPage = ranking?.page ?? pageRequest.page;
+    const requestPage = (nextPage: number): void => {
+        setPageRequest((current) => ({ page: nextPage, attempt: current.attempt + 1 }));
     };
 
     return (
@@ -159,54 +173,88 @@ export default function RshogiPlayerRankingPage(): ReactElement {
                         </div>
                     )}
                     {!isLoading && players.length > 0 && (
-                        <ol aria-label="選手ランキング" className="divide-y divide-wafuu-border">
-                            {players.map((player, index) => (
-                                <li key={player.playerId}>
-                                    <Link
-                                        to="/rshogi-viewer/players/$playerId"
-                                        params={{ playerId: player.playerId }}
-                                        className="group grid grid-cols-[3rem_minmax(0,1fr)_5rem] items-center px-3 py-3 transition-colors hover:bg-wafuu-kincha/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-wafuu-shu sm:grid-cols-[4rem_minmax(0,1fr)_7rem_9rem_8rem] sm:px-5 sm:py-4"
-                                    >
-                                        <span
-                                            className={
-                                                index < 3
-                                                    ? "font-serif text-2xl font-bold text-wafuu-shu"
-                                                    : "font-mono text-sm text-muted-foreground"
-                                            }
+                        <ol
+                            start={firstRank}
+                            aria-label="選手ランキング"
+                            className="divide-y divide-wafuu-border"
+                        >
+                            {players.map((player, index) => {
+                                const rank = firstRank + index;
+                                return (
+                                    <li key={player.playerId}>
+                                        <Link
+                                            to="/rshogi-viewer/players/$playerId"
+                                            params={{ playerId: player.playerId }}
+                                            className="group grid grid-cols-[3rem_minmax(0,1fr)_5rem] items-center px-3 py-3 transition-colors hover:bg-wafuu-kincha/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-wafuu-shu sm:grid-cols-[4rem_minmax(0,1fr)_7rem_9rem_8rem] sm:px-5 sm:py-4"
                                         >
-                                            {String(index + 1).padStart(2, "0")}
-                                        </span>
-                                        <span className="min-w-0">
-                                            <span className="flex items-center gap-2">
-                                                <strong className="truncate font-serif text-base text-wafuu-sumi group-hover:text-wafuu-shu sm:text-lg">
-                                                    {player.displayName}
-                                                </strong>
-                                                {player.legacy && (
-                                                    <span className="shrink-0 rounded-sm border border-wafuu-border px-1.5 py-0.5 text-[9px] tracking-wider text-muted-foreground">
-                                                        LEGACY
-                                                    </span>
-                                                )}
+                                            <span
+                                                className={
+                                                    rank <= 3
+                                                        ? "font-serif text-2xl font-bold text-wafuu-shu"
+                                                        : "font-mono text-sm text-muted-foreground"
+                                                }
+                                            >
+                                                {String(rank).padStart(2, "0")}
                                             </span>
-                                            <span className="mt-0.5 block text-[11px] text-muted-foreground sm:text-xs">
-                                                {player.games}局 · 最終{" "}
-                                                {lastPlayed(player.lastPlayedAtMs)}
+                                            <span className="min-w-0">
+                                                <span className="flex items-center gap-2">
+                                                    <strong className="truncate font-serif text-base text-wafuu-sumi group-hover:text-wafuu-shu sm:text-lg">
+                                                        {player.displayName}
+                                                    </strong>
+                                                    {player.legacy && (
+                                                        <span className="shrink-0 rounded-sm border border-wafuu-border px-1.5 py-0.5 text-[9px] tracking-wider text-muted-foreground">
+                                                            LEGACY
+                                                        </span>
+                                                    )}
+                                                </span>
+                                                <span className="mt-0.5 block text-[11px] text-muted-foreground sm:text-xs">
+                                                    {player.games}局 · 最終{" "}
+                                                    {lastPlayed(player.lastPlayedAtMs)}
+                                                </span>
                                             </span>
-                                        </span>
-                                        <strong className="text-right font-mono text-lg tabular-nums text-wafuu-sumi sm:text-xl">
-                                            {formatRate(player.rating)}
-                                        </strong>
-                                        <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
-                                            {player.wins}–{player.losses}–{player.draws}
-                                        </span>
-                                        <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
-                                            {winRate(player)}
-                                        </span>
-                                    </Link>
-                                </li>
-                            ))}
+                                            <strong className="text-right font-mono text-lg tabular-nums text-wafuu-sumi sm:text-xl">
+                                                {formatRate(player.rating)}
+                                            </strong>
+                                            <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
+                                                {player.wins}–{player.losses}–{player.draws}
+                                            </span>
+                                            <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
+                                                {winRate(player)}
+                                            </span>
+                                        </Link>
+                                    </li>
+                                );
+                            })}
                         </ol>
                     )}
                 </section>
+
+                {totalPages > 1 && (
+                    <nav
+                        className="flex items-center justify-between border-t border-wafuu-border pt-3"
+                        aria-label="選手番付ページ"
+                    >
+                        <button
+                            type="button"
+                            onClick={() => requestPage(Math.max(1, displayedPage - 1))}
+                            disabled={displayedPage <= 1 || isLoading}
+                            className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
+                        >
+                            ← 上位
+                        </button>
+                        <span className="font-mono text-xs text-muted-foreground">
+                            {displayedPage} / {totalPages}
+                        </span>
+                        <button
+                            type="button"
+                            onClick={() => requestPage(Math.min(totalPages, displayedPage + 1))}
+                            disabled={displayedPage >= totalPages || isLoading}
+                            className="rounded-md border border-wafuu-border px-4 py-1.5 text-sm text-wafuu-sumi transition-colors hover:bg-wafuu-kincha/10 disabled:opacity-40"
+                        >
+                            下位 →
+                        </button>
+                    </nav>
+                )}
 
                 <p className="text-xs leading-6 text-muted-foreground">
                     Elo は初期値 1500、K=32、引分 0.5 で算出。同一 ID

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerRankingPage.tsx
@@ -1,0 +1,219 @@
+import type { RshogiPlayerSummary } from "@shogi/match-client";
+import { fetchRshogiPlayerList } from "@shogi/match-client";
+import { Link } from "@tanstack/react-router";
+import type { ReactElement } from "react";
+import { useEffect, useState } from "react";
+import { HeaderNav } from "../../components/HeaderNav";
+import { PageContainer } from "../../components/PageContainer";
+import { PageHeader } from "../../components/PageHeader";
+import { StatusBanner } from "../../components/StatusBanner";
+
+const resolveApiBaseUrl = (): string | undefined => {
+    const raw = import.meta.env.VITE_RSHOGI_API_BASE as string | undefined;
+    return raw?.trim() || undefined;
+};
+
+const formatRate = (rating: number): string => Math.round(rating).toLocaleString("ja-JP");
+
+const winRate = (player: RshogiPlayerSummary): string => {
+    if (player.games === 0) return "—";
+    return `${((player.wins / player.games) * 100).toFixed(1)}%`;
+};
+
+const lastPlayed = (value: number | undefined): string => {
+    if (value === undefined) return "対局記録なし";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "日時不明";
+    return new Intl.DateTimeFormat("ja-JP", {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    }).format(date);
+};
+
+export default function RshogiPlayerRankingPage(): ReactElement {
+    const apiBaseUrl = resolveApiBaseUrl();
+    const [players, setPlayers] = useState<RshogiPlayerSummary[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setIsLoading(true);
+        setErrorMessage(null);
+        void fetchRshogiPlayerList({ baseUrl: apiBaseUrl, signal: controller.signal })
+            .then((response) => {
+                if (!controller.signal.aborted) setPlayers(response.players);
+            })
+            .catch((error: unknown) => {
+                if (!controller.signal.aborted) {
+                    setErrorMessage(
+                        error instanceof Error
+                            ? error.message
+                            : `ランキングの取得に失敗しました: ${String(error)}`,
+                    );
+                }
+            })
+            .finally(() => {
+                if (!controller.signal.aborted) setIsLoading(false);
+            });
+        return () => controller.abort();
+    }, [apiBaseUrl]);
+
+    const totals = {
+        players: players.length,
+        games: Math.round(players.reduce((sum, player) => sum + player.games, 0) / 2),
+        leader: players[0],
+    };
+
+    return (
+        <>
+            <PageHeader
+                items={[
+                    { label: "ラム将棋", to: "/" },
+                    { label: "rshogi viewer", to: "/rshogi-viewer" },
+                    { label: "選手番付" },
+                ]}
+                right={<HeaderNav />}
+            />
+            <PageContainer width="wide" className="gap-5">
+                <section className="relative overflow-hidden rounded-2xl bg-wafuu-sumi px-5 py-7 text-wafuu-washi-warm shadow-lg sm:px-8 sm:py-9">
+                    <div
+                        className="pointer-events-none absolute -right-10 -top-20 h-64 w-64 rounded-full border-[44px] border-wafuu-shu/20"
+                        aria-hidden="true"
+                    />
+                    <div className="relative grid gap-7 lg:grid-cols-[1fr_auto] lg:items-end">
+                        <div className="flex flex-col gap-3">
+                            <p className="text-xs font-semibold tracking-[0.28em] text-wafuu-kincha">
+                                RSHOGI PLAYER RATING
+                            </p>
+                            <h1 className="font-serif text-3xl font-bold tracking-tight sm:text-4xl">
+                                選手番付
+                            </h1>
+                            <p className="max-w-2xl text-sm leading-7 text-wafuu-washi-warm/75">
+                                終局順に Elo を更新した、CSA
+                                サーバの選手ランキングです。勝敗だけでなく、対戦相手の強さも評点に反映します。
+                            </p>
+                        </div>
+                        <Link
+                            to="/rshogi-viewer"
+                            className="w-fit border-b border-wafuu-kincha pb-1 text-sm text-wafuu-washi-warm transition-colors hover:text-wafuu-kincha"
+                        >
+                            棋譜一覧を見る ↗
+                        </Link>
+                    </div>
+                </section>
+
+                {errorMessage && <StatusBanner variant="error">{errorMessage}</StatusBanner>}
+
+                <section
+                    className="grid grid-cols-3 overflow-hidden rounded-xl border border-wafuu-border bg-wafuu-washi-warm"
+                    aria-label="番付概要"
+                >
+                    <div className="flex flex-col gap-1 border-r border-wafuu-border px-3 py-4 text-center sm:px-6">
+                        <span className="text-[10px] tracking-widest text-muted-foreground sm:text-xs">
+                            登録選手
+                        </span>
+                        <strong className="font-serif text-xl text-wafuu-sumi sm:text-2xl">
+                            {totals.players}
+                        </strong>
+                    </div>
+                    <div className="flex flex-col gap-1 border-r border-wafuu-border px-3 py-4 text-center sm:px-6">
+                        <span className="text-[10px] tracking-widest text-muted-foreground sm:text-xs">
+                            集計対局
+                        </span>
+                        <strong className="font-serif text-xl text-wafuu-sumi sm:text-2xl">
+                            {totals.games}
+                        </strong>
+                    </div>
+                    <div className="flex min-w-0 flex-col gap-1 px-3 py-4 text-center sm:px-6">
+                        <span className="text-[10px] tracking-widest text-muted-foreground sm:text-xs">
+                            首位
+                        </span>
+                        <strong className="truncate font-serif text-base text-wafuu-shu sm:text-xl">
+                            {totals.leader?.displayName ?? "—"}
+                        </strong>
+                    </div>
+                </section>
+
+                <section className="overflow-hidden rounded-xl border border-wafuu-border bg-wafuu-washi-warm">
+                    <div className="grid grid-cols-[3rem_minmax(0,1fr)_5rem] items-center border-b border-wafuu-border bg-wafuu-kincha/10 px-3 py-2 text-[11px] font-semibold tracking-widest text-muted-foreground sm:grid-cols-[4rem_minmax(0,1fr)_7rem_9rem_8rem] sm:px-5">
+                        <span>順位</span>
+                        <span>選手</span>
+                        <span className="text-right">RATING</span>
+                        <span className="hidden text-right sm:block">勝–敗–分</span>
+                        <span className="hidden text-right sm:block">勝率</span>
+                    </div>
+                    {isLoading && (
+                        <div
+                            className="px-5 py-12 text-center text-sm text-muted-foreground"
+                            aria-live="polite"
+                        >
+                            番付を編成中…
+                        </div>
+                    )}
+                    {!isLoading && players.length === 0 && !errorMessage && (
+                        <div className="px-5 py-12 text-center text-sm text-muted-foreground">
+                            集計できる終局済対局がまだありません。
+                        </div>
+                    )}
+                    {!isLoading && players.length > 0 && (
+                        <ol aria-label="選手ランキング" className="divide-y divide-wafuu-border">
+                            {players.map((player, index) => (
+                                <li key={player.playerId}>
+                                    <Link
+                                        to="/rshogi-viewer/players/$playerId"
+                                        params={{ playerId: player.playerId }}
+                                        className="group grid grid-cols-[3rem_minmax(0,1fr)_5rem] items-center px-3 py-3 transition-colors hover:bg-wafuu-kincha/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-wafuu-shu sm:grid-cols-[4rem_minmax(0,1fr)_7rem_9rem_8rem] sm:px-5 sm:py-4"
+                                    >
+                                        <span
+                                            className={
+                                                index < 3
+                                                    ? "font-serif text-2xl font-bold text-wafuu-shu"
+                                                    : "font-mono text-sm text-muted-foreground"
+                                            }
+                                        >
+                                            {String(index + 1).padStart(2, "0")}
+                                        </span>
+                                        <span className="min-w-0">
+                                            <span className="flex items-center gap-2">
+                                                <strong className="truncate font-serif text-base text-wafuu-sumi group-hover:text-wafuu-shu sm:text-lg">
+                                                    {player.displayName}
+                                                </strong>
+                                                {player.legacy && (
+                                                    <span className="shrink-0 rounded-sm border border-wafuu-border px-1.5 py-0.5 text-[9px] tracking-wider text-muted-foreground">
+                                                        LEGACY
+                                                    </span>
+                                                )}
+                                            </span>
+                                            <span className="mt-0.5 block text-[11px] text-muted-foreground sm:text-xs">
+                                                {player.games}局 · 最終{" "}
+                                                {lastPlayed(player.lastPlayedAtMs)}
+                                            </span>
+                                        </span>
+                                        <strong className="text-right font-mono text-lg tabular-nums text-wafuu-sumi sm:text-xl">
+                                            {formatRate(player.rating)}
+                                        </strong>
+                                        <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
+                                            {player.wins}–{player.losses}–{player.draws}
+                                        </span>
+                                        <span className="hidden text-right font-mono text-sm tabular-nums text-muted-foreground sm:block">
+                                            {winRate(player)}
+                                        </span>
+                                    </Link>
+                                </li>
+                            ))}
+                        </ol>
+                    )}
+                </section>
+
+                <p className="text-xs leading-6 text-muted-foreground">
+                    Elo は初期値 1500、K=32、引分 0.5 で算出。同一 ID
+                    同士の対局は集計対象外です。LEGACY
+                    は識別情報導入前の棋譜を選手名だけでまとめた記録です。
+                </p>
+            </PageContainer>
+        </>
+    );
+}

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerListPage.tsx
@@ -222,12 +222,20 @@ export default function RshogiViewerListPage(): ReactElement {
                     title="rshogi 棋譜一覧"
                     description="rshogi CSA サーバで終局した棋譜を新着順で表示します。クリックすると個別の viewer に遷移します。"
                 >
-                    <Link
-                        to="/rshogi-viewer/live"
-                        className="text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-                    >
-                        進行中の対局一覧へ →
-                    </Link>
+                    <div className="flex flex-wrap gap-x-4 gap-y-2">
+                        <Link
+                            to="/rshogi-viewer/players"
+                            className="text-sm font-medium text-wafuu-shu underline-offset-2 hover:underline"
+                        >
+                            選手番付を見る →
+                        </Link>
+                        <Link
+                            to="/rshogi-viewer/live"
+                            className="text-sm text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                        >
+                            進行中の対局一覧へ →
+                        </Link>
+                    </div>
                 </PageHeading>
 
                 <form

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -234,6 +234,18 @@ const rshogiViewerListRoute = createRoute({
     component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiViewerListPage")),
 });
 
+const rshogiPlayerRankingRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer/players",
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiPlayerRankingPage")),
+});
+
+const rshogiPlayerDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: "/rshogi-viewer/players/$playerId",
+    component: lazyRouteComponent(() => import("./pages/rshogi-viewer/RshogiPlayerDetailPage")),
+});
+
 // 進行中対局一覧 (静的 path)。単局 `/rshogi-viewer/live/$gameId` とはセグメント数が
 // 異なるため衝突しない。単局 `/rshogi-viewer/$gameId` より前に登録して、`live` を
 // gameId として誤解決しないようにする。
@@ -347,6 +359,8 @@ const routeTree = rootRoute.addChildren([
     createRoomRoute,
     roomRoute,
     rshogiViewerListRoute,
+    rshogiPlayerRankingRoute,
+    rshogiPlayerDetailRoute,
     rshogiViewerLiveListRoute,
     rshogiViewerLiveRoute,
     rshogiViewerRoute,

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -50,6 +50,7 @@ export type {
     FetchRshogiGameOptions,
     FetchRshogiGameSearchOptions,
     FetchRshogiLiveGameListOptions,
+    FetchRshogiPlayerDetailOptions,
     RshogiClockKind,
     RshogiEndReason,
     RshogiGame,
@@ -62,6 +63,9 @@ export type {
     RshogiGameSummary,
     RshogiLiveGameListPage,
     RshogiLiveGameSummary,
+    RshogiPlayerDetail,
+    RshogiPlayerList,
+    RshogiPlayerSummary,
     RshogiTimeControl,
 } from "./rshogi-csa/client";
 export {
@@ -69,9 +73,12 @@ export {
     fetchRshogiGameList,
     fetchRshogiGameSearch,
     fetchRshogiLiveGameList,
+    fetchRshogiPlayerDetail,
+    fetchRshogiPlayerList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,
+    RshogiPlayerNotFoundError,
 } from "./rshogi-csa/client";
 export type {
     RshogiLiveCallbacks,

--- a/packages/match-client/src/index.ts
+++ b/packages/match-client/src/index.ts
@@ -51,6 +51,7 @@ export type {
     FetchRshogiGameSearchOptions,
     FetchRshogiLiveGameListOptions,
     FetchRshogiPlayerDetailOptions,
+    FetchRshogiPlayerListOptions,
     RshogiClockKind,
     RshogiEndReason,
     RshogiGame,

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -11,6 +11,7 @@ import {
     RshogiGameNotFoundError,
     RshogiPlayerNotFoundError,
 } from "./client";
+import { MOCK_RSHOGI_GAME_LIST } from "./fixtures";
 
 describe("rshogi player API (mock fallback)", () => {
     it("builds a ranked player list and paginated detail from fixtures", async () => {
@@ -24,6 +25,15 @@ describe("rshogi player API (mock fallback)", () => {
                 legacy: true,
             }),
         );
+        expect(list).toEqual(
+            expect.objectContaining({
+                page: 1,
+                pageSize: 20,
+                totalCount: list.players.length,
+                totalGames: MOCK_RSHOGI_GAME_LIST.length,
+                leader: list.players[0],
+            }),
+        );
 
         const detail = await fetchRshogiPlayerDetail(list.players[0].playerId, { pageSize: 1 });
         expect(detail.player).toEqual(list.players[0]);
@@ -35,6 +45,40 @@ describe("rshogi player API (mock fallback)", () => {
         await expect(fetchRshogiPlayerDetail("missing")).rejects.toBeInstanceOf(
             RshogiPlayerNotFoundError,
         );
+    });
+
+    it("uses fixture player ids for detail filtering and preserves an unknown last-played time", async () => {
+        const originalLength = MOCK_RSHOGI_GAME_LIST.length;
+        MOCK_RSHOGI_GAME_LIST.push(
+            {
+                gameId: "same-name-a",
+                senteName: "同名選手",
+                sentePlayerId: "p_same_a",
+                goteName: "相手A",
+                gotePlayerId: "p_opponent_a",
+                result: { kind: "resignation", winner: "sente", endReason: "RESIGN" },
+            },
+            {
+                gameId: "same-name-b",
+                senteName: "同名選手",
+                sentePlayerId: "p_same_b",
+                goteName: "相手B",
+                gotePlayerId: "p_opponent_b",
+                endedAtMs: 123,
+                result: { kind: "resignation", winner: "sente", endReason: "RESIGN" },
+            },
+        );
+
+        try {
+            const list = await fetchRshogiPlayerList({ pageSize: 100 });
+            const player = list.players.find((candidate) => candidate.playerId === "p_same_a");
+            expect(player).toEqual(expect.objectContaining({ lastPlayedAtMs: undefined }));
+
+            const detail = await fetchRshogiPlayerDetail("p_same_a");
+            expect(detail.games.map((game) => game.gameId)).toEqual(["same-name-a"]);
+        } finally {
+            MOCK_RSHOGI_GAME_LIST.splice(originalLength);
+        }
     });
 });
 
@@ -53,16 +97,32 @@ describe("rshogi player API (real baseUrl)", () => {
 
     it("decodes the ranking list", async () => {
         const fetchImpl = vi.fn(
-            async () => new Response(JSON.stringify({ players: [summary] }), { status: 200 }),
+            async () =>
+                new Response(
+                    JSON.stringify({
+                        players: [summary],
+                        page: 2,
+                        page_size: 10,
+                        total_count: 31,
+                        total_games: 148,
+                        leader: { ...summary, player_id: "p_leader", display_name: "LEADER" },
+                    }),
+                    { status: 200 },
+                ),
         ) as unknown as typeof fetch;
         const result = await fetchRshogiPlayerList({
             baseUrl: "https://rshogi.example.com/api/v1/",
+            page: 2,
+            pageSize: 10,
             fetchImpl,
         });
-        expect(fetchImpl).toHaveBeenCalledWith("https://rshogi.example.com/api/v1/players", {
-            signal: undefined,
-            cache: "no-store",
-        });
+        expect(fetchImpl).toHaveBeenCalledWith(
+            "https://rshogi.example.com/api/v1/players?page=2&pageSize=10",
+            {
+                signal: undefined,
+                cache: "no-store",
+            },
+        );
         expect(result.players[0]).toEqual({
             playerId: "p_012345",
             displayName: "RAMU",
@@ -74,6 +134,18 @@ describe("rshogi player API (real baseUrl)", () => {
             lastPlayedAtMs: 1_777_392_877_244,
             legacy: false,
         });
+        expect(result).toEqual(
+            expect.objectContaining({
+                page: 2,
+                pageSize: 10,
+                totalCount: 31,
+                totalGames: 148,
+                leader: expect.objectContaining({
+                    playerId: "p_leader",
+                    displayName: "LEADER",
+                }),
+            }),
+        );
     });
 
     it("encodes the player id and decodes detail games with player ids", async () => {

--- a/packages/match-client/src/rshogi-csa/client.test.ts
+++ b/packages/match-client/src/rshogi-csa/client.test.ts
@@ -4,10 +4,121 @@ import {
     fetchRshogiGameList,
     fetchRshogiGameSearch,
     fetchRshogiLiveGameList,
+    fetchRshogiPlayerDetail,
+    fetchRshogiPlayerList,
     listMockRshogiGameIds,
     RshogiGameFetchError,
     RshogiGameNotFoundError,
+    RshogiPlayerNotFoundError,
 } from "./client";
+
+describe("rshogi player API (mock fallback)", () => {
+    it("builds a ranked player list and paginated detail from fixtures", async () => {
+        const list = await fetchRshogiPlayerList();
+        expect(list.players.length).toBeGreaterThan(1);
+        expect(list.players[0]).toEqual(
+            expect.objectContaining({
+                playerId: expect.stringMatching(/^legacy_mock_/),
+                rating: expect.any(Number),
+                games: expect.any(Number),
+                legacy: true,
+            }),
+        );
+
+        const detail = await fetchRshogiPlayerDetail(list.players[0].playerId, { pageSize: 1 });
+        expect(detail.player).toEqual(list.players[0]);
+        expect(detail.games).toHaveLength(1);
+        expect(detail.totalCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it("rejects an unknown player id", async () => {
+        await expect(fetchRshogiPlayerDetail("missing")).rejects.toBeInstanceOf(
+            RshogiPlayerNotFoundError,
+        );
+    });
+});
+
+describe("rshogi player API (real baseUrl)", () => {
+    const summary = {
+        player_id: "p_012345",
+        display_name: "RAMU",
+        rating: 1542.4,
+        games: 12,
+        wins: 7,
+        losses: 4,
+        draws: 1,
+        last_played_at_ms: 1_777_392_877_244,
+        legacy: false,
+    };
+
+    it("decodes the ranking list", async () => {
+        const fetchImpl = vi.fn(
+            async () => new Response(JSON.stringify({ players: [summary] }), { status: 200 }),
+        ) as unknown as typeof fetch;
+        const result = await fetchRshogiPlayerList({
+            baseUrl: "https://rshogi.example.com/api/v1/",
+            fetchImpl,
+        });
+        expect(fetchImpl).toHaveBeenCalledWith("https://rshogi.example.com/api/v1/players", {
+            signal: undefined,
+            cache: "no-store",
+        });
+        expect(result.players[0]).toEqual({
+            playerId: "p_012345",
+            displayName: "RAMU",
+            rating: 1542.4,
+            games: 12,
+            wins: 7,
+            losses: 4,
+            draws: 1,
+            lastPlayedAtMs: 1_777_392_877_244,
+            legacy: false,
+        });
+    });
+
+    it("encodes the player id and decodes detail games with player ids", async () => {
+        const fetchImpl = vi.fn(
+            async () =>
+                new Response(
+                    JSON.stringify({
+                        player: summary,
+                        games: [
+                            {
+                                game_id: "g-1",
+                                black_handle: "RAMU",
+                                black_player_id: "p_012345",
+                                white_handle: "OTHER",
+                                white_player_id: "p_987654",
+                                result_kind: "WIN_BLACK",
+                                end_reason: "RESIGN",
+                            },
+                        ],
+                        page: 2,
+                        page_size: 10,
+                        total_count: 12,
+                    }),
+                    { status: 200 },
+                ),
+        ) as unknown as typeof fetch;
+        const result = await fetchRshogiPlayerDetail("p/a", {
+            baseUrl: "https://rshogi.example.com/api/v1",
+            page: 2,
+            pageSize: 10,
+            fetchImpl,
+        });
+        expect(fetchImpl).toHaveBeenCalledWith(
+            "https://rshogi.example.com/api/v1/players/p%2Fa?page=2&pageSize=10",
+            { signal: undefined, cache: "no-store" },
+        );
+        expect(result.games[0]).toEqual(
+            expect.objectContaining({
+                sentePlayerId: "p_012345",
+                gotePlayerId: "p_987654",
+            }),
+        );
+        expect(result).toEqual(expect.objectContaining({ page: 2, pageSize: 10, totalCount: 12 }));
+    });
+});
 
 describe("fetchRshogiGameSearch (mock fallback)", () => {
     it("filters by name and paginates the embedded fixtures", async () => {

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -153,6 +153,12 @@ export interface RshogiPlayerSummary {
 
 export interface RshogiPlayerList {
     players: RshogiPlayerSummary[];
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    totalGames: number;
+    /** 全ページを通したレーティング首位。選手がいない場合は undefined。 */
+    leader?: RshogiPlayerSummary;
 }
 
 export interface RshogiPlayerDetail {
@@ -226,6 +232,13 @@ export interface FetchRshogiLiveGameListOptions extends FetchRshogiGameOptions {
     cursor?: string;
     /** 1 ページあたり件数 (1〜100、サーバ既定 50)。 */
     limit?: number;
+}
+
+export interface FetchRshogiPlayerListOptions extends FetchRshogiGameOptions {
+    /** 1 始まり。 */
+    page?: number;
+    /** 1 ページあたり件数 (1〜100、サーバ既定 20)。 */
+    pageSize?: number;
 }
 
 export interface FetchRshogiPlayerDetailOptions extends FetchRshogiGameOptions {
@@ -393,6 +406,11 @@ interface PlayerSummaryWire {
 
 interface PlayerListResponseWire {
     players?: PlayerSummaryWire[];
+    page?: number;
+    page_size?: number;
+    total_count?: number;
+    total_games?: number;
+    leader?: PlayerSummaryWire | null;
 }
 
 interface PlayerDetailResponseWire {
@@ -765,17 +783,21 @@ export async function fetchRshogiGameSearch(
 
 /** 終局履歴から算出された選手ランキングを取得する。 */
 export async function fetchRshogiPlayerList(
-    options: FetchRshogiGameOptions = {},
+    options: FetchRshogiPlayerListOptions = {},
 ): Promise<RshogiPlayerList> {
     const baseUrl = options.baseUrl?.trim();
-    if (!baseUrl) return { players: buildMockPlayerList() };
+    if (!baseUrl) return mockPlayerList(options.page, options.pageSize);
 
     const fetchImpl = options.fetchImpl ?? globalThis.fetch;
     if (!fetchImpl) {
         throw new RshogiGameFetchError("", "fetch is not available in this environment");
     }
+    const params = new URLSearchParams();
+    if (options.page !== undefined) params.set("page", String(options.page));
+    if (options.pageSize !== undefined) params.set("pageSize", String(options.pageSize));
+    const query = params.toString();
     const response = await fetchImpl(
-        `${trimTrailingSlash(baseUrl)}/players`,
+        `${trimTrailingSlash(baseUrl)}/players${query ? `?${query}` : ""}`,
         buildRequestInit(options.signal),
     );
     if (!response.ok) {
@@ -789,7 +811,15 @@ export async function fetchRshogiPlayerList(
     if (!payload || !Array.isArray(payload.players)) {
         throw new RshogiGameFetchError("", "rshogi API response missing players array");
     }
-    return { players: payload.players.map(decodePlayerSummary) };
+    const players = payload.players.map(decodePlayerSummary);
+    return {
+        players,
+        page: payload.page ?? 1,
+        pageSize: payload.page_size ?? 20,
+        totalCount: payload.total_count ?? players.length,
+        totalGames: payload.total_games ?? 0,
+        leader: payload.leader ? decodePlayerSummary(payload.leader) : undefined,
+    };
 }
 
 /** 選手の集計成績と、その選手が参加した終局済棋譜を取得する。 */
@@ -886,6 +916,10 @@ const DEFAULT_MOCK_SEARCH_PAGE_SIZE = 20;
 
 const mockPlayerId = (name: string): string => `legacy_mock_${encodeURIComponent(name)}`;
 
+const mockGamePlayerId = (game: RshogiGameSummary, side: "sente" | "gote"): string =>
+    (side === "sente" ? game.sentePlayerId : game.gotePlayerId) ??
+    mockPlayerId(side === "sente" ? game.senteName : game.goteName);
+
 const buildMockPlayerList = (): RshogiPlayerSummary[] => {
     const records = new Map<string, Omit<RshogiPlayerSummary, "rating">>();
     for (const game of [...MOCK_RSHOGI_GAME_LIST].reverse()) {
@@ -894,7 +928,7 @@ const buildMockPlayerList = (): RshogiPlayerSummary[] => {
             ["sente", game.senteName],
             ["gote", game.goteName],
         ] as const) {
-            const id = mockPlayerId(name);
+            const id = mockGamePlayerId(game, side);
             const current = records.get(id) ?? {
                 playerId: id,
                 displayName: name,
@@ -909,7 +943,12 @@ const buildMockPlayerList = (): RshogiPlayerSummary[] => {
             if (!winner) current.draws += 1;
             else if (winner === side) current.wins += 1;
             else current.losses += 1;
-            current.lastPlayedAtMs = Math.max(current.lastPlayedAtMs ?? 0, game.endedAtMs ?? 0);
+            if (game.endedAtMs !== undefined) {
+                current.lastPlayedAtMs = Math.max(
+                    current.lastPlayedAtMs ?? game.endedAtMs,
+                    game.endedAtMs,
+                );
+            }
             records.set(id, current);
         }
     }
@@ -921,6 +960,21 @@ const buildMockPlayerList = (): RshogiPlayerSummary[] => {
         .sort((a, b) => b.rating - a.rating || a.displayName.localeCompare(b.displayName));
 };
 
+const mockPlayerList = (page = 1, pageSize = DEFAULT_MOCK_SEARCH_PAGE_SIZE): RshogiPlayerList => {
+    const allPlayers = buildMockPlayerList();
+    const normalizedPage = Math.max(1, page);
+    const normalizedPageSize = Math.min(Math.max(1, pageSize), MAX_MOCK_LIMIT);
+    const start = (normalizedPage - 1) * normalizedPageSize;
+    return {
+        players: allPlayers.slice(start, start + normalizedPageSize),
+        page: normalizedPage,
+        pageSize: normalizedPageSize,
+        totalCount: allPlayers.length,
+        totalGames: MOCK_RSHOGI_GAME_LIST.length,
+        leader: allPlayers[0],
+    };
+};
+
 const mockPlayerDetail = (
     playerId: string,
     page = 1,
@@ -929,7 +983,9 @@ const mockPlayerDetail = (
     const player = buildMockPlayerList().find((candidate) => candidate.playerId === playerId);
     if (!player) throw new RshogiPlayerNotFoundError(playerId);
     const allGames = MOCK_RSHOGI_GAME_LIST.filter(
-        (game) => game.senteName === player.displayName || game.goteName === player.displayName,
+        (game) =>
+            mockGamePlayerId(game, "sente") === playerId ||
+            mockGamePlayerId(game, "gote") === playerId,
     );
     const normalizedPage = Math.max(1, page);
     const normalizedPageSize = Math.min(Math.max(1, pageSize), MAX_MOCK_LIMIT);

--- a/packages/match-client/src/rshogi-csa/client.ts
+++ b/packages/match-client/src/rshogi-csa/client.ts
@@ -78,8 +78,12 @@ export interface RshogiGameMeta {
     gameId: string;
     /** 黒 (= 先手 / sente) のハンドル。 */
     senteName: string;
+    /** 先手の公開用不透明 player ID。過去棋譜では存在しないことがある。 */
+    sentePlayerId?: string;
     /** 白 (= 後手 / gote) のハンドル。 */
     goteName: string;
+    /** 後手の公開用不透明 player ID。過去棋譜では存在しないことがある。 */
+    gotePlayerId?: string;
     /** 開始時刻 (epoch ms)。Date 化は UI 側で行う (タイムゾーン事故防止)。 */
     startedAtMs?: number;
     /** 終了時刻 (epoch ms)。 */
@@ -109,7 +113,9 @@ export interface RshogiGame {
 export interface RshogiGameSummary {
     gameId: string;
     senteName: string;
+    sentePlayerId?: string;
     goteName: string;
+    gotePlayerId?: string;
     startedAtMs?: number;
     endedAtMs?: number;
     timeControl?: RshogiTimeControl;
@@ -125,6 +131,32 @@ export interface RshogiGameListPage {
 }
 
 export interface RshogiGameSearchPage {
+    games: RshogiGameSummary[];
+    page: number;
+    pageSize: number;
+    totalCount: number;
+}
+
+/** 終局履歴から算出した選手の Elo と通算成績。 */
+export interface RshogiPlayerSummary {
+    playerId: string;
+    displayName: string;
+    rating: number;
+    games: number;
+    wins: number;
+    losses: number;
+    draws: number;
+    lastPlayedAtMs?: number;
+    /** secret-aware ID 導入前の、名前だけで集約された履歴か。 */
+    legacy: boolean;
+}
+
+export interface RshogiPlayerList {
+    players: RshogiPlayerSummary[];
+}
+
+export interface RshogiPlayerDetail {
+    player: RshogiPlayerSummary;
     games: RshogiGameSummary[];
     page: number;
     pageSize: number;
@@ -196,6 +228,13 @@ export interface FetchRshogiLiveGameListOptions extends FetchRshogiGameOptions {
     limit?: number;
 }
 
+export interface FetchRshogiPlayerDetailOptions extends FetchRshogiGameOptions {
+    /** 1 始まり。 */
+    page?: number;
+    /** 1 ページあたり件数 (1〜100、サーバ既定 20)。 */
+    pageSize?: number;
+}
+
 export class RshogiGameNotFoundError extends Error {
     readonly gameId: string;
     constructor(gameId: string) {
@@ -213,6 +252,15 @@ export class RshogiGameFetchError extends Error {
         this.name = "RshogiGameFetchError";
         this.gameId = gameId;
         this.status = status;
+    }
+}
+
+export class RshogiPlayerNotFoundError extends Error {
+    readonly playerId: string;
+    constructor(playerId: string) {
+        super(`rshogi player not found: ${playerId}`);
+        this.name = "RshogiPlayerNotFoundError";
+        this.playerId = playerId;
     }
 }
 
@@ -295,7 +343,9 @@ interface GameWireBase {
     started_at_ms?: number | null;
     ended_at_ms?: number | null;
     black_handle: string;
+    black_player_id?: string | null;
     white_handle: string;
+    white_player_id?: string | null;
     result_kind?: RshogiResultKindWire | string | null;
     end_reason?: RshogiEndReasonWire | string | null;
     moves_count?: number | null;
@@ -323,6 +373,30 @@ interface GameListResponseWire {
 }
 
 interface GameSearchResponseWire {
+    games?: GameWireBase[];
+    page?: number;
+    page_size?: number;
+    total_count?: number;
+}
+
+interface PlayerSummaryWire {
+    player_id: string;
+    display_name: string;
+    rating: number;
+    games: number;
+    wins: number;
+    losses: number;
+    draws: number;
+    last_played_at_ms?: number | null;
+    legacy?: boolean;
+}
+
+interface PlayerListResponseWire {
+    players?: PlayerSummaryWire[];
+}
+
+interface PlayerDetailResponseWire {
+    player?: PlayerSummaryWire;
     games?: GameWireBase[];
     page?: number;
     page_size?: number;
@@ -475,7 +549,9 @@ const decodeGameSummary = (wire: GameWireBase): RshogiGameSummary => ({
     gameId: wire.game_id,
     // black=sente, white=gote のマッピング (rshogi 側の命名と TS 側の慣習を橋渡しする)
     senteName: wire.black_handle,
+    sentePlayerId: decodeStringOrUndefined(wire.black_player_id ?? undefined),
     goteName: wire.white_handle,
+    gotePlayerId: decodeStringOrUndefined(wire.white_player_id ?? undefined),
     startedAtMs: decodeNumberOrUndefined(wire.started_at_ms),
     endedAtMs: decodeNumberOrUndefined(wire.ended_at_ms),
     timeControl: decodeClock(wire.clock),
@@ -494,7 +570,9 @@ const decodeGameDetail = (wire: GameDetailWire): RshogiGame => {
     const meta: RshogiGameMeta = {
         gameId: wire.game_id,
         senteName: summary.senteName,
+        sentePlayerId: summary.sentePlayerId,
         goteName: summary.goteName,
+        gotePlayerId: summary.gotePlayerId,
         startedAtMs: summary.startedAtMs,
         endedAtMs: summary.endedAtMs,
         event: decodeStringOrUndefined(metaWire.event ?? undefined),
@@ -519,6 +597,18 @@ const decodeGameSearchResponse = (wire: GameSearchResponseWire): RshogiGameSearc
     page: wire.page ?? 1,
     pageSize: wire.page_size ?? 20, // server default
     totalCount: wire.total_count ?? 0,
+});
+
+const decodePlayerSummary = (wire: PlayerSummaryWire): RshogiPlayerSummary => ({
+    playerId: wire.player_id,
+    displayName: wire.display_name,
+    rating: Number.isFinite(wire.rating) ? wire.rating : 1500,
+    games: Number.isFinite(wire.games) ? wire.games : 0,
+    wins: Number.isFinite(wire.wins) ? wire.wins : 0,
+    losses: Number.isFinite(wire.losses) ? wire.losses : 0,
+    draws: Number.isFinite(wire.draws) ? wire.draws : 0,
+    lastPlayedAtMs: decodeNumberOrUndefined(wire.last_played_at_ms),
+    legacy: wire.legacy === true,
 });
 
 const decodeLiveGameSummary = (wire: LiveGameWireBase): RshogiLiveGameSummary => ({
@@ -673,6 +763,77 @@ export async function fetchRshogiGameSearch(
     return decodeGameSearchResponse(payload);
 }
 
+/** 終局履歴から算出された選手ランキングを取得する。 */
+export async function fetchRshogiPlayerList(
+    options: FetchRshogiGameOptions = {},
+): Promise<RshogiPlayerList> {
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) return { players: buildMockPlayerList() };
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError("", "fetch is not available in this environment");
+    }
+    const response = await fetchImpl(
+        `${trimTrailingSlash(baseUrl)}/players`,
+        buildRequestInit(options.signal),
+    );
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            "",
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+    const payload = (await response.json()) as PlayerListResponseWire | null;
+    if (!payload || !Array.isArray(payload.players)) {
+        throw new RshogiGameFetchError("", "rshogi API response missing players array");
+    }
+    return { players: payload.players.map(decodePlayerSummary) };
+}
+
+/** 選手の集計成績と、その選手が参加した終局済棋譜を取得する。 */
+export async function fetchRshogiPlayerDetail(
+    playerId: string,
+    options: FetchRshogiPlayerDetailOptions = {},
+): Promise<RshogiPlayerDetail> {
+    if (!playerId) throw new RshogiPlayerNotFoundError(playerId);
+    const baseUrl = options.baseUrl?.trim();
+    if (!baseUrl) return mockPlayerDetail(playerId, options.page, options.pageSize);
+
+    const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!fetchImpl) {
+        throw new RshogiGameFetchError("", "fetch is not available in this environment");
+    }
+    const params = new URLSearchParams();
+    if (options.page !== undefined) params.set("page", String(options.page));
+    if (options.pageSize !== undefined) params.set("pageSize", String(options.pageSize));
+    const query = params.toString();
+    const response = await fetchImpl(
+        `${trimTrailingSlash(baseUrl)}/players/${encodeURIComponent(playerId)}${query ? `?${query}` : ""}`,
+        buildRequestInit(options.signal),
+    );
+    if (response.status === 404) throw new RshogiPlayerNotFoundError(playerId);
+    if (!response.ok) {
+        throw new RshogiGameFetchError(
+            "",
+            `rshogi API returned ${response.status} ${response.statusText}`,
+            response.status,
+        );
+    }
+    const payload = (await response.json()) as PlayerDetailResponseWire | null;
+    if (!payload?.player || !Array.isArray(payload.games)) {
+        throw new RshogiGameFetchError("", "rshogi API response missing player/games");
+    }
+    return {
+        player: decodePlayerSummary(payload.player),
+        games: payload.games.map(decodeGameSummary),
+        page: payload.page ?? 1,
+        pageSize: payload.page_size ?? 20,
+        totalCount: payload.total_count ?? 0,
+    };
+}
+
 /**
  * rshogi の進行中対局一覧 (`GET /api/v1/games/live`) を取得する。
  *
@@ -722,6 +883,65 @@ export async function fetchRshogiLiveGameList(
 const DEFAULT_MOCK_LIMIT = 50;
 const MAX_MOCK_LIMIT = 100;
 const DEFAULT_MOCK_SEARCH_PAGE_SIZE = 20;
+
+const mockPlayerId = (name: string): string => `legacy_mock_${encodeURIComponent(name)}`;
+
+const buildMockPlayerList = (): RshogiPlayerSummary[] => {
+    const records = new Map<string, Omit<RshogiPlayerSummary, "rating">>();
+    for (const game of [...MOCK_RSHOGI_GAME_LIST].reverse()) {
+        const winner = game.result?.winner;
+        for (const [side, name] of [
+            ["sente", game.senteName],
+            ["gote", game.goteName],
+        ] as const) {
+            const id = mockPlayerId(name);
+            const current = records.get(id) ?? {
+                playerId: id,
+                displayName: name,
+                games: 0,
+                wins: 0,
+                losses: 0,
+                draws: 0,
+                lastPlayedAtMs: undefined,
+                legacy: true,
+            };
+            current.games += 1;
+            if (!winner) current.draws += 1;
+            else if (winner === side) current.wins += 1;
+            else current.losses += 1;
+            current.lastPlayedAtMs = Math.max(current.lastPlayedAtMs ?? 0, game.endedAtMs ?? 0);
+            records.set(id, current);
+        }
+    }
+    return [...records.values()]
+        .map((record) => ({
+            ...record,
+            rating: Math.round(1500 + (record.wins - record.losses) * 16),
+        }))
+        .sort((a, b) => b.rating - a.rating || a.displayName.localeCompare(b.displayName));
+};
+
+const mockPlayerDetail = (
+    playerId: string,
+    page = 1,
+    pageSize = DEFAULT_MOCK_SEARCH_PAGE_SIZE,
+): RshogiPlayerDetail => {
+    const player = buildMockPlayerList().find((candidate) => candidate.playerId === playerId);
+    if (!player) throw new RshogiPlayerNotFoundError(playerId);
+    const allGames = MOCK_RSHOGI_GAME_LIST.filter(
+        (game) => game.senteName === player.displayName || game.goteName === player.displayName,
+    );
+    const normalizedPage = Math.max(1, page);
+    const normalizedPageSize = Math.min(Math.max(1, pageSize), MAX_MOCK_LIMIT);
+    const start = (normalizedPage - 1) * normalizedPageSize;
+    return {
+        player,
+        games: allGames.slice(start, start + normalizedPageSize),
+        page: normalizedPage,
+        pageSize: normalizedPageSize,
+        totalCount: allGames.length,
+    };
+};
 
 const mockGameListPage = (
     cursor: string | undefined,


### PR DESCRIPTION
## Summary
- add `/rshogi-viewer/players` as a responsive Japanese-style player ranking
- add player detail pages with Elo, W/L/D totals, legacy identity labeling, and paginated game history
- add typed match-client player APIs and player IDs on game summaries
- link the ranking from the viewer list and navigation drawer

## Backend dependency
- Requires https://github.com/SH11235/rshogi/pull/948 and its `/api/v1/players` endpoints.
- The backend must be migrated, warmed, and verified before this UI is deployed.

## Verification
- match-client tests: 36/36 targeted
- web tests: 53/53
- match-client and web typechecks
- Biome check on all 11 changed/new files
- production deployment build sequence completed successfully
- independent agent review: APPROVE after three review rounds
