### PR TITLE
feat(web): load more authenticated games

### DIFF
--- a/apps/web/src/pages/games/GamesPage.test.tsx
+++ b/apps/web/src/pages/games/GamesPage.test.tsx
@@ -1,0 +1,129 @@
+import type { GameRecordSummary } from "@shogi/api-contract";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const useLoaderData = vi.fn();
+
+vi.mock("@tanstack/react-router", () => ({
+    getRouteApi: () => ({ useLoaderData }),
+    Link: ({ children }: { children: ReactNode }) => <a href="/games/example">{children}</a>,
+}));
+
+vi.mock("../../components/AuthRequiredCard", () => ({ AuthRequiredCard: () => null }));
+vi.mock("../../components/HeaderNav", () => ({ HeaderNav: () => null }));
+vi.mock("../../components/PageHeader", () => ({ PageHeader: () => null }));
+vi.mock("../../components/PageContainer", () => ({
+    PageContainer: ({ children }: { children: ReactNode }) => <main>{children}</main>,
+}));
+vi.mock("../../components/PageHeading", () => ({
+    PageHeading: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock("../../components/Section", () => ({
+    Section: ({ children }: { children: ReactNode }) => <section>{children}</section>,
+}));
+
+const { default: GamesPage } = await import("./GamesPage");
+
+function game(id: string, displayName: string): GameRecordSummary {
+    return {
+        id,
+        roomId: null,
+        publicId: null,
+        source: "online_room",
+        visibility: "private",
+        status: "finished",
+        result: null,
+        finishedAt: null,
+        createdAt: "2026-07-21T00:00:00.000Z",
+        participants: [{ seat: "b", userId: null, displayNameSnapshot: displayName }],
+    };
+}
+
+describe("GamesPage keyset pagination", () => {
+    let loaderData: {
+        needsAuth: boolean;
+        games: GameRecordSummary[];
+        nextCursor: string | null;
+    };
+
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        useLoaderData.mockReset();
+        loaderData = {
+            needsAuth: false,
+            games: [game("game-1", "先手1")],
+            nextCursor: "opaque+/cursor=",
+        };
+        useLoaderData.mockImplementation(() => loaderData);
+    });
+
+    it("nextCursorで次ページを取得し、既存一覧へ追記する", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(
+            new Response(JSON.stringify({ games: [game("game-2", "先手2")], nextCursor: null }), {
+                status: 200,
+                headers: { "content-type": "application/json" },
+            }),
+        );
+
+        render(<GamesPage />);
+        fireEvent.click(screen.getByRole("button", { name: "もっと見る" }));
+
+        await screen.findByText("先手2");
+        expect(globalThis.fetch).toHaveBeenCalledWith("/api/games?cursor=opaque%2B%2Fcursor%3D", {
+            credentials: "same-origin",
+            signal: expect.any(AbortSignal),
+        });
+        expect(screen.getByText("先手1")).toBeTruthy();
+        expect(screen.getByText("2件を表示中")).toBeTruthy();
+        expect(screen.queryByRole("button", { name: "もっと見る" })).toBeNull();
+    });
+
+    it("追加取得に失敗した場合は再試行可能なエラーを表示する", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 503 }));
+
+        render(<GamesPage />);
+        fireEvent.click(screen.getByRole("button", { name: "もっと見る" }));
+
+        expect((await screen.findByRole("alert")).textContent).toBe(
+            "棋譜の追加取得に失敗しました。時間をおいて再度お試しください。",
+        );
+        await waitFor(() =>
+            expect(
+                (screen.getByRole("button", { name: "もっと見る" }) as HTMLButtonElement).disabled,
+            ).toBe(false),
+        );
+    });
+
+    it("loader再検証時に一覧を置換し、古い追加取得結果を混ぜない", async () => {
+        let resolveRequest: ((response: Response) => void) | undefined;
+        const pendingRequest = new Promise<Response>((resolve) => {
+            resolveRequest = resolve;
+        });
+        vi.spyOn(globalThis, "fetch").mockReturnValue(pendingRequest);
+
+        const { rerender } = render(<GamesPage />);
+        fireEvent.click(screen.getByRole("button", { name: "もっと見る" }));
+
+        loaderData = {
+            needsAuth: false,
+            games: [game("game-new", "再検証後")],
+            nextCursor: null,
+        };
+        rerender(<GamesPage />);
+
+        await screen.findByText("再検証後");
+        expect(screen.queryByText("先手1")).toBeNull();
+        expect(screen.queryByRole("button", { name: "もっと見る" })).toBeNull();
+
+        resolveRequest?.(
+            new Response(
+                JSON.stringify({ games: [game("game-stale", "古い追加結果")], nextCursor: null }),
+                { status: 200, headers: { "content-type": "application/json" } },
+            ),
+        );
+
+        await waitFor(() => expect(screen.queryByText("古い追加結果")).toBeNull());
+        expect(screen.getByText("1件を表示中")).toBeTruthy();
+    });
+});

--- a/apps/web/src/pages/games/GamesPage.test.tsx
+++ b/apps/web/src/pages/games/GamesPage.test.tsx
@@ -141,4 +141,18 @@ describe("GamesPage keyset pagination", () => {
         await waitFor(() => expect(screen.queryByText("古い追加結果")).toBeNull());
         expect(screen.getByText("1件を表示中")).toBeTruthy();
     });
+
+    it("追加取得中にunmountした場合はrequestをabortする", () => {
+        vi.spyOn(globalThis, "fetch").mockReturnValue(new Promise<Response>(() => {}));
+
+        const { unmount } = render(<GamesPage />);
+        fireEvent.click(screen.getByRole("button", { name: "もっと見る" }));
+        const requestInit = vi.mocked(globalThis.fetch).mock.calls[0]?.[1];
+        const signal = requestInit?.signal;
+        expect(signal?.aborted).toBe(false);
+
+        unmount();
+
+        expect(signal?.aborted).toBe(true);
+    });
 });

--- a/apps/web/src/pages/games/GamesPage.test.tsx
+++ b/apps/web/src/pages/games/GamesPage.test.tsx
@@ -10,7 +10,9 @@ vi.mock("@tanstack/react-router", () => ({
     Link: ({ children }: { children: ReactNode }) => <a href="/games/example">{children}</a>,
 }));
 
-vi.mock("../../components/AuthRequiredCard", () => ({ AuthRequiredCard: () => null }));
+vi.mock("../../components/AuthRequiredCard", () => ({
+    AuthRequiredCard: () => <div>認証が必要です</div>,
+}));
 vi.mock("../../components/HeaderNav", () => ({ HeaderNav: () => null }));
 vi.mock("../../components/PageHeader", () => ({ PageHeader: () => null }));
 vi.mock("../../components/PageContainer", () => ({
@@ -93,6 +95,19 @@ describe("GamesPage keyset pagination", () => {
                 (screen.getByRole("button", { name: "もっと見る" }) as HTMLButtonElement).disabled,
             ).toBe(false),
         );
+    });
+
+    it("追加取得中にsessionが切れた場合は認証要求表示へ戻す", async () => {
+        vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 401 }));
+
+        render(<GamesPage />);
+        fireEvent.click(screen.getByRole("button", { name: "もっと見る" }));
+
+        await waitFor(() => expect(screen.queryByText("先手1")).toBeNull());
+        expect(screen.getByText("認証が必要です")).toBeTruthy();
+        expect(screen.queryByRole("alert")).toBeNull();
+        expect(screen.queryByRole("button", { name: "もっと見る" })).toBeNull();
+        expect(screen.queryByText("0件を表示中")).toBeNull();
     });
 
     it("loader再検証時に一覧を置換し、古い追加取得結果を混ぜない", async () => {

--- a/apps/web/src/pages/games/GamesPage.tsx
+++ b/apps/web/src/pages/games/GamesPage.tsx
@@ -23,7 +23,7 @@ export default function GamesPage(): ReactElement {
         games: GameRecordSummary[];
         nextCursor: string | null;
     };
-    const needsAuth = loaderData.needsAuth;
+    const [needsAuth, setNeedsAuth] = useState(loaderData.needsAuth);
     const [games, setGames] = useState(loaderData.games);
     const [nextCursor, setNextCursor] = useState(loaderData.nextCursor);
     const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -35,6 +35,7 @@ export default function GamesPage(): ReactElement {
         loaderGenerationRef.current += 1;
         requestAbortRef.current?.abort();
         requestAbortRef.current = null;
+        setNeedsAuth(loaderData.needsAuth);
         setGames(loaderData.games);
         setNextCursor(loaderData.nextCursor);
         setIsLoadingMore(false);
@@ -57,6 +58,18 @@ export default function GamesPage(): ReactElement {
                 credentials: "same-origin",
                 signal: abortController.signal,
             });
+            if (response.status === 401) {
+                if (
+                    abortController.signal.aborted ||
+                    loaderGeneration !== loaderGenerationRef.current
+                ) {
+                    return;
+                }
+                setNeedsAuth(true);
+                setGames([]);
+                setNextCursor(null);
+                return;
+            }
             if (!response.ok) throw new Error("棋譜の追加取得に失敗しました");
 
             const payload = (await response.json()) as ListGamesResponse;

--- a/apps/web/src/pages/games/GamesPage.tsx
+++ b/apps/web/src/pages/games/GamesPage.tsx
@@ -1,6 +1,7 @@
-import type { GameRecordSummary } from "@shogi/api-contract";
+import type { GameRecordSummary, ListGamesResponse } from "@shogi/api-contract";
 import { getRouteApi, Link } from "@tanstack/react-router";
 import type { ReactElement } from "react";
+import { useEffect, useRef, useState } from "react";
 import { AuthRequiredCard } from "../../components/AuthRequiredCard";
 import { HeaderNav } from "../../components/HeaderNav";
 import { PageContainer } from "../../components/PageContainer";
@@ -20,9 +21,71 @@ export default function GamesPage(): ReactElement {
     const loaderData = routeApi.useLoaderData() as {
         needsAuth: boolean;
         games: GameRecordSummary[];
+        nextCursor: string | null;
     };
     const needsAuth = loaderData.needsAuth;
-    const games = loaderData.games;
+    const [games, setGames] = useState(loaderData.games);
+    const [nextCursor, setNextCursor] = useState(loaderData.nextCursor);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const loaderGenerationRef = useRef(0);
+    const requestAbortRef = useRef<AbortController | null>(null);
+
+    useEffect(() => {
+        loaderGenerationRef.current += 1;
+        requestAbortRef.current?.abort();
+        requestAbortRef.current = null;
+        setGames(loaderData.games);
+        setNextCursor(loaderData.nextCursor);
+        setIsLoadingMore(false);
+        setLoadError(null);
+
+        return () => requestAbortRef.current?.abort();
+    }, [loaderData]);
+
+    async function handleLoadMore(): Promise<void> {
+        if (isLoadingMore || !nextCursor) return;
+        const loaderGeneration = loaderGenerationRef.current;
+        const abortController = new AbortController();
+        requestAbortRef.current = abortController;
+        setIsLoadingMore(true);
+        setLoadError(null);
+
+        try {
+            const params = new URLSearchParams({ cursor: nextCursor });
+            const response = await fetch(`/api/games?${params.toString()}`, {
+                credentials: "same-origin",
+                signal: abortController.signal,
+            });
+            if (!response.ok) throw new Error("棋譜の追加取得に失敗しました");
+
+            const payload = (await response.json()) as ListGamesResponse;
+            if (
+                abortController.signal.aborted ||
+                loaderGeneration !== loaderGenerationRef.current
+            ) {
+                return;
+            }
+            setGames((current) => [...current, ...payload.games]);
+            setNextCursor(payload.nextCursor);
+        } catch {
+            if (
+                abortController.signal.aborted ||
+                loaderGeneration !== loaderGenerationRef.current
+            ) {
+                return;
+            }
+            setLoadError("棋譜の追加取得に失敗しました。時間をおいて再度お試しください。");
+        } finally {
+            if (requestAbortRef.current === abortController) {
+                requestAbortRef.current = null;
+                if (loaderGeneration === loaderGenerationRef.current) {
+                    setIsLoadingMore(false);
+                }
+            }
+        }
+    }
+
     return (
         <>
             <PageHeader
@@ -35,14 +98,7 @@ export default function GamesPage(): ReactElement {
                     description="保存済みのオンライン対局を確認できます。"
                 >
                     {!needsAuth && (
-                        <p className="text-xs text-muted-foreground">
-                            {games.length} / 50件
-                            {games.length >= 45 && (
-                                <span className="ml-2 text-wafuu-shu">
-                                    ※ 50件を超えると古い棋譜から自動削除されます
-                                </span>
-                            )}
-                        </p>
+                        <p className="text-xs text-muted-foreground">{games.length}件を表示中</p>
                     )}
                 </PageHeading>
 
@@ -109,6 +165,25 @@ export default function GamesPage(): ReactElement {
                                 </div>
                             </Link>
                         ))}
+                    </div>
+                )}
+
+                {!needsAuth && loadError && (
+                    <p role="alert" className="text-center text-sm text-destructive">
+                        {loadError}
+                    </p>
+                )}
+
+                {!needsAuth && nextCursor && (
+                    <div className="flex justify-center">
+                        <button
+                            type="button"
+                            onClick={() => void handleLoadMore()}
+                            disabled={isLoadingMore}
+                            className="rounded-md border border-input px-6 py-2 text-sm font-medium text-foreground transition-colors hover:bg-muted/50 disabled:pointer-events-none disabled:opacity-50"
+                        >
+                            {isLoadingMore ? "読み込み中..." : "もっと見る"}
+                        </button>
                     </div>
                 )}
             </PageContainer>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -57,6 +57,7 @@ const authRoute = createRoute({
 interface GamesRouteLoaderData {
     needsAuth: boolean;
     games: GameRecordSummary[];
+    nextCursor: string | null;
 }
 
 async function fetchGamesLoaderData(): Promise<GamesRouteLoaderData> {
@@ -73,6 +74,7 @@ async function fetchGamesLoaderData(): Promise<GamesRouteLoaderData> {
         return {
             needsAuth: true,
             games: [],
+            nextCursor: null,
         };
     }
 
@@ -80,6 +82,7 @@ async function fetchGamesLoaderData(): Promise<GamesRouteLoaderData> {
     return {
         needsAuth: false,
         games: payload.games,
+        nextCursor: payload.nextCursor,
     };
 }
 

--- a/packages/api-contract/src/generated/openapi.json
+++ b/packages/api-contract/src/generated/openapi.json
@@ -119,9 +119,12 @@
                         "items": {
                             "$ref": "#/components/schemas/GameRecordSummary"
                         }
+                    },
+                    "nextCursor": {
+                        "type": ["string", "null"]
                     }
                 },
-                "required": ["games"]
+                "required": ["games", "nextCursor"]
             },
             "GameRecordSummary": {
                 "type": "object",
@@ -964,6 +967,26 @@
             "get": {
                 "operationId": "listGames",
                 "tags": ["Games"],
+                "parameters": [
+                    {
+                        "schema": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 50
+                        },
+                        "required": false,
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "schema": {
+                            "type": "string"
+                        },
+                        "required": false,
+                        "name": "cursor",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "List accessible games",
@@ -971,6 +994,16 @@
                             "application/json": {
                                 "schema": {
                                     "$ref": "#/components/schemas/ListGamesResponse"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid pagination query or cursor",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorResponse"
                                 }
                             }
                         }

--- a/packages/api-contract/src/generated/schema.ts
+++ b/packages/api-contract/src/generated/schema.ts
@@ -372,6 +372,7 @@ export interface components {
         };
         ListGamesResponse: {
             games: components["schemas"]["GameRecordSummary"][];
+            nextCursor: string | null;
         };
         GameRecordSummary: {
             id: string;
@@ -682,7 +683,10 @@ export interface operations {
     };
     listGames: {
         parameters: {
-            query?: never;
+            query?: {
+                limit?: number;
+                cursor?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -696,6 +700,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ListGamesResponse"];
+                };
+            };
+            /** @description Invalid pagination query or cursor */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
                 };
             };
             /** @description Authentication is required */


### PR DESCRIPTION
## Summary
- consume the authenticated games keyset cursor and append additional pages
- reset pagination state on route revalidation and fence stale in-flight responses
- sync the generated games pagination contract from backend #27
- replace the obsolete 50-game auto-delete message with the displayed count

## Review
- independent agent review: APPROVE after one REQUEST CHANGES cycle

## Validation
- `pnpm --dir apps/web test` (14 files, 72 tests)
- `pnpm lint`
- `pnpm format:ci`
- `pnpm knip:ci`
- `pnpm turbo typecheck --filter='!@shogi/engine-wasm'`
- `pnpm --dir packages/api-contract typecheck`
- `git diff --check`

## Deployment
- production deployment is intentionally out of scope; main push workflows run CI only
