### PR TITLE
分岐ノード解析後に残るNNUEエラーを解消

### DIFF
--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
@@ -54,7 +54,7 @@ describe("useBatchAnalysis", () => {
         expect(analyzePosition).toHaveBeenCalledTimes(1);
     });
 
-    it("NNUE未ダウンロード後に分岐ノード解析が成功したら古いエラーメッセージを消す", async () => {
+    it("分岐ノード解析はNNUE未ダウンロード中の案内を維持し、ダウンロード後の成功時に消す", async () => {
         const startPosition = {
             board: createInitialBoard(),
             hands: createEmptyHands(),
@@ -64,7 +64,13 @@ describe("useBatchAnalysis", () => {
         const nodePosition = { ...startPosition, turn: "gote" as const, ply: 1 };
         const kifuTree = addMove(createKifuTree(startPosition, "startpos"), "7g7f", nodePosition);
         const analyzePosition = vi.fn().mockResolvedValue(undefined);
+        const openNnueManager = vi.fn();
         const setMessage = vi.fn();
+        const resolveNnue = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("評価関数がダウンロードされていません"))
+            .mockRejectedValueOnce(new Error("評価関数がダウンロードされていません"))
+            .mockResolvedValueOnce({ nnueId: "ramu", fvScale: 8 });
 
         const { result } = renderHook(() =>
             useBatchAnalysis({
@@ -78,9 +84,7 @@ describe("useBatchAnalysis", () => {
                     cancel: vi.fn().mockResolvedValue(undefined),
                     dispose: vi.fn().mockResolvedValue(undefined),
                 },
-                resolveNnue: vi
-                    .fn()
-                    .mockRejectedValueOnce(new Error("評価関数がダウンロードされていません")),
+                resolveNnue,
                 analysisNnueSelection: { presetKey: "ramu", nnueId: null },
                 recordEvalByPly: vi.fn(),
                 recordEvalByNodeId: vi.fn(),
@@ -89,7 +93,7 @@ describe("useBatchAnalysis", () => {
                 analyzePosition,
                 isAnalyzing: false,
                 kifuTree,
-                openNnueManager: vi.fn(),
+                openNnueManager,
                 setMessage,
                 batchAnalysis: null,
                 setBatchAnalysis: vi.fn(),
@@ -98,6 +102,11 @@ describe("useBatchAnalysis", () => {
 
         await act(() => result.current.handleAnalyzePly(1));
         expect(setMessage).toHaveBeenLastCalledWith(expect.objectContaining({ type: "error" }));
+
+        await act(() => result.current.handleAnalyzeNode(kifuTree.currentNodeId));
+        expect(setMessage).toHaveBeenLastCalledWith(expect.objectContaining({ type: "error" }));
+        expect(openNnueManager).toHaveBeenLastCalledWith("missing-analysis");
+        expect(analyzePosition).not.toHaveBeenCalled();
 
         await act(() => result.current.handleAnalyzeNode(kifuTree.currentNodeId));
 

--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.test.ts
@@ -1,3 +1,4 @@
+import { addMove, createEmptyHands, createInitialBoard, createKifuTree } from "@shogi/app-core";
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { DEFAULT_ANALYSIS_SETTINGS } from "../types";
@@ -51,5 +52,58 @@ describe("useBatchAnalysis", () => {
 
         expect(setMessage).toHaveBeenLastCalledWith(null);
         expect(analyzePosition).toHaveBeenCalledTimes(1);
+    });
+
+    it("NNUE未ダウンロード後に分岐ノード解析が成功したら古いエラーメッセージを消す", async () => {
+        const startPosition = {
+            board: createInitialBoard(),
+            hands: createEmptyHands(),
+            turn: "sente" as const,
+            ply: 0,
+        };
+        const nodePosition = { ...startPosition, turn: "gote" as const, ply: 1 };
+        const kifuTree = addMove(createKifuTree(startPosition, "startpos"), "7g7f", nodePosition);
+        const analyzePosition = vi.fn().mockResolvedValue(undefined);
+        const setMessage = vi.fn();
+
+        const { result } = renderHook(() =>
+            useBatchAnalysis({
+                kifMoves: [],
+                startSfen: "startpos",
+                analysisSettings: DEFAULT_ANALYSIS_SETTINGS,
+                enginePool: {
+                    isRunning: false,
+                    progress: null,
+                    start: vi.fn(),
+                    cancel: vi.fn().mockResolvedValue(undefined),
+                    dispose: vi.fn().mockResolvedValue(undefined),
+                },
+                resolveNnue: vi
+                    .fn()
+                    .mockRejectedValueOnce(new Error("評価関数がダウンロードされていません")),
+                analysisNnueSelection: { presetKey: "ramu", nnueId: null },
+                recordEvalByPly: vi.fn(),
+                recordEvalByNodeId: vi.fn(),
+                clearEvalByPly: vi.fn(),
+                clearEvalByNodeId: vi.fn(),
+                analyzePosition,
+                isAnalyzing: false,
+                kifuTree,
+                openNnueManager: vi.fn(),
+                setMessage,
+                batchAnalysis: null,
+                setBatchAnalysis: vi.fn(),
+            }),
+        );
+
+        await act(() => result.current.handleAnalyzePly(1));
+        expect(setMessage).toHaveBeenLastCalledWith(expect.objectContaining({ type: "error" }));
+
+        await act(() => result.current.handleAnalyzeNode(kifuTree.currentNodeId));
+
+        expect(analyzePosition).toHaveBeenCalledWith(
+            expect.objectContaining({ moves: ["7g7f"], ply: 1 }),
+        );
+        expect(setMessage).toHaveBeenLastCalledWith(null);
     });
 });

--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
@@ -192,6 +192,18 @@ export function useBatchAnalysis({
             return;
         }
 
+        // NNUE の存在確認（未ダウンロードの場合はエラー）
+        try {
+            await resolveNnue(analysisNnueSelection);
+        } catch (e) {
+            const errorMessage = e instanceof Error ? e.message : "評価関数の準備に失敗しました";
+            const detailedMessage = `解析を開始できません: ${errorMessage}\n\n対処方法:\n1. NNUE管理画面が開きます\n2. 必要なファイルをダウンロードしてください\n3. 再度解析を実行してください`;
+            setMessage({ text: detailedMessage, type: "error" });
+            openNnueManager("missing-analysis");
+            return;
+        }
+        setMessage(null);
+
         // 再解析のために既存の評価値をクリア
         clearEvalByNodeId(nodeId);
 
@@ -217,7 +229,6 @@ export function useBatchAnalysis({
                 depth: analysisSettings.batchAnalysisDepth,
                 multiPv: analysisSettings.multiPv,
             });
-            setMessage(null);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             setAnalyzingState({ type: "error", ply: node.ply, message: errorMessage });

--- a/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
+++ b/packages/ui/src/components/shogi-match/hooks/useBatchAnalysis.ts
@@ -217,6 +217,7 @@ export function useBatchAnalysis({
                 depth: analysisSettings.batchAnalysisDepth,
                 multiPv: analysisSettings.multiPv,
             });
+            setMessage(null);
         } catch (error) {
             const errorMessage = error instanceof Error ? error.message : String(error);
             setAnalyzingState({ type: "error", ply: node.ply, message: errorMessage });


### PR DESCRIPTION
## 概要

PR #114 のレビュー指摘を受け、NNUE 未ダウンロードエラーの後に分岐ノード解析を実行しても古いエラーバナーが残る経路を修正します。

レビュー指摘: https://github.com/SH11235/ramu-shogi/pull/114#discussion_r3610774898

## 原因と修正

通常局面・一括・ツリー・分岐一括解析では解析前に NNUE を明示解決し、解決成功時に古い「NNUE 未ダウンロード」メッセージを解除していましたが、個別の分岐ノード解析を行う `handleAnalyzeNode` だけがこの処理を持っていませんでした。

`handleAnalyzeNode` でも解析前に `resolveNnue` を実行します。

- NNUE が未取得なら、エラー案内を維持して NNUE マネージャーを開き、解析は開始しません
- NNUE が解決できたら、既に事実ではなくなった未ダウンロード案内を解除して解析を開始します
- その後の探索失敗は従来どおり `analyzingState` の解析エラーとして扱います

## 回帰テスト

同一 hook 上で次の経路を再現するテストを追加しました。

1. NNUE 未ダウンロード状態で通常解析に失敗し、共有エラーを表示
2. NNUE 未取得のまま分岐ノード解析を実行し、案内を維持して解析を開始しないことを確認
3. ダウンロード後を想定して再度分岐ノード解析を実行し、解析開始と共有エラー解除を確認

## 検証

- `@shogi/ui`: 35 files / 423 tests passed
- workspace lint: 9 tasks passed
- workspace typecheck: 12 tasks passed
- production single/threaded WASM build passed
- production Web build passed
