### PR TITLE
workers.dev / preview URL を無効化 (無料枠保護、到達経路を Custom Domain に一本化)

### DIFF
--- a/apps/web/wrangler.toml
+++ b/apps/web/wrangler.toml
@@ -6,6 +6,11 @@ compatibility_date = "2026-01-20"
 main = "./worker/index.ts"
 # Custom Domain binding。DNS record (AAAA 100:: proxied) は iac repo (Pulumi) が正典
 routes = [{ pattern = "ramu-shogi.sh11235.com", custom_domain = true }]
+# workers.dev 直 URL / preview URL は zone (sh11235.com) の WAF・Rate Limiting を
+# 経由しないため公開しない。到達経路は Custom Domain (proxied) のみに限定する。
+# named env (stg 含む) にも継承される
+workers_dev = false
+preview_urls = false
 
 # /api/* を backend Worker にプロキシ（Service Binding）
 [[services]]


### PR DESCRIPTION
workers.dev 直 URL / preview URL は zone (sh11235.com) の WAF・Rate Limiting を経由しないため、DDoS 様のアクセスによる Workers 無料枠の焼き潰し経路になる。到達経路を Custom Domain (proxied) に一本化するため `workers_dev = false` / `preview_urls = false` を宣言する。

runtime 側は 2026-07-20 に Cloudflare API で全 Worker の subdomain を無効化済み (workers.dev 直 URL は 404、Custom Domain は 200 を確認)。本 PR は次回 deploy での再有効化を防ぐ宣言の恒久化。調査ログ: iac docs/operation-log/2026-07-20-waf-free-plan-survey.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XF8uygMzncnuMf5V17RztU