### PR TITLE
NNUE取得後に残る解析エラーを解消

### DIFF
--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
@@ -1,0 +1,55 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DEFAULT_ANALYSIS_SETTINGS } from "../types";
+import { useBatchAnalysis } from "./useBatchAnalysis";
+
+describe("useBatchAnalysis", () => {
+    it("NNUE未ダウンロード後の再解析に成功したら古いエラーメッセージを消す", async () => {
+        const resolveNnue = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("評価関数がダウンロードされていません"))
+            .mockResolvedValueOnce({ nnueId: "ramu", fvScale: 8 });
+        const analyzePosition = vi.fn().mockResolvedValue(undefined);
+        const openNnueManager = vi.fn();
+        const setMessage = vi.fn();
+
+        const { result } = renderHook(() =>
+            useBatchAnalysis({
+                kifMoves: [],
+                startSfen: "startpos",
+                analysisSettings: DEFAULT_ANALYSIS_SETTINGS,
+                enginePool: {
+                    isRunning: false,
+                    progress: null,
+                    start: vi.fn(),
+                    cancel: vi.fn().mockResolvedValue(undefined),
+                    dispose: vi.fn().mockResolvedValue(undefined),
+                },
+                resolveNnue,
+                analysisNnueSelection: { presetKey: "ramu", nnueId: null },
+                recordEvalByPly: vi.fn(),
+                recordEvalByNodeId: vi.fn(),
+                clearEvalByPly: vi.fn(),
+                clearEvalByNodeId: vi.fn(),
+                analyzePosition,
+                isAnalyzing: false,
+                kifuTree: null,
+                openNnueManager,
+                setMessage,
+                batchAnalysis: null,
+                setBatchAnalysis: vi.fn(),
+            }),
+        );
+
+        await act(() => result.current.handleAnalyzePly(0));
+
+        expect(setMessage).toHaveBeenLastCalledWith(expect.objectContaining({ type: "error" }));
+        expect(openNnueManager).toHaveBeenCalledWith("missing-analysis");
+        expect(analyzePosition).not.toHaveBeenCalled();
+
+        await act(() => result.current.handleAnalyzePly(0));
+
+        expect(setMessage).toHaveBeenLastCalledWith(null);
+        expect(analyzePosition).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
@@ -146,6 +146,7 @@ export function useBatchAnalysis({
             openNnueManager("missing-analysis");
             return;
         }
+        setMessage(null);
 
         // ply手目の局面を解析するには、ply-1手までの指し手が必要
         // （ply 1 = 1手目を指した後の局面 = moves[0]まで適用した局面）
@@ -250,6 +251,7 @@ export function useBatchAnalysis({
             openNnueManager("missing-analysis");
             return;
         }
+        setMessage(null);
 
         // ジョブを生成
         const jobs: AnalysisJob[] = targetPlies.map((ply) => ({
@@ -293,6 +295,7 @@ export function useBatchAnalysis({
             openNnueManager("missing-analysis");
             return;
         }
+        setMessage(null);
 
         // AnalysisJob形式に変換
         const jobs: AnalysisJob[] = treeJobs.map((job) => ({
@@ -337,6 +340,7 @@ export function useBatchAnalysis({
             openNnueManager("missing-analysis");
             return;
         }
+        setMessage(null);
 
         // AnalysisJob形式に変換
         const jobs: AnalysisJob[] = branchJobs.map((job) => ({


### PR DESCRIPTION
## 概要

NNUE が未ダウンロードの状態で解析を試した後、NNUE のダウンロードと再解析に成功しても、以前の「解析を開始できません」エラーバナーが残り続ける問題を修正します。

## 原因と修正

未ダウンロード時のエラーは `ShogiMatch` の共有メッセージへ設定されますが、次の解析で `resolveNnue` が成功した際にそのメッセージを解除していませんでした。

NNUE 解決が成功した直後に共有メッセージをクリアします。単発解析だけでなく、同じ処理を持つ一括解析・ツリー解析・分岐解析にも適用しています。NNUE 解決が失敗した場合は従来どおりエラーを維持します。

## 検証

- 未ダウンロードで失敗 → ダウンロード済みとして再試行 → 解析成功、という回帰テストを追加
- `@shogi/ui`: 35 files / 422 tests passed
- workspace lint: 9 tasks passed
- workspace typecheck: 12 tasks passed
- production single/threaded WASM build passed
- production Web build passed
