### PR TITLE
Universal NNUE対応をWeb WASMへ導入

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,6 +2,9 @@
 VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # Optional
 # VITE_DEFAULT_NNUE_PRESET=ramu
+# WASM エンジンの要求スレッド数。未設定時は4。ブラウザ上限でclampされ、
+# SharedArrayBufferが利用できない場合はsingle-threaded版へフォールバックする。
+# VITE_WASM_THREADS=4
 # VITE_BASE_PATH=/
 # VITE_ALLOWED_HOSTS=your-host.example.com,another-host.example.com
 # rshogi 棋譜配信 API のベース URL。

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,34 +1,21 @@
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { EngineOption } from "@shogi/ui";
 import { EngineControlPanel, ShogiMatch, useDevMode } from "@shogi/ui";
 import { useState } from "react";
 import { HeaderNav } from "./components/HeaderNav";
 import { PageHeader } from "./components/PageHeader";
 import { useRemotePrivateNnueManager } from "./hooks/useRemotePrivateNnueManager";
-
-const resolveWasmThreads = () => {
-    const fallback = import.meta.env.DEV ? 4 : 1;
-    const raw = import.meta.env.VITE_WASM_THREADS;
-    if (typeof raw !== "string" || raw.trim() === "") return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-    return Math.trunc(parsed);
-};
-
-const wasmThreads = resolveWasmThreads();
-
-const createEngineClient = () =>
-    createWasmEngineClient({
-        stopMode: "terminate",
-        defaultInitOptions: { threads: wasmThreads },
-        logWarningsToConsole: true,
-    });
+import { createWebWasmEngineClient } from "./platform/wasm-engine-client";
 
 const engineOptions: EngineOption[] = [
-    { id: "wasm", label: "内蔵エンジン", createClient: createEngineClient, kind: "internal" },
+    {
+        id: "wasm",
+        label: "内蔵エンジン",
+        createClient: createWebWasmEngineClient,
+        kind: "internal",
+    },
 ];
 
-const panelEngine = createEngineClient();
+const panelEngine = createWebWasmEngineClient();
 
 // NNUE プリセット manifest.json の URL（環境変数で設定、必須）
 const nnueManifestUrl = import.meta.env.VITE_NNUE_MANIFEST_URL as string;

--- a/apps/web/src/hooks/useOnlineAnalysis.ts
+++ b/apps/web/src/hooks/useOnlineAnalysis.ts
@@ -1,6 +1,6 @@
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { AnalysisMoveResult, OnlineAnalysis } from "@shogi/ui";
 import { useEffect, useRef, useState } from "react";
+import { createWebWasmEngineClient } from "../platform/wasm-engine-client";
 
 function buildPassRightsForAnalysis(moves: string[], initialCount: number) {
     const hasPass = moves.some((m) => m.toLowerCase() === "pass");
@@ -28,7 +28,7 @@ export function useOnlineAnalysis(
     searchTimeMs: number | null,
     initialPassCount = 1,
 ): OnlineAnalysis {
-    const engineRef = useRef<ReturnType<typeof createWasmEngineClient> | null>(null);
+    const engineRef = useRef<ReturnType<typeof createWebWasmEngineClient> | null>(null);
     const searchHandleRef = useRef<{ cancel(): Promise<void> } | null>(null);
     const unsubscribeRef = useRef<(() => void) | null>(null);
     const [isAnalyzing, setIsAnalyzing] = useState(false);
@@ -36,10 +36,10 @@ export function useOnlineAnalysis(
     const topMovesMapRef = useRef<Map<number, AnalysisMoveResult>>(new Map());
 
     useEffect(() => {
-        const engine = createWasmEngineClient({ stopMode: "terminate" });
+        const engine = createWebWasmEngineClient();
         engineRef.current = engine;
         engine
-            .init({ threads: 1 })
+            .init()
             .then(() => engine.setOption("MultiPV", 3))
             .catch(console.error);
         return () => {

--- a/apps/web/src/pages/games/GameReviewPage.tsx
+++ b/apps/web/src/pages/games/GameReviewPage.tsx
@@ -7,7 +7,6 @@ import type {
     GetAnalysisSnapshotResponse,
     JsonValue,
 } from "@shogi/api-contract";
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { AnalysisSettings, AnalysisSnapshotDraft, EngineOption } from "@shogi/ui";
 import {
     decodeSnapshotEvalMateReviver,
@@ -21,28 +20,13 @@ import { HeaderNav } from "../../components/HeaderNav";
 import { PageHeader } from "../../components/PageHeader";
 import { parseApiError } from "../../hooks/useAuthSession";
 import { useRemotePrivateNnueManager } from "../../hooks/useRemotePrivateNnueManager";
-
-const resolveWasmThreads = () => {
-    const fallback = import.meta.env.DEV ? 4 : 1;
-    const raw = import.meta.env.VITE_WASM_THREADS;
-    if (typeof raw !== "string" || raw.trim() === "") return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-    return Math.trunc(parsed);
-};
-
-const wasmThreads = resolveWasmThreads();
+import { createWebWasmEngineClient } from "../../platform/wasm-engine-client";
 
 const engineOptions: EngineOption[] = [
     {
         id: "wasm",
         label: "内蔵エンジン",
-        createClient: () =>
-            createWasmEngineClient({
-                stopMode: "terminate",
-                defaultInitOptions: { threads: wasmThreads },
-                logWarningsToConsole: true,
-            }),
+        createClient: createWebWasmEngineClient,
         kind: "internal",
     },
 ];

--- a/apps/web/src/pages/games/PublicGamePage.tsx
+++ b/apps/web/src/pages/games/PublicGamePage.tsx
@@ -1,35 +1,19 @@
 import type { GameRecordDetail } from "@shogi/api-contract";
 import { parseCsaMoves } from "@shogi/app-core";
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { EngineOption } from "@shogi/ui";
 import { ShogiMatch } from "@shogi/ui";
 import { getRouteApi } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageHeader } from "../../components/PageHeader";
+import { createWebWasmEngineClient } from "../../platform/wasm-engine-client";
 import { formatGameResult } from "./gameResultUtils";
-
-const resolveWasmThreads = () => {
-    const fallback = import.meta.env.DEV ? 4 : 1;
-    const raw = import.meta.env.VITE_WASM_THREADS;
-    if (typeof raw !== "string" || raw.trim() === "") return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-    return Math.trunc(parsed);
-};
-
-const wasmThreads = resolveWasmThreads();
 
 const engineOptions: EngineOption[] = [
     {
         id: "wasm",
         label: "内蔵エンジン",
-        createClient: () =>
-            createWasmEngineClient({
-                stopMode: "terminate",
-                defaultInitOptions: { threads: wasmThreads },
-                logWarningsToConsole: true,
-            }),
+        createClient: createWebWasmEngineClient,
         kind: "internal",
     },
 ];

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerLivePage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerLivePage.tsx
@@ -1,32 +1,16 @@
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { EngineOption } from "@shogi/ui";
 import { RshogiCsaLiveViewer } from "@shogi/ui";
 import { getRouteApi } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageHeader } from "../../components/PageHeader";
-
-const resolveWasmThreads = (): number => {
-    const fallback = import.meta.env.DEV ? 4 : 1;
-    const raw = import.meta.env.VITE_WASM_THREADS;
-    if (typeof raw !== "string" || raw.trim() === "") return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-    return Math.trunc(parsed);
-};
-
-const wasmThreads = resolveWasmThreads();
+import { createWebWasmEngineClient } from "../../platform/wasm-engine-client";
 
 const engineOptions: EngineOption[] = [
     {
         id: "wasm",
         label: "内蔵エンジン",
-        createClient: () =>
-            createWasmEngineClient({
-                stopMode: "terminate",
-                defaultInitOptions: { threads: wasmThreads },
-                logWarningsToConsole: true,
-            }),
+        createClient: createWebWasmEngineClient,
         kind: "internal",
     },
 ];

--- a/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiViewerPage.tsx
@@ -1,32 +1,16 @@
-import { createWasmEngineClient } from "@shogi/engine-wasm";
 import type { EngineOption } from "@shogi/ui";
 import { RshogiCsaViewer } from "@shogi/ui";
 import { getRouteApi } from "@tanstack/react-router";
 import type { ReactElement } from "react";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageHeader } from "../../components/PageHeader";
-
-const resolveWasmThreads = (): number => {
-    const fallback = import.meta.env.DEV ? 4 : 1;
-    const raw = import.meta.env.VITE_WASM_THREADS;
-    if (typeof raw !== "string" || raw.trim() === "") return fallback;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed) || parsed < 1) return fallback;
-    return Math.trunc(parsed);
-};
-
-const wasmThreads = resolveWasmThreads();
+import { createWebWasmEngineClient } from "../../platform/wasm-engine-client";
 
 const engineOptions: EngineOption[] = [
     {
         id: "wasm",
         label: "内蔵エンジン",
-        createClient: () =>
-            createWasmEngineClient({
-                stopMode: "terminate",
-                defaultInitOptions: { threads: wasmThreads },
-                logWarningsToConsole: true,
-            }),
+        createClient: createWebWasmEngineClient,
         kind: "internal",
     },
 ];

--- a/apps/web/src/platform/wasm-engine-client.test.ts
+++ b/apps/web/src/platform/wasm-engine-client.test.ts
@@ -7,6 +7,7 @@ describe("resolveWasmThreads", () => {
         "",
         "false",
         "0",
+        "0.5",
         "-1",
         "NaN",
     ])("無効値 %s ではマルチスレッド既定値を返す", (raw) => {

--- a/apps/web/src/platform/wasm-engine-client.test.ts
+++ b/apps/web/src/platform/wasm-engine-client.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_WASM_THREADS, resolveWasmThreads } from "./wasm-engine-client";
+
+describe("resolveWasmThreads", () => {
+    it.each([
+        undefined,
+        "",
+        "false",
+        "0",
+        "-1",
+        "NaN",
+    ])("無効値 %s ではマルチスレッド既定値を返す", (raw) => {
+        expect(resolveWasmThreads(raw)).toBe(DEFAULT_WASM_THREADS);
+    });
+
+    it("正の有限値を整数化する", () => {
+        expect(resolveWasmThreads("8.9")).toBe(8);
+    });
+});

--- a/apps/web/src/platform/wasm-engine-client.ts
+++ b/apps/web/src/platform/wasm-engine-client.ts
@@ -1,0 +1,19 @@
+import { createWasmEngineClient } from "@shogi/engine-wasm";
+
+export const DEFAULT_WASM_THREADS = 4;
+
+export function resolveWasmThreads(raw = import.meta.env.VITE_WASM_THREADS): number {
+    if (typeof raw !== "string" || raw.trim() === "") return DEFAULT_WASM_THREADS;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_WASM_THREADS;
+    return Math.trunc(parsed);
+}
+
+const wasmThreads = resolveWasmThreads();
+
+export const createWebWasmEngineClient = () =>
+    createWasmEngineClient({
+        stopMode: "terminate",
+        defaultInitOptions: { threads: wasmThreads },
+        logWarningsToConsole: true,
+    });

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
     /** デフォルトの NNUE プリセットキー */
     readonly VITE_DEFAULT_NNUE_PRESET?: string;
+    /** WASM エンジンの要求スレッド数。未設定時は4、利用不可時は1へフォールバック */
+    readonly VITE_WASM_THREADS?: string;
 }
 
 interface ImportMeta {

--- a/packages/app-controller/src/engine-controller.ts
+++ b/packages/app-controller/src/engine-controller.ts
@@ -232,8 +232,8 @@ const normalizeThreadCount = (value?: number): number | undefined => {
 };
 
 // 0 (自動) は UI が「自動（推奨: N）」と表示する検出値に解決する。
-// undefined のまま init に渡すとクライアントの既定値 (Web 本番は 1) に落ち、
-// ラベルと実際のスレッド数が食い違う
+// undefined のまま init に渡すとクライアントごとの既定値に落ち、
+// UI の「自動（推奨: N）」と実際のスレッド数が食い違う
 const getThreadCountForSide = (threads: Record<Player, number>, side: Player): number =>
     normalizeThreadCount(threads[side]) ?? detectParallelism().recommendedWorkers;
 

--- a/packages/rust-core/Cargo.lock
+++ b/packages/rust-core/Cargo.lock
@@ -117,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "rshogi-core"
-version = "0.2.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e86c1b671b17e6b8c20a58fd728db8a5188ef3dbfcc0330fb2bf44ddaf75fa"
+checksum = "b4f0509a245495ee3a01fcb9d62ebc95cb615ed77d0d23ffc40931c81860d737"
 dependencies = [
  "anyhow",
  "getrandom",
@@ -537,7 +537,3 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[patch.unused]]
-name = "rshogi-core"
-version = "0.4.0"

--- a/packages/rust-core/crates/engine-wasm/Cargo.toml
+++ b/packages/rust-core/crates/engine-wasm/Cargo.toml
@@ -10,7 +10,7 @@ description = "Wasm bindings for the shogi engine core"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-rshogi-core = "0.2"
+rshogi-core = "0.5.2"
 wasm-bindgen = { version = "0.2.106", features = ["serde-serialize"] }
 wasm-bindgen-rayon = { version = "1.2", optional = true }
 js-sys = "0.3.83"


### PR DESCRIPTION
## 概要

- `engine-wasm` の `rshogi-core` を `0.2.4` から `0.5.2` へ更新し、Simple / LayerStacks KingRank9 を動的に扱う Universal NNUE ローダーを Web 版で利用します。
- Web の WASM クライアント生成を共通化し、本番を含む既定要求を 4 threads にします。
- 対局・棋譜解析の `0=自動` は従来どおり `hardwareConcurrency / 2`（最大32）へ解決します。
- `SharedArrayBuffer` / cross-origin isolation が使えない場合や threaded 初期化に失敗した場合は、既存の single-threaded 版へフォールバックします。
- `VITE_WASM_THREADS` で明示上書きできます。

## 実モデル検証

tatara の軽量学習設定（FT 128、dense 2x2、1 batch / 1 superbatch）で55ファイルを生成し、Chromium上で single / threaded の両方を検証しました。

- Simple: 5 FeatureTransformer × 3 activation = 15件
- LayerStacks KingRank9: 5 FeatureTransformer × 8構成 = 40件
  - base / PSQT / full Threat: 15件はロード・探索成功
  - 現時点で非対応の非full Threat 5構成: 25件は想定した次元/profile不一致として拒否
- single / threaded とも判定差分 0件
- ロード成功した全30件で `bestmove` 取得を確認
- 本番配信モデル（75,076,151 bytes、SHA-256一致）でもロード・探索を確認

## サイズ・初期表示への影響

`rshogi-core 0.2.4` の同一productionビルドとの比較です。

| artifact | raw | gzip -9 |
|---|---:|---:|
| single baseline | 1,479,835 B | 258,154 B |
| single universal | 2,035,046 B (+37.52%) | 284,203 B (+10.09%) |
| threaded baseline | 1,553,077 B | 276,576 B |
| threaded universal | 2,124,515 B (+36.79%) | 304,842 B (+10.22%) |

Chromiumの新規contextを各10回起動した初期描画中央値:

- baseline FCP: 140.80 ms
- universal FCP: 143.15 ms（+2.35 ms / +1.67%）
- 両方とも初期1.5秒では WASM / Worker request は0件

WASMは初期描画経路に含まれず、増加分は初回エンジン利用時のdownloadへ影響します。

## 探索性能の確認

- node-material固定スクリプト12ケース平均: 447,919 → 465,690 NPS（+3.97%）
- 本番NNUE、200k node、各3 cold page中央値:
  - single: 438,734 → 398,426 NPS（-9.19%）
  - threaded: 460,908 → 604,752 NPS（+31.21%）

後者はエンジン更新により探索木・bestmoveが変わるため、評価関数単体の厳密な同条件比較ではありません。既存の固定LayerStacks editionについては別途行った `search_only_ab` の退行確認で同等を確認済みです。

## 検証

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo check --workspace`（crates.io の `rshogi-core 0.5.2` を使用）
- `pnpm --filter @shogi/app-controller test -- --run`（35件）
- `pnpm --dir apps/web test -- --run`（65件）
- `pnpm --filter @shogi/engine-wasm test -- --run`（221件）
- `pnpm lint`
- `pnpm typecheck`
- production single / threaded WASM build + web build
- Chromium実ロード・探索、初期描画計測

なおrootの `pnpm test` は既存の `@shogi/api-contract` にtest fileがないため失敗します。変更対象のテストは個別に完走しています。
