### PR TITLE
feat(web): rshogi viewer の player 詳細に nnue-lab 実験へのバックリンクを表示

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,6 +14,9 @@ VITE_NNUE_MANIFEST_URL=https://example/manifest.json
 # 例 (staging): VITE_RSHOGI_API_BASE=https://stg.rshogi-csa-server.sh11235.com/api/v1
 # VITE_RSHOGI_API_BASE=https://rshogi.example.com/api/v1
 
+# nnue-lab の公開実験へのリンク先。未設定時は https://nnue-lab.sh11235.com
+# VITE_NNUE_LAB_BASE=https://nnue-lab.example.com
+
 # クライアント種識別子。viewer 配信 API のリクエスト header `X-Client: <kind>/<version>` で送信される。
 # 未設定なら header を送らない (= server 側ログでは `unknown` 扱い)。
 # version 部分は vite.config.ts が package.json::version を build 時に literal 置換する。

--- a/apps/web/src/lib/nnueLabBaseUrl.ts
+++ b/apps/web/src/lib/nnueLabBaseUrl.ts
@@ -1,0 +1,7 @@
+const DEFAULT_NNUE_LAB_BASE_URL = "https://nnue-lab.sh11235.com";
+
+/** nnue-lab の Vite 設定値を正規化し、未設定時は本番 URL を返す。 */
+export const resolveNnueLabBaseUrl = (): string => {
+    const raw = import.meta.env.VITE_NNUE_LAB_BASE as string | undefined;
+    return (raw?.trim() || DEFAULT_NNUE_LAB_BASE_URL).replace(/\/+$/, "");
+};

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.test.tsx
@@ -6,8 +6,9 @@ const fetchRshogiPlayerDetail = vi.fn();
 const navigate = vi.fn();
 
 vi.mock("@shogi/match-client", () => ({ fetchRshogiPlayerDetail }));
+let routePlayerId = "p_one";
 vi.mock("@tanstack/react-router", () => ({
-    getRouteApi: () => ({ useParams: () => ({ playerId: "p_one" }) }),
+    getRouteApi: () => ({ useParams: () => ({ playerId: routePlayerId }) }),
     Link: ({ children }: { children: ReactNode }) => <a href="/players">{children}</a>,
     useNavigate: () => navigate,
 }));
@@ -56,6 +57,8 @@ const { default: RshogiPlayerDetailPage } = await import("./RshogiPlayerDetailPa
 describe("RshogiPlayerDetailPage", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        routePlayerId = "p_one";
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ status: 404 }));
         fetchRshogiPlayerDetail.mockImplementation(
             (_playerId: string, options: { page?: number }) => {
                 const page = options.page ?? 1;
@@ -117,5 +120,75 @@ describe("RshogiPlayerDetailPage", () => {
         fetchRshogiPlayerDetail.mockRejectedValueOnce(new Error("player unavailable"));
         render(<RshogiPlayerDetailPage />);
         expect((await screen.findByRole("alert")).textContent).toContain("player unavailable");
+    });
+
+    it("公開実験がある場合は nnue-lab へのリンクを表示する", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce({
+            status: 200,
+            json: () =>
+                Promise.resolve({
+                    tenant_slug: "public-team",
+                    experiment_id: "exp-42",
+                    experiment_name: "HalfKA 実験",
+                }),
+        } as Response);
+
+        render(<RshogiPlayerDetailPage />);
+
+        const link = await screen.findByRole("link", { name: /nnue-lab で実験を見る/ });
+        expect(link.getAttribute("href")).toBe(
+            "https://nnue-lab.sh11235.com/t/public-team/experiments/exp-42",
+        );
+        expect(link.getAttribute("target")).toBe("_blank");
+        expect(link.getAttribute("rel")).toBe("noreferrer");
+        expect(screen.getByText("HalfKA 実験")).toBeTruthy();
+    });
+
+    it("公開実験がない場合は nnue-lab の表示を追加しない", async () => {
+        render(<RshogiPlayerDetailPage />);
+
+        await waitFor(() => expect(fetch).toHaveBeenCalled());
+        expect(screen.queryByRole("link", { name: /nnue-lab で実験を見る/ })).toBeNull();
+    });
+
+    it("player 遷移時は新詳細の取得完了前に旧 nnue-lab リンクを消す", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce({
+            status: 200,
+            json: () =>
+                Promise.resolve({
+                    tenant_slug: "public-team",
+                    experiment_id: "exp-42",
+                    experiment_name: "HalfKA 実験",
+                }),
+        } as Response);
+
+        const { rerender } = render(<RshogiPlayerDetailPage />);
+        await screen.findByRole("link", { name: /nnue-lab で実験を見る/ });
+
+        // 次 player の詳細取得を未解決のまま保留し、遷移直後の表示を検証する
+        fetchRshogiPlayerDetail.mockImplementation(() => new Promise(() => {}));
+        routePlayerId = "p_two";
+        rerender(<RshogiPlayerDetailPage />);
+
+        await waitFor(() =>
+            expect(screen.queryByRole("link", { name: /nnue-lab で実験を見る/ })).toBeNull(),
+        );
+        expect(screen.queryByText("銀将")).toBeNull();
+    });
+
+    it("読み込んだ詳細の canonical playerId で公開実験を検索する", async () => {
+        fetchRshogiPlayerDetail.mockResolvedValueOnce({
+            ...detail,
+            player: { ...detail.player, playerId: "canonical/player" },
+        });
+
+        render(<RshogiPlayerDetailPage />);
+
+        await waitFor(() =>
+            expect(fetch).toHaveBeenCalledWith(
+                "https://nnue-lab.sh11235.com/api/public/csa-players/canonical%2Fplayer",
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            ),
+        );
     });
 });

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
@@ -8,19 +8,35 @@ import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
 import { PageHeader } from "../../components/PageHeader";
 import { StatusBanner } from "../../components/StatusBanner";
+import { resolveNnueLabBaseUrl } from "../../lib/nnueLabBaseUrl";
 import { resolveRshogiApiBaseUrl } from "../../lib/rshogiApiBaseUrl";
 
 const PAGE_SIZE = 20;
 const routeApi = getRouteApi("/rshogi-viewer/players/$playerId");
 
+type NnueLabExperiment = {
+    tenant_slug: string;
+    experiment_id: string;
+    experiment_name: string;
+};
+
 export default function RshogiPlayerDetailPage(): ReactElement {
     const { playerId } = routeApi.useParams();
     const navigate = useNavigate();
     const apiBaseUrl = resolveRshogiApiBaseUrl();
+    const nnueLabBaseUrl = resolveNnueLabBaseUrl();
     const [detail, setDetail] = useState<RshogiPlayerDetail | null>(null);
+    const [nnueLabExperiment, setNnueLabExperiment] = useState<NnueLabExperiment | null>(null);
     const [pageRequest, setPageRequest] = useState({ page: 1, attempt: 0 });
     const [isLoading, setIsLoading] = useState(true);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+    // route の playerId が変わったら旧 player の詳細と nnue-lab カードを即座に
+    // 破棄する (新詳細の取得が失敗しても旧 player の情報が残らないように)。
+    useEffect(() => {
+        setDetail(null);
+        setNnueLabExperiment(null);
+    }, [playerId]);
 
     useEffect(() => {
         const controller = new AbortController();
@@ -51,6 +67,28 @@ export default function RshogiPlayerDetailPage(): ReactElement {
     }, [apiBaseUrl, pageRequest, playerId]);
 
     const player = detail?.player;
+    const canonicalPlayerId = player?.playerId;
+
+    useEffect(() => {
+        setNnueLabExperiment(null);
+        if (!canonicalPlayerId) return;
+
+        const controller = new AbortController();
+        void fetch(
+            `${nnueLabBaseUrl}/api/public/csa-players/${encodeURIComponent(canonicalPlayerId)}`,
+            { signal: controller.signal },
+        )
+            .then(async (response) => {
+                if (response.status !== 200) return null;
+                return (await response.json()) as NnueLabExperiment;
+            })
+            .then((experiment) => {
+                if (!controller.signal.aborted) setNnueLabExperiment(experiment);
+            })
+            .catch(() => undefined);
+        return () => controller.abort();
+    }, [canonicalPlayerId, nnueLabBaseUrl]);
+
     const totalPages = detail ? Math.max(1, Math.ceil(detail.totalCount / detail.pageSize)) : 1;
     const displayedPage = detail?.page ?? pageRequest.page;
     const requestPage = (nextPage: number): void => {
@@ -139,6 +177,25 @@ export default function RshogiPlayerDetailPage(): ReactElement {
                                 ))}
                             </dl>
                         </section>
+
+                        {nnueLabExperiment && (
+                            <a
+                                href={`${nnueLabBaseUrl}/t/${encodeURIComponent(nnueLabExperiment.tenant_slug)}/experiments/${encodeURIComponent(nnueLabExperiment.experiment_id)}`}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="flex items-center justify-between gap-4 rounded-xl border border-wafuu-border bg-wafuu-washi-warm px-5 py-4 text-wafuu-sumi shadow-sm transition-colors hover:bg-wafuu-kincha/10"
+                            >
+                                <span className="min-w-0">
+                                    <span className="block text-[10px] font-semibold tracking-[0.2em] text-wafuu-shu">
+                                        NNUE EXPERIMENT
+                                    </span>
+                                    <span className="block truncate font-serif font-bold">
+                                        {nnueLabExperiment.experiment_name}
+                                    </span>
+                                </span>
+                                <span className="shrink-0 text-sm">nnue-lab で実験を見る ↗</span>
+                            </a>
+                        )}
 
                         <section className="flex flex-col gap-3">
                             <div className="flex items-end justify-between gap-4 border-b border-wafuu-border pb-2">

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
@@ -82,7 +82,16 @@ export default function RshogiPlayerDetailPage(): ReactElement {
         )
             .then(async (response) => {
                 if (response.status !== 200) return null;
-                return (await response.json()) as NnueLabExperiment;
+                const body = (await response.json()) as Partial<NnueLabExperiment> | null;
+                // 外部 API 依存のため実行時にも必須フィールドを検証し、欠落時は非表示に倒す
+                if (
+                    typeof body?.tenant_slug !== "string" ||
+                    typeof body.experiment_id !== "string" ||
+                    typeof body.experiment_name !== "string"
+                ) {
+                    return null;
+                }
+                return body as NnueLabExperiment;
             })
             .then((experiment) => {
                 if (!controller.signal.aborted) setNnueLabExperiment(experiment);
@@ -195,7 +204,9 @@ export default function RshogiPlayerDetailPage(): ReactElement {
                                         {nnueLabExperiment.experiment_name}
                                     </span>
                                 </span>
-                                <span className="shrink-0 text-sm">nnue-lab で実験を見る ↗</span>
+                                <span className="shrink-0 text-sm">
+                                    nnue-lab で実験を見る <span aria-hidden="true">↗</span>
+                                </span>
                             </a>
                         )}
 

--- a/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
+++ b/apps/web/src/pages/rshogi-viewer/RshogiPlayerDetailPage.tsx
@@ -33,10 +33,12 @@ export default function RshogiPlayerDetailPage(): ReactElement {
 
     // route の playerId が変わったら旧 player の詳細と nnue-lab カードを即座に
     // 破棄する (新詳細の取得が失敗しても旧 player の情報が残らないように)。
-    useEffect(() => {
+    const [renderedPlayerId, setRenderedPlayerId] = useState(playerId);
+    if (renderedPlayerId !== playerId) {
+        setRenderedPlayerId(playerId);
         setDetail(null);
         setNnueLabExperiment(null);
-    }, [playerId]);
+    }
 
     useEffect(() => {
         const controller = new AbortController();


### PR DESCRIPTION
## 概要

rshogi viewer のエンジン (player) 詳細ページから、対応する nnue-lab 実験へのバックリンクカードを表示する。設計正典は rshogi-notes `design/20260720-nnue-lab-csa-player-link/design.md` (Phase 2)。

## 変更内容

- nnue-lab の公開逆引き API `GET /api/public/csa-players/:playerId` を、読み込み済み詳細の canonical `detail.player.playerId` で照会 (route param は alias の可能性があるため使わない)
- 200 のときのみ実験名付きの外部リンクカードを描画 (`/t/<tenant>/experiments/<id>`)。404・非200・通信/JSON エラーはすべて無表示でページ本体に影響なし
- route の playerId 変更時は旧詳細と旧カードを即破棄 (遷移中の残留防止)
- base URL は `VITE_NNUE_LAB_BASE` で上書き可 (既定 https://nnue-lab.sh11235.com)

## 検証

- web 全テスト 69/69 PASS (バックリンク 200/404/canonical id/遷移残留の 4 テスト追加)、typecheck PASS
- Codex + Claude の 2 reviewer 独立レビュー: 指摘 1 件 (遷移時の旧カード残留) 修正済み、最終 APPROVE

## 備考

nnue-lab 側の公開逆引き endpoint は nnue-lab リポジトリの別 PR で追加 (endpoint 未デプロイの間、このカードは常に非表示で無害)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eRPfGJWFSVJBcjgowdmDf